### PR TITLE
Avoid erroneous 'Could not cancel' warning produced by cache tasks

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/utils/CloseableExecutorService.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/CloseableExecutorService.java
@@ -148,7 +148,7 @@ public class CloseableExecutorService implements Closeable
         {
             Future<?> future = iterator.next();
             iterator.remove();
-            if ( !future.cancel(true) )
+            if ( !future.isDone() && !future.isCancelled() && !future.cancel(true) )
             {
                 log.warn("Could not cancel " + future);
             }


### PR DESCRIPTION
When closing providers, we regularly see an erroneous warning related to a failure to cancel cache tasks.

This change applies some more defensive checks before attempting to cancel tasks, ensuring that the cancel operation is only attempted if the future has not completed.
