### PR TITLE
make ChildData constructor public for access from unit tests and such

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/ChildData.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/ChildData.java
@@ -28,7 +28,7 @@ public class ChildData implements Comparable<ChildData>
     private final Stat      stat;
     private final AtomicReference<byte[]>    data;
 
-    ChildData(String path, Stat stat, byte[] data)
+    public ChildData(String path, Stat stat, byte[] data)
     {
         this.path = path;
         this.stat = stat;


### PR DESCRIPTION
When unit testing an application making use of PathChildrenCache, I wanted to make some PathChildrenCacheEvents to pass to my PathChildrenCacheListener-implementing class. However I found that PathChildrenCacheEvent contains ChildData, which has only a no-modifier constructor, meaning my unit test would have to be in the org.apache.curator.framework.recipies.cache package in order to perform these tests.
