### PR TITLE
CURATOR-90

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/utils/DebugUtils.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/DebugUtils.java
@@ -22,7 +22,7 @@ public class DebugUtils
 {
     public static final String          PROPERTY_LOG_EVENTS = "curator-log-events";
     public static final String          PROPERTY_DONT_LOG_CONNECTION_ISSUES = "curator-dont-log-connection-problems";
-    public static final String          PROPERTY_LOG_ALL_CONNECTION_ISSUES_AS_ERROR_LEVEL = "curator-log-all-connection-issues-as-error-level";
+    public static final String          PROPERTY_LOG_ONLY_FIRST_CONNECTION_ISSUE_AS_ERROR_LEVEL = "curator-log-only-first-connection-issue-as-error-level";
 
     private DebugUtils()
     {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -76,7 +76,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
     private volatile ExecutorService                                    executorService;
     private final AtomicBoolean                                         logAsErrorConnectionErrors = new AtomicBoolean(false);
 
-    private static final boolean                                        LOG_ALL_CONNECTION_ISSUES_AS_ERROR_LEVEL = Boolean.getBoolean(DebugUtils.PROPERTY_LOG_ALL_CONNECTION_ISSUES_AS_ERROR_LEVEL);
+    private static final boolean                                        LOG_ALL_CONNECTION_ISSUES_AS_ERROR_LEVEL = !Boolean.getBoolean(DebugUtils.PROPERTY_LOG_ONLY_FIRST_CONNECTION_ISSUE_AS_ERROR_LEVEL);
 
     interface DebugBackgroundListener
     {


### PR DESCRIPTION
Making Connection erros less verbose. Only first error is logged with error level; subsequent errors are logged as debug
