### PR TITLE
Curator locks leaving dangling watches

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java
@@ -298,24 +298,21 @@ public class LockInternals
                         try 
                         {
                             byte[] data = client.getData().usingWatcher(watcher).forPath(previousSequencePath);
-                            if ( data != null )
+                            if ( millisToWait != null )
                             {
-                                if ( millisToWait != null )
+                                millisToWait -= (System.currentTimeMillis() - startMillis);
+                                startMillis = System.currentTimeMillis();
+                                if ( millisToWait <= 0 )
                                 {
-                                    millisToWait -= (System.currentTimeMillis() - startMillis);
-                                    startMillis = System.currentTimeMillis();
-                                    if ( millisToWait <= 0 )
-                                    {
-                                        doDelete = true;    // timed out - delete our node
-                                        break;
-                                    }
+                                    doDelete = true;    // timed out - delete our node
+                                    break;
+                                }
 
-                                    wait(millisToWait);
-                                }
-                                else
-                                {
-                                    wait();
-                                }
+                                wait(millisToWait);
+                            }
+                            else
+                            {
+                                wait();
                             }
                         }
                         catch ( KeeperException.NoNodeException e ) 


### PR DESCRIPTION
As per https://issues.apache.org/jira/browse/CURATOR-107 . I've seen this in our services too. 

The issue is because the code is using exists() call rather than getData() for creating a watch for lock. exists() creates a watch regardless of whether the node exists or not, getData() will only create the watch if node exists
