### PR TITLE
CURATOR-127 Fix trivial warnings

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/CuratorConnectionLossException.java
+++ b/curator-client/src/main/java/org/apache/curator/CuratorConnectionLossException.java
@@ -26,4 +26,5 @@ import org.apache.zookeeper.KeeperException;
  */
 public class CuratorConnectionLossException extends KeeperException.ConnectionLossException
 {
+  private static final long serialVersionUID = 1L;
 }

--- a/curator-client/src/main/java/org/apache/curator/SessionFailRetryLoop.java
+++ b/curator-client/src/main/java/org/apache/curator/SessionFailRetryLoop.java
@@ -116,6 +116,7 @@ public class SessionFailRetryLoop implements Closeable
 
     public static class SessionFailedException extends Exception
     {
+      private static final long serialVersionUID = 1L;
     }
 
     public enum Mode

--- a/curator-client/src/test/java/org/apache/curator/TestEnsurePath.java
+++ b/curator-client/src/test/java/org/apache/curator/TestEnsurePath.java
@@ -18,6 +18,20 @@
  */
 package org.apache.curator;
 
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.utils.EnsurePath;
 import org.apache.zookeeper.ZooKeeper;
@@ -27,16 +41,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
-
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.mock;
 
 public class TestEnsurePath
 {

--- a/curator-test/src/main/java/org/apache/curator/test/ServerHelper.java
+++ b/curator-test/src/main/java/org/apache/curator/test/ServerHelper.java
@@ -27,12 +27,12 @@ class ServerHelper
 {
     private static class ServerCnxnFactoryMethods
     {
-        private final Constructor constructor;
+        private final Constructor<?> constructor;
         private final Method configureMethod;
         private final Method startupMethod;
         private final Method shutdownMethod;
 
-        private ServerCnxnFactoryMethods(Constructor constructor, Method configureMethod, Method startupMethod, Method shutdownMethod)
+        private ServerCnxnFactoryMethods(Constructor<?> constructor, Method configureMethod, Method startupMethod, Method shutdownMethod)
         {
             this.constructor = constructor;
             this.configureMethod = configureMethod;
@@ -43,11 +43,11 @@ class ServerHelper
 
     private static class NioServerCnxnMethods
     {
-        private final Constructor constructor;
+        private final Constructor<?> constructor;
         private final Method startupMethod;
         private final Method shutdownMethod;
 
-        private NioServerCnxnMethods(Constructor constructor, Method startupMethod, Method shutdownMethod)
+        private NioServerCnxnMethods(Constructor<?> constructor, Method startupMethod, Method shutdownMethod)
         {
             this.constructor = constructor;
             this.startupMethod = startupMethod;
@@ -60,8 +60,8 @@ class ServerHelper
 
     static
     {
-        Class       serverCnxnFactoryClass = null;
-        Class       nioServerCnxnFactoryClass = null;
+        Class<?>       serverCnxnFactoryClass = null;
+        Class<?>       nioServerCnxnFactoryClass = null;
         try
         {
             serverCnxnFactoryClass = Class.forName("org.apache.zookeeper.server.NIOServerCnxnFactory");


### PR DESCRIPTION
Remove wildcard imports. Add generic types to Class.
Add serialVersionUID to Serializable.
