### PR TITLE
CURATOR-42 - Modified guaranteed delete handling so that it will only

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
@@ -27,7 +27,6 @@ import org.apache.curator.framework.api.ChildrenDeletable;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.framework.api.DeleteBuilder;
-import org.apache.curator.framework.api.Guaranteeable;
 import org.apache.curator.framework.api.Pathable;
 import org.apache.curator.framework.api.transaction.CuratorTransactionBridge;
 import org.apache.curator.framework.api.transaction.OperationType;
@@ -248,14 +247,11 @@ class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<String>
                     }
                 }
             );
-        }
-        catch ( KeeperException.NodeExistsException e )
-        {
-            throw e;
-        }
+        }      
         catch ( Exception e )
         {
-            if ( guaranteed )
+            //Only retry a guaranteed delete if it's a retryable error
+            if( RetryLoop.isRetryException(e) && guaranteed )
             {
                 client.getFailedDeleteManager().addFailedDelete(unfixedPath);
             }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FailedDeleteManager.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FailedDeleteManager.java
@@ -26,6 +26,13 @@ class FailedDeleteManager
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final CuratorFramework client;
+    
+    volatile FailedDeleteManagerListener debugListener = null;
+    
+    interface FailedDeleteManagerListener
+    {
+       public void pathAddedForDelete(String path);
+    }
 
     FailedDeleteManager(CuratorFramework client)
     {
@@ -34,6 +41,12 @@ class FailedDeleteManager
 
     void addFailedDelete(String path)
     {
+        if ( debugListener != null )
+        {
+            debugListener.pathAddedForDelete(path);
+        }
+        
+        
         if ( client.isStarted() )
         {
             log.debug("Path being added to guaranteed delete set: " + path);


### PR DESCRIPTION
add the node to the guaranteed delete set if a recoverable exception is
encountered. If a non recoverable exception (such as a NoNodeException)
is encountered, then this will not be retried. Added a debug listener to
the FailedDeleteManager to facilitate unit testing this case. Added unit
tests, for both guaranteed deletes in the background and foreground for
the NoNodeException case. Note that this error was only present for
guaranteed deletes in the foreground.
