### PR TITLE
fixed not to try to reconnect when session and connection timeout.

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/ConnectionState.java
+++ b/curator-client/src/main/java/org/apache/curator/ConnectionState.java
@@ -191,7 +191,6 @@ class ConnectionState implements Watcher, Closeable
                     {
                         log.warn(String.format("Connection attempt unsuccessful after %d (greater than max timeout of %d). Resetting connection and trying again with a new connection.", elapsed, maxTimeout));
                     }
-                    reset();
                 }
                 else
                 {


### PR DESCRIPTION
The application received the zookeeper event without any problems after network is reconnected.

e.g.
RetryPolicy retryPolicy = new ExponentialBackoffRetry(Config.BASE_SLEEP_TIME_MS, 3);
CuratorFrameworkFactory.newClient(connectString, 20000, 10000, retryPolicy);

But following example is not working after network is not available for about 30s.

e.g.
RetryPolicy retryPolicy = new ExponentialBackoffRetry(Config.BASE_SLEEP_TIME_MS, 3);
zkClient = CuratorFrameworkFactory.newClient(connectString, 10000, 10000, retryPolicy);

The application didn't receive any zookeeper event after this reset() method is invoked.
