### PR TITLE
CURATOR-131 use iterator.remove instead of foreach

### DIFF
--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/DownInstanceManager.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/DownInstanceManager.java
@@ -19,10 +19,13 @@
 package org.apache.curator.x.discovery.details;
 
 import com.google.common.collect.Maps;
+
 import org.apache.curator.x.discovery.DownInstancePolicy;
 import org.apache.curator.x.discovery.InstanceFilter;
 import org.apache.curator.x.discovery.ServiceInstance;
-import java.util.Map;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -77,12 +80,14 @@ class DownInstanceManager<T> implements InstanceFilter<T>
             return;
         }
 
-        for ( Map.Entry<ServiceInstance<?>, Status> entry : statuses.entrySet() )
+        Iterator<Entry<ServiceInstance<?>, Status>> it = statuses.entrySet().iterator();
+        while ( it.hasNext() )
         {
+            Entry<ServiceInstance<?>, Status> entry = it.next();
             long elapsedMs = System.currentTimeMillis() - entry.getValue().startMs;
             if ( elapsedMs >= downInstancePolicy.getTimeoutMs() )
             {
-                statuses.remove(entry.getKey());
+                it.remove();
             }
         }
     }


### PR DESCRIPTION
When iterating over a collection, if we try to remove elements that
can lead to undefined behaviour. We should use an iterator and its
remove method to do this safely.
