### PR TITLE
CURATOR-67 defer creation of serializer

### DIFF
--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceDiscoveryBuilder.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceDiscoveryBuilder.java
@@ -29,9 +29,10 @@ public class ServiceDiscoveryBuilder<T>
     private String                  basePath;
     private InstanceSerializer<T>   serializer;
     private ServiceInstance<T>      thisInstance;
+    private Class<T>                payloadClass;
 
     /**
-     * Return a new builder. The builder will be defaulted with a {@link JsonInstanceSerializer}.
+     * Return a new builder.
      *
      * @param payloadClass the class of the payload of your service instance (you can use {@link Void}
      * if your instances don't need a payload)
@@ -39,16 +40,20 @@ public class ServiceDiscoveryBuilder<T>
      */
     public static<T> ServiceDiscoveryBuilder<T>     builder(Class<T> payloadClass)
     {
-        return new ServiceDiscoveryBuilder<T>(payloadClass).serializer(new JsonInstanceSerializer<T>(payloadClass));
+        return new ServiceDiscoveryBuilder<T>(payloadClass);
     }
 
     /**
-     * Build a new service discovery with the currently set values
+     * Build a new service discovery with the currently set values. If not set, the builder will be
+     * defaulted with a {@link JsonInstanceSerializer}.
      *
      * @return new service discovery
      */
     public ServiceDiscovery<T>      build()
     {
+        if ( serializer == null ) {
+            serializer(new JsonInstanceSerializer<T>(payloadClass));
+        }
         return new ServiceDiscoveryImpl<T>(client, basePath, serializer, thisInstance);
     }
 
@@ -102,5 +107,6 @@ public class ServiceDiscoveryBuilder<T>
 
     ServiceDiscoveryBuilder(Class<T> payloadClass)
     {
+        this.payloadClass = payloadClass;
     }
 }

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestServiceDiscoveryBuilder.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestServiceDiscoveryBuilder.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.x.discovery;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.curator.x.discovery.details.InstanceSerializer;
+import org.apache.curator.x.discovery.details.JsonInstanceSerializer;
+import org.apache.curator.x.discovery.details.ServiceDiscoveryImpl;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestServiceDiscoveryBuilder extends BaseClassForTests
+{
+    @Test
+    public void testDefaultSerializer() throws Exception
+    {        
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        ServiceDiscoveryBuilder<Object> builder = ServiceDiscoveryBuilder.builder(Object.class).client(client);
+        ServiceDiscoveryImpl<?> discovery = (ServiceDiscoveryImpl<?>) builder.basePath("/path").build();
+
+        Assert.assertNotNull(discovery.getSerializer(), "default serializer not set");
+        Assert.assertTrue(discovery.getSerializer() instanceof JsonInstanceSerializer, "default serializer not JSON");
+    }
+
+    @Test
+    public void testSetSerializer() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        ServiceDiscoveryBuilder<Object> builder = ServiceDiscoveryBuilder.builder(Object.class).client(client);
+        builder.serializer(new InstanceSerializer<Object>()
+        {
+            @Override
+            public byte[] serialize(ServiceInstance<Object> instance)
+            {
+                return null;
+            }
+
+            @Override
+            public ServiceInstance<Object> deserialize(byte[] bytes)
+            {
+                return null;
+            }
+        });
+
+        ServiceDiscoveryImpl<?> discovery = (ServiceDiscoveryImpl<?>) builder.basePath("/path").build();
+        Assert.assertNotNull(discovery.getSerializer(), "default serializer not set");
+        Assert.assertFalse(discovery.getSerializer() instanceof JsonInstanceSerializer, "set serializer is JSON");
+    }
+}


### PR DESCRIPTION
Instead of immediately creating a new JSONInstanceSerializer we can
defer until build() is actually called. This lets users specify their
own serializers and avoids issues where there may be version conflicts.
