### PR TITLE
CURATOR-71 do not log-and-throw

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/ConnectionState.java
+++ b/curator-client/src/main/java/org/apache/curator/ConnectionState.java
@@ -77,7 +77,6 @@ class ConnectionState implements Watcher, Closeable
         Exception exception = backgroundExceptions.poll();
         if ( exception != null )
         {
-            log.error("Background exception caught", exception);
             tracer.get().addCount("background-exceptions", 1);
             throw exception;
         }

--- a/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
+++ b/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
@@ -182,9 +182,8 @@ public class CuratorZookeeperClient implements Closeable
 
         if ( !started.compareAndSet(false, true) )
         {
-            IllegalStateException error = new IllegalStateException();
-            log.error("Already started", error);
-            throw error;
+            IllegalStateException ise = new IllegalStateException("Already started");
+            throw ise;
         }
 
         state.start();

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -233,9 +233,8 @@ public class CuratorFrameworkImpl implements CuratorFramework
         log.info("Starting");
         if ( !state.compareAndSet(CuratorFrameworkState.LATENT, CuratorFrameworkState.STARTED) )
         {
-            IllegalStateException error = new IllegalStateException();
-            log.error("Cannot be started more than once", error);
-            throw error;
+            IllegalStateException ise = new IllegalStateException("Cannot be started more than once");
+            throw ise;
         }
 
         try

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderSelector.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderSelector.java
@@ -418,7 +418,6 @@ public class LeaderSelector implements Closeable
         }
         catch ( Exception e )
         {
-            log.error("mutex.acquire() threw an exception", e);
             throw e;
         }
         finally

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/StandardLockInternalsDriver.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/StandardLockInternalsDriver.java
@@ -61,7 +61,6 @@ public class StandardLockInternalsDriver implements LockInternalsDriver
     {
         if ( ourIndex < 0 )
         {
-            log.error("Sequential path not found: " + sequenceNodeName);
             throw new KeeperException.NoNodeException("Sequential path not found: " + sequenceNodeName);
         }
     }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
@@ -320,7 +320,6 @@ public class PersistentEphemeralNode implements Closeable
             }
             catch ( Exception e )
             {
-                log.error("Deleting node: " + localNodePath, e);
                 throw e;
             }
         }
@@ -341,8 +340,7 @@ public class PersistentEphemeralNode implements Closeable
         }
         catch ( Exception e )
         {
-            log.error("Creating node. BasePath: " + basePath, e);
-            throw new RuntimeException(e);  // should never happen unless there's a programming error - so throw RuntimeException
+            throw new RuntimeException("Creating node. BasePath: " + basePath, e);  // should never happen unless there's a programming error - so throw RuntimeException
         }
     }
 
@@ -362,7 +360,6 @@ public class PersistentEphemeralNode implements Closeable
             }
             catch ( Exception e )
             {
-                log.error("Watching node: " + localNodePath, e);
                 throw e;
             }
         }


### PR DESCRIPTION
If we throw an exception, then there is no point in logging it since
something further up the call stack already has to deal with it. At
best, the exception gets logged twice, at worst we log potentially
confusing exceptions that end up not mattering.
