### PR TITLE
CURATOR-132 - Modified the NamespaceFacade so that it does not proxy

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceFacade.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceFacade.java
@@ -71,18 +71,6 @@ class NamespaceFacade extends CuratorFrameworkImpl
     }
 
     @Override
-    public GetACLBuilder getACL()
-    {
-        return client.getACL();
-    }
-
-    @Override
-    public SetACLBuilder setACL()
-    {
-        return client.setACL();
-    }
-
-    @Override
     public Listenable<ConnectionStateListener> getConnectionStateListenable()
     {
         return client.getConnectionStateListenable();


### PR DESCRIPTION
Modified the NamespaceFacade so that it does not proxy getACL() and setACL() calls to the underlying client (which is not namespace aware), and instead handles them itself.
