### PR TITLE
discovery: registration of wrong/old service instance on RECONNECT

### DIFF
--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
@@ -174,6 +174,7 @@ public class ServiceDiscoveryImpl<T> implements ServiceDiscovery<T>
     public void updateService(ServiceInstance<T> service) throws Exception
     {
         Preconditions.checkArgument(services.containsKey(service.getId()), "Service is not registered: " + service);
+        services.put(service.getId(), service);
 
         byte[]          bytes = serializer.serialize(service);
         String          path = pathForInstance(service.getName(), service.getId());


### PR DESCRIPTION
```ServiceDiscoveryImpl.registerService()``` remembers service registrations in a map. However ```updateService()``` does not update the map. 
This causes a wrong registration in the case of a RECONNECT - e.g. ```reRegisterServices()``` called by the ```ConnectionStateListener``` registers the old ```ServiceInstance``` instead of the updated one.