### PR TITLE
Performance fix in processChildren()

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
@@ -646,20 +646,10 @@ public class PathChildrenCache implements Closeable
 
     private void processChildren(List<String> children, RefreshMode mode) throws Exception
     {
-        List<String> fullPaths = Lists.newArrayList(Lists.transform
-            (
-                children,
-                new Function<String, String>()
-                {
-                    @Override
-                    public String apply(String child)
-                    {
-                        return ZKPaths.makePath(path, child);
-                    }
-                }
-            ));
         Set<String> removedNodes = Sets.newHashSet(currentData.keySet());
-        removedNodes.removeAll(fullPaths);
+        for ( String child : children ) {
+            removedNodes.remove(ZKPaths.makePath(path, child));
+        }
 
         for ( String fullPath : removedNodes )
         {


### PR DESCRIPTION
Current implementation may lead to a large number of calls to java.util.ArrayList.contains() with a large list, when syncing a large number of path children, as evident from this stack trace:

```
"main-EventThread" daemon prio=10 tid=0x00007fd089593800 nid=0x6fbf runnable [0x00007fd0eb3a1000]
           java.lang.Thread.State: RUNNABLE
                at java.util.ArrayList.indexOf(ArrayList.java:298)
                at java.util.ArrayList.contains(ArrayList.java:281)
                at java.util.AbstractSet.removeAll(AbstractSet.java:176)
                at org.apache.curator.framework.recipes.cache.PathChildrenCache.processChildren(PathChildrenCache.java:655)
                at org.apache.curator.framework.recipes.cache.PathChildrenCache.access$200(PathChildrenCache.java:68)
                at org.apache.curator.framework.recipes.cache.PathChildrenCache$4.processResult(PathChildrenCache.java:490)
                at org.apache.curator.framework.imps.CuratorFrameworkImpl.sendToBackgroundCallback(CuratorFrameworkImpl.java:715)
                at org.apache.curator.framework.imps.CuratorFrameworkImpl.processBackgroundOperation(CuratorFrameworkImpl.java:502)
                at org.apache.curator.framework.imps.GetChildrenBuilderImpl$2.processResult(GetChildrenBuilderImpl.java:166)
                at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:587)
                at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:495)
```
