### PR TITLE
CURATOR-157 Avoid stack traces on close

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/NodeCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/NodeCache.java
@@ -185,7 +185,8 @@ public class NodeCache implements Closeable
         }
         client.getConnectionStateListenable().removeListener(connectionStateListener);
 
-        synchronized (backgroundTaskMonitor) {
+        synchronized (backgroundTaskMonitor)
+        {
             // To make sure background callbacks are finished before returning, avoids ugly
             // stack traces if ZooKeeper is closed immediately after the NodeCache
         }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
@@ -677,6 +677,12 @@ public class PathChildrenCache implements Closeable
 
         for ( String name : children )
         {
+            if (state.get() == State.CLOSED)
+            {
+                // When close() is being called, no need to continue with this
+                return;
+            }
+
             String fullPath = ZKPaths.makePath(path, name);
 
             if ( (mode == RefreshMode.FORCE_GET_DATA_AND_STAT) || !currentData.containsKey(fullPath) )

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
@@ -384,7 +384,8 @@ public class PathChildrenCache implements Closeable
             childrenWatcher = null;
             dataWatcher = null;
 
-            synchronized (backgroundTaskMonitor) {
+            synchronized (backgroundTaskMonitor)
+            {
                 // To make sure background callbacks are finished before returning, avoids ugly
                 // stack traces if ZooKeeper is closed immediately after the PathChildrenCache
             }
@@ -494,20 +495,25 @@ public class PathChildrenCache implements Closeable
             @Override
             public void processResult(CuratorFramework client, CuratorEvent event) throws Exception
             {
-                synchronized (backgroundTaskMonitor) {
-                    if (PathChildrenCache.this.state.get().equals(State.CLOSED)) {
+                synchronized (backgroundTaskMonitor)
+                {
+                    if (PathChildrenCache.this.state.get().equals(State.CLOSED))
+                    {
                         // This ship is closed, don't handle the callback
                         return;
                     }
-                    if (event.getResultCode() == KeeperException.Code.OK.intValue()) {
+                    if (event.getResultCode() == KeeperException.Code.OK.intValue())
+                    {
                         processChildren(event.getChildren(), mode);
                     }
                 }
             }
         };
 
-        synchronized (backgroundTaskMonitor) {
-            if (PathChildrenCache.this.state.get().equals(State.CLOSED)) {
+        synchronized (backgroundTaskMonitor)
+        {
+            if (PathChildrenCache.this.state.get().equals(State.CLOSED))
+            {
                 // This ship is closed, don't launch new tasks
                 return;
             }


### PR DESCRIPTION
Avoid error-level stack traces closing PathChildrenCache followed by closing CuratorFramework

See details in jira: https://issues.apache.org/jira/browse/CURATOR-157
