### PR TITLE
CURATOR-175: If zookeeper is down when discovery is started, it fails to register when the zookeeper comes up for the first time.

### DIFF
--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
@@ -69,7 +69,7 @@ public class ServiceDiscoveryImpl<T> implements ServiceDiscovery<T>
         @Override
         public void stateChanged(CuratorFramework client, ConnectionState newState)
         {
-            if ( newState == ConnectionState.RECONNECTED )
+            if ( newState == ConnectionState.RECONNECTED || newState == ConnectionState.CONNECTED )
             {
                 try
                 {
@@ -109,8 +109,12 @@ public class ServiceDiscoveryImpl<T> implements ServiceDiscovery<T>
     @Override
     public void start() throws Exception
     {
+        try {
+    	    reRegisterServices();
+        } catch (Exception ex) {
+            log.error("Could not register instances", ex);
+        }
         client.getConnectionStateListenable().addListener(connectionStateListener);
-        reRegisterServices();
     }
 
     @Override

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestServiceDiscovery.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestServiceDiscovery.java
@@ -24,6 +24,7 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.KillSession;
 import org.apache.curator.test.Timing;
@@ -263,4 +264,38 @@ public class TestServiceDiscovery extends BaseClassForTests
             }
         }
     }
+    
+    @Test
+    public void         testNoServerOnStart() throws Exception
+    {
+        server.stop();
+        List<Closeable>     closeables = Lists.newArrayList();
+        try
+        {
+            CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryNTimes(0,1000));
+            closeables.add(client);
+            client.start();
+            
+            ServiceInstance<String>     instance = ServiceInstance.<String>builder().payload("thing").name("test").port(10064).build();
+            ServiceDiscovery<String>    discovery = ServiceDiscoveryBuilder.builder(String.class).basePath("/test").client(client).thisInstance(instance).build();
+            closeables.add(discovery);
+            discovery.start();
+
+            server.restart();
+            Assert.assertEquals(discovery.queryForNames(), Arrays.asList("test"));
+
+            List<ServiceInstance<String>> list = Lists.newArrayList();
+            list.add(instance);
+            Assert.assertEquals(discovery.queryForInstances("test"), list);
+        }
+        finally
+        {
+            Collections.reverse(closeables);
+            for ( Closeable c : closeables )
+            {
+                CloseableUtils.closeQuietly(c);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
**The issue:** If zookeeper is down when discovery is started, it fails to register when the zookeeper comes up for the first time. However, if the zookeeper is restarted again, it discovery will connect and register the service instance correctly.
**Cause :** This happened because *org.apache.curator.x.discovery.details.ServiceDiscoveryImpl.stateChanged()* considered only *ConnectionState.RECONNECTED* state and not *ConnectionState.CONNECTED*.  This caused the first connection to be ignored, while subsequent connection recoveries worked fine. 

This pull request has fix for the same and a test case for it.