### PR TITLE
CURATOR-148 Allow create compressed withProtection

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/api/ACLCreateModeBackgroundPathAndBytesable.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/ACLCreateModeBackgroundPathAndBytesable.java
@@ -20,7 +20,6 @@ package org.apache.curator.framework.api;
 
 public interface ACLCreateModeBackgroundPathAndBytesable<T> extends
     ACLBackgroundPathAndBytesable<T>,
-    BackgroundPathAndBytesable<T>,
     CreateModable<ACLBackgroundPathAndBytesable<T>>
 {
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/CompressACLCreateModeBackgroundPathAndBytesable.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/CompressACLCreateModeBackgroundPathAndBytesable.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.curator.framework.api;
+
+public interface CompressACLCreateModeBackgroundPathAndBytesable<T> extends
+    Compressible<CreateBackgroundModeACLable>,
+    ACLCreateModeBackgroundPathAndBytesable<T>
+{
+}

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/CreateBackgroundModeACLable.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/CreateBackgroundModeACLable.java
@@ -19,8 +19,6 @@
 package org.apache.curator.framework.api;
 
 public interface CreateBackgroundModeACLable extends
-    BackgroundPathAndBytesable<String>,
-    CreateModable<ACLBackgroundPathAndBytesable<String>>,
     ACLCreateModeBackgroundPathAndBytesable<String>
 {
     /**

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/CreateBuilder.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/CreateBuilder.java
@@ -19,10 +19,8 @@
 package org.apache.curator.framework.api;
 
 public interface CreateBuilder extends
-    BackgroundPathAndBytesable<String>,
-    CreateModable<ACLBackgroundPathAndBytesable<String>>,
-    ACLCreateModeBackgroundPathAndBytesable<String>,
-    Compressible<CreateBackgroundModeACLable>
+    CompressACLCreateModeBackgroundPathAndBytesable<String>,
+    ProtectACLCreateModePathAndBytesable<String>
 {
     /**
      * Causes any parent nodes to get created if they haven't already been
@@ -39,34 +37,4 @@ public interface CreateBuilder extends
      * @return this
      */
     public ACLPathAndBytesable<String>              withProtectedEphemeralSequential();
-
-    /**
-     * <p>
-     *     Hat-tip to https://github.com/sbridges for pointing this out
-     * </p>
-     *
-     * <p>
-     *     It turns out there is an edge case that exists when creating sequential-ephemeral
-     *     nodes. The creation can succeed on the server, but the server can crash before
-     *     the created node name is returned to the client. However, the ZK session is still
-     *     valid so the ephemeral node is not deleted. Thus, there is no way for the client to
-     *     determine what node was created for them.
-     * </p>
-     *
-     * <p>
-     *     Even without sequential-ephemeral, however, the create can succeed on the sever
-     *     but the client (for various reasons) will not know it.
-     * </p>
-     *
-     * <p>
-     *     Putting the create builder into protection mode works around this.
-     *     The name of the node that is created is prefixed with a GUID. If node creation fails
-     *     the normal retry mechanism will occur. On the retry, the parent path is first searched
-     *     for a node that has the GUID in it. If that node is found, it is assumed to be the lost
-     *     node that was successfully created on the first try and is returned to the caller.
-     * </p>
-     *
-     * @return this
-     */
-    public ACLCreateModeBackgroundPathAndBytesable<String>    withProtection();
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/ProtectACLCreateModePathAndBytesable.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/ProtectACLCreateModePathAndBytesable.java
@@ -50,5 +50,5 @@ public interface ProtectACLCreateModePathAndBytesable<T> extends
      *
      * @return this
      */
-    public ACLCreateModeBackgroundPathAndBytesable<String>    withProtection();
+    public CompressACLCreateModeBackgroundPathAndBytesable<String> withProtection();
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -266,7 +266,7 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
         return new ProtectACLCreateModePathAndBytesable<String>()
         {
             @Override
-            public ACLCreateModeBackgroundPathAndBytesable<String> withProtection()
+            public CompressACLCreateModeBackgroundPathAndBytesable<String> withProtection()
             {
                 return CreateBuilderImpl.this.withProtection();
             }
@@ -334,7 +334,7 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
     }
 
     @Override
-    public ACLCreateModeBackgroundPathAndBytesable<String> withProtection()
+    public CompressACLCreateModeBackgroundPathAndBytesable<String> withProtection()
     {
         setProtected();
         return this;

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCombinations.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCombinations.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.curator.framework.imps;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.CreateBuilder;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.data.ACL;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Maps;
+
+public class TestCombinations extends BaseClassForTests
+{
+    @Test
+    public void testCreate() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.builder().build();
+        client.start();
+
+        try {
+            // Don't care what this does, just that it compiles and makes sense
+            client.create()
+            .creatingParentsIfNeeded()
+            .withProtection()
+            .compressed()
+            .withMode(CreateMode.EPHEMERAL)
+            .withACL(Collections.singletonList(new ACL()))
+            .inBackground()
+            .forPath("/");
+        } catch (Exception e) {
+        }
+    }
+
+    @Test
+    public void testDelete() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.builder().build();
+        client.start();
+
+        try {
+            // Don't care what this does, just that it compiles.
+            client.delete()
+            .guaranteed()
+            .deletingChildrenIfNeeded()
+            .withVersion(0)
+            .inBackground()
+            .forPath("/");
+        } catch (Exception e) {
+        }
+    }
+
+    @Test
+    public void testSetData() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.builder().build();
+        client.start();
+
+        try {
+            // Don't care what this does, just that it compiles.
+            client.setData()
+            .compressed()
+            .withVersion(0)
+            .inBackground()
+            .forPath("/");
+        } catch (Exception e) {
+        }
+    }
+}


### PR DESCRIPTION
Move some interfaces around to allow CreateBuilder to chain
withProtection and compressed calls. Additionally, reduce some
duplication in the API to make method declarations more streamlined.
