### PR TITLE
Port Codehaus Jackson to fasterxml Jackson.

### DIFF
--- a/curator-examples/src/main/java/discovery/InstanceDetails.java
+++ b/curator-examples/src/main/java/discovery/InstanceDetails.java
@@ -18,7 +18,7 @@
  */
 package discovery;
 
-import org.codehaus.jackson.map.annotate.JsonRootName;
+import com.fasterxml.jackson.annotation.JsonRootName;
 
 /**
  * In a real application, the Service payload will most likely

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/contexts/GenericDiscoveryContext.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/contexts/GenericDiscoveryContext.java
@@ -18,13 +18,13 @@
  */
 package org.apache.curator.x.discovery.server.contexts;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.reflect.TypeToken;
 import org.apache.curator.x.discovery.ProviderStrategy;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.server.rest.DiscoveryContext;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ObjectNode;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 
@@ -88,7 +88,7 @@ public class GenericDiscoveryContext<T> implements DiscoveryContext<T>, ContextR
         T payload;
         ObjectMapper mapper = new ObjectMapper();
         //noinspection unchecked
-        payload = (T)mapper.readValue(node, payloadType.getRawType());
+        payload = (T)mapper.readValue(mapper.treeAsTokens(node), payloadType.getRawType());
         return payload;
     }
 

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/contexts/IntegerDiscoveryContext.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/contexts/IntegerDiscoveryContext.java
@@ -18,11 +18,11 @@
  */
 package org.apache.curator.x.discovery.server.contexts;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.curator.x.discovery.ProviderStrategy;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.server.rest.DiscoveryContext;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ObjectNode;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/contexts/StringDiscoveryContext.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/contexts/StringDiscoveryContext.java
@@ -18,11 +18,11 @@
  */
 package org.apache.curator.x.discovery.server.contexts;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.curator.x.discovery.ProviderStrategy;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.server.rest.DiscoveryContext;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ObjectNode;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceInstanceMarshaller.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceInstanceMarshaller.java
@@ -18,13 +18,13 @@
  */
 package org.apache.curator.x.discovery.server.entity;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.ServiceInstanceBuilder;
 import org.apache.curator.x.discovery.ServiceType;
 import org.apache.curator.x.discovery.server.rest.DiscoveryContext;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ObjectNode;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceInstancesMarshaller.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceInstancesMarshaller.java
@@ -18,13 +18,13 @@
  */
 package org.apache.curator.x.discovery.server.entity;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.server.rest.DiscoveryContext;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceNamesMarshaller.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceNamesMarshaller.java
@@ -18,11 +18,11 @@
  */
 package org.apache.curator.x.discovery.server.entity;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/rest/DiscoveryContext.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/rest/DiscoveryContext.java
@@ -18,10 +18,10 @@
  */
 package org.apache.curator.x.discovery.server.rest;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.curator.x.discovery.ProviderStrategy;
 import org.apache.curator.x.discovery.ServiceDiscovery;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ObjectNode;
 
 /**
  * Bridge between the specifics of your needs and the generic implementation

--- a/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/ServiceDetails.java
+++ b/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/ServiceDetails.java
@@ -18,10 +18,10 @@
  */
 package org.apache.curator.x.discovery.server.jetty_jersey;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import org.codehaus.jackson.map.annotate.JsonRootName;
 
 /**
  * Service payload describing details of a service.

--- a/curator-x-discovery/pom.xml
+++ b/curator-x-discovery/pom.xml
@@ -51,8 +51,18 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <dependency>

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceInstance.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceInstance.java
@@ -18,15 +18,13 @@
  */
 package org.apache.curator.x.discovery;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.net.InetAddress;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
-
-import org.codehaus.jackson.annotate.JsonTypeInfo;
-import org.codehaus.jackson.annotate.JsonTypeInfo.Id;
 
 /**
  * POJO that represents a service instance
@@ -124,7 +122,7 @@ public class ServiceInstance<T>
         return sslPort;
     }
 
-    @JsonTypeInfo(use=Id.CLASS, defaultImpl=Object.class)
+    @JsonTypeInfo(use= JsonTypeInfo.Id.CLASS, defaultImpl=Object.class)
     public T getPayload()
     {
         return payload;

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/JsonInstanceSerializer.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/JsonInstanceSerializer.java
@@ -18,9 +18,9 @@
  */
 package org.apache.curator.x.discovery.details;
 
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.curator.x.discovery.ServiceInstance;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.JavaType;
 import java.io.ByteArrayOutputStream;
 
 /**

--- a/curator-x-rpc/src/test/java/org/apache/curator/x/rpc/RpcTests.java
+++ b/curator-x-rpc/src/test/java/org/apache/curator/x/rpc/RpcTests.java
@@ -18,6 +18,9 @@
  */
 package org.apache.curator.x.rpc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.generated.*;
@@ -32,9 +35,6 @@ import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TSocket;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <apache-rat-plugin-version>0.10</apache-rat-plugin-version>
         <javassist-version>3.18.1-GA</javassist-version>
         <commons-math-version>2.2</commons-math-version>
-        <jackson-mapper-asl-version>1.9.13</jackson-mapper-asl-version>
+        <jackson-version>2.3.2</jackson-version>
         <jersey-version>1.18.1</jersey-version>
         <jsr311-api-version>1.1.1</jsr311-api-version>
         <jetty-version>6.1.26</jetty-version>
@@ -354,9 +354,21 @@
             </dependency>
 
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-                <version>${jackson-mapper-asl-version}</version>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
CURATOR-186

One line of executable code changed, here, in

org.apache.curator.x.discovery.server.contexts.GenericDiscoveryContext#unMarshallJson

	@Override
    public T unMarshallJson(JsonNode node) throws Exception
    {
        T payload;
        ObjectMapper mapper = new ObjectMapper();
        //noinspection unchecked
        payload = (T)mapper.readValue(mapper.treeAsTokens(node),  // <<<<<<<<<<<<<<<<
        payloadType.getRawType());
        return payload;
    }

Jackson v2 has no method on ObjectMapper supporting readValue(JsonNode, Class).  However, Jackson v1 states the form I used
is a shortcut for that legacy method.

All other changes to the code and poms were simply replacing imports
and maven dependencies.

Jackson 2.3.2 was chosen to be compatible with the version already
being transitively provided through the dependency
io.dropwizard:dropwizard-configuration:jar:0.7.0:compile