### PR TITLE
CURATOR-190 - Modified to always use the base name when creating protect...

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
@@ -336,7 +336,7 @@ public class PersistentEphemeralNode implements Closeable
         try
         {
             String existingPath = nodePath.get();
-            String createPath = (existingPath != null) ? existingPath : basePath;
+            String createPath = (existingPath != null && !mode.isProtected()) ? existingPath : basePath;
             createMethod.withMode(mode.getCreateMode(existingPath != null)).inBackground(backgroundCallback).forPath(createPath, data.get());
         }
         catch ( Exception e )


### PR DESCRIPTION
Modified to always use the base name when creating protected ephemeral nodes. This prevents the current protected name being appended to the name each time the node is created, which in turn prevents multiple
nodes being created.