### PR TITLE
make sure ChildReaper always moves through all registered nodes.

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/ChildReaper.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/ChildReaper.java
@@ -1,3 +1,4 @@
+
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,13 +19,14 @@
  */
 package org.apache.curator.framework.recipes.locks;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-
-import org.apache.curator.framework.recipes.leader.LeaderLatch;
-import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.curator.utils.CloseableScheduledExecutorService;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.curator.utils.PathUtils;
 import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.data.Stat;
@@ -34,13 +36,14 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.curator.utils.PathUtils;
 
 /**
  * Utility to reap empty child nodes of a parent node. Periodically calls getChildren on
@@ -53,11 +56,13 @@ public class ChildReaper implements Closeable
     private final AtomicReference<State> state = new AtomicReference<State>(State.LATENT);
     private final CuratorFramework client;
     private final Collection<String> paths = Sets.newConcurrentHashSet();
+    private volatile Iterator<String> pathIterator = null;
     private final Reaper.Mode mode;
     private final CloseableScheduledExecutorService executor;
     private final int reapingThresholdMs;
     private final LeaderLatch leaderLatch;
     private final Set<String> lockSchema;
+    private final AtomicInteger maxChildren = new AtomicInteger(-1);
 
     private volatile Future<?> task;
 
@@ -210,19 +215,54 @@ public class ChildReaper implements Closeable
         return paths.remove(PathUtils.validatePath(path));
     }
 
+    /**
+     * If a node has so many children that {@link CuratorFramework#getChildren()} will fail
+     * (due to jute.maxbuffer) it can cause connection instability. Set the max number of
+     * children here to prevent the path from being queried in these cases. The number should usually
+     * be: avergage-node-name/1000000
+     *
+     * @param maxChildren max children
+     */
+    public void setMaxChildren(int maxChildren)
+    {
+        this.maxChildren.set(maxChildren);
+    }
+
     public static ScheduledExecutorService newExecutorService()
     {
         return ThreadUtils.newFixedThreadScheduledPool(2, "ChildReaper");
     }
 
+    @VisibleForTesting
+    protected void warnMaxChildren(String path, Stat stat)
+    {
+        log.warn(String.format("Skipping %s as it has too many children: %d", path, stat.getNumChildren()));
+    }
+
     private void doWork()
     {
-        if (shouldDoWork())
+        if ( shouldDoWork() )
         {
-            for ( String path : paths )
+            if ( (pathIterator == null) || !pathIterator.hasNext() )
             {
+                pathIterator = paths.iterator();
+            }
+            while ( pathIterator.hasNext() )
+            {
+                String path = pathIterator.next();
                 try
                 {
+                    int maxChildren = this.maxChildren.get();
+                    if ( maxChildren > 0 )
+                    {
+                        Stat stat = client.checkExists().forPath(path);
+                        if ( (stat != null) && (stat.getNumChildren() > maxChildren) )
+                        {
+                            warnMaxChildren(path, stat);
+                            continue;
+                        }
+                    }
+
                     List<String> children = client.getChildren().forPath(path);
                     for ( String name : children )
                     {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/ChildReaper.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/ChildReaper.java
@@ -219,7 +219,7 @@ public class ChildReaper implements Closeable
      * If a node has so many children that {@link CuratorFramework#getChildren()} will fail
      * (due to jute.maxbuffer) it can cause connection instability. Set the max number of
      * children here to prevent the path from being queried in these cases. The number should usually
-     * be: avergage-node-name/1000000
+     * be: average-node-name-length/1000000
      *
      * @param maxChildren max children
      */

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/ChildReaper.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/ChildReaper.java
@@ -264,6 +264,7 @@ public class ChildReaper implements Closeable
                     }
 
                     List<String> children = client.getChildren().forPath(path);
+                    log.info(String.format("Found %d children for %s", children.size(), path));
                     for ( String name : children )
                     {
                         String childPath = ZKPaths.makePath(path, name);
@@ -288,6 +289,7 @@ public class ChildReaper implements Closeable
         Stat stat = client.checkExists().forPath(path);
         if ( (stat != null) && (stat.getNumChildren() == 0) )
         {
+            log.info("Adding " + path);
             reaper.addPath(path, mode);
         }
     }


### PR DESCRIPTION
make sure ChildReaper always moves through all registered nodes. Also, add an optionl check so that large nodes are never queried