### PR TITLE
LeaderSelector mutex resurrection

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderSelector.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderSelector.java
@@ -383,7 +383,7 @@ public class LeaderSelector implements Closeable
         hasLeadership = false;
         try
         {
-            mutex.acquire();
+            mutex.acquire(true);
 
             hasLeadership = true;
             try

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java
@@ -204,6 +204,7 @@ public class LockInternals
         boolean         isDone = false;
         while ( !isDone )
         {
+            ourPath = null;
             isDone = true;
             if ( resurrect )
             {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java
@@ -157,17 +157,17 @@ public class LockInternals
     {
         List<String> sortedList = Lists.newArrayList(children);
         Collections.sort
-                (
-                        sortedList,
-                        new Comparator<String>()
-                        {
-                            @Override
-                            public int compare(String lhs, String rhs)
-                            {
-                                return sorter.fixForSorting(lhs, lockName).compareTo(sorter.fixForSorting(rhs, lockName));
-                            }
-                        }
-                );
+        (
+            sortedList,
+            new Comparator<String>()
+            {
+                @Override
+                public int compare(String lhs, String rhs)
+                {
+                    return sorter.fixForSorting(lhs, lockName).compareTo(sorter.fixForSorting(rhs, lockName));
+                }
+            }
+        );
         return sortedList;
     }
 


### PR DESCRIPTION
I am not alone in experiencing situations in which my LeaderSelectors will wind up in an indefinite state of having no leader (relevant JIRA issues are listed below). This problem had been occurring nearly daily in our AWS environments (which regularly experience transient network issues). I believe I have solved this issue. This may not be the most elegant approach but, in the least, our deployments have behaved correctly since its activation.

This branch allows an InterProcessMutex to optionally reuse an existing acquisition. This of course breaks the contract of re-entrance as stated by the InterProcessLock interface but it is not done by default and only used specifically by the LeaderSelector (which is the only thing I am interested in using it for). I have a test reliably (though hackily) reproducing this issue but it is written in terms of an internal project and as I am unfamiliar with your test code I haven't ported it yet. All existing tests pass. The term resurrect probably isn't the best but hey, it works :p

Issues possibly fixed by this branch:
https://issues.apache.org/jira/browse/CURATOR-3
https://issues.apache.org/jira/browse/CURATOR-171
https://issues.apache.org/jira/browse/CURATOR-188
https://issues.apache.org/jira/browse/CURATOR-202
https://issues.apache.org/jira/browse/CURATOR-205
