### PR TITLE
CURATOR-211 - Fix readLockPredicate() index validation issue

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessReadWriteLock.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessReadWriteLock.java
@@ -193,7 +193,7 @@ public class InterProcessReadWriteLock
 
         int         index = 0;
         int         firstWriteIndex = Integer.MAX_VALUE;
-        int         ourIndex = Integer.MAX_VALUE;
+        int         ourIndex = -1;
         for ( String node : children )
         {
             if ( node.contains(WRITE_LOCK_NAME) )
@@ -208,6 +208,7 @@ public class InterProcessReadWriteLock
 
             ++index;
         }
+
         StandardLockInternalsDriver.validateOurIndex(sequenceNodeName, ourIndex);
 
         boolean     getsTheLock = (ourIndex < firstWriteIndex);


### PR DESCRIPTION
Fixing bug described in https://issues.apache.org/jira/browse/CURATOR-211.

In case if `ourIndex` is never assigned in loop it will be equal to `-1` which will result in throwing exception by `StandardLockInternalsDriver.validateOurIndex()`.