### PR TITLE
[CURATOR-215] Support async multi/transaction APIs

### DIFF
--- a/curator-examples/src/main/java/framework/TransactionExamples.java
+++ b/curator-examples/src/main/java/framework/TransactionExamples.java
@@ -19,25 +19,24 @@
 package framework;
 
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.api.transaction.CuratorTransaction;
-import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
 import java.util.Collection;
 
 public class TransactionExamples
 {
     public static Collection<CuratorTransactionResult>      transaction(CuratorFramework client) throws Exception
     {
-        // this example shows how to use ZooKeeper's new transactions
+        // this example shows how to use ZooKeeper's transactions
 
-        Collection<CuratorTransactionResult>    results = client.inTransaction()
-                .create().forPath("/a/path", "some data".getBytes())
-            .and()
-                .setData().forPath("/another/path", "other data".getBytes())
-            .and()
-                .delete().forPath("/yet/another/path")
-            .and()
-                .commit();  // IMPORTANT! The transaction is not submitted until commit() is called
+        CuratorOp createOp = client.transactionOp().create().forPath("/a/path", "some data".getBytes());
+        CuratorOp setDataOp = client.transactionOp().setData().forPath("/another/path", "other data".getBytes());
+        CuratorOp deleteOp = client.transactionOp().delete().forPath("/yet/another/path");
+
+        Collection<CuratorTransactionResult>    results = client.transaction().forOperations(createOp, setDataOp, deleteOp);
 
         for ( CuratorTransactionResult result : results )
         {
@@ -45,34 +44,5 @@ public class TransactionExamples
         }
 
         return results;
-    }
-
-    /*
-            These next four methods show how to use Curator's transaction APIs in a more
-            traditional - one-at-a-time - manner
-     */
-
-    public static CuratorTransaction        startTransaction(CuratorFramework client)
-    {
-        // start the transaction builder
-        return client.inTransaction();
-    }
-
-    public static CuratorTransactionFinal   addCreateToTransaction(CuratorTransaction transaction) throws Exception
-    {
-        // add a create operation
-        return transaction.create().forPath("/a/path", "some data".getBytes()).and();
-    }
-
-    public static CuratorTransactionFinal   addDeleteToTransaction(CuratorTransaction transaction) throws Exception
-    {
-        // add a delete operation
-        return transaction.delete().forPath("/another/path").and();
-    }
-
-    public static void                      commitTransaction(CuratorTransactionFinal transaction) throws Exception
-    {
-        // commit the transaction
-        transaction.commit();
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
@@ -22,6 +22,7 @@ package org.apache.curator.framework;
 import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.framework.api.*;
 import org.apache.curator.framework.api.transaction.CuratorMultiTransaction;
+import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
 import org.apache.curator.framework.api.transaction.TransactionOp;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
@@ -152,7 +153,9 @@ public interface CuratorFramework extends Closeable
     public CuratorMultiTransaction transaction();
 
     /**
-     * Allocate an operation that can be used with {@link #transaction()}
+     * Allocate an operation that can be used with {@link #transaction()}.
+     * NOTE: {@link CuratorOp} instances created by this builder are
+     * reusable.
      *
      * @return operation builder
      */

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
@@ -23,9 +23,9 @@ import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.framework.api.*;
 import org.apache.curator.framework.api.transaction.CuratorMultiTransaction;
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
+import org.apache.curator.framework.api.transaction.TransactionOp;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.listen.Listenable;
-import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.EnsurePath;
 import org.apache.zookeeper.Watcher;
@@ -126,6 +126,7 @@ public interface CuratorFramework extends Closeable
      * Start a transaction builder
      *
      * @return builder object
+     * @deprecated use {@link #transaction()} instead
      */
     public CuratorTransaction inTransaction();
 
@@ -135,6 +136,13 @@ public interface CuratorFramework extends Closeable
      * @return builder object
      */
     public CuratorMultiTransaction transaction();
+
+    /**
+     * Allocate an operation that can be used with {@link #transaction()}
+     *
+     * @return operation builder
+     */
+    public TransactionOp transactionOp();
 
     /**
      * Perform a sync on the given path - syncs are always in the background

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
@@ -21,6 +21,7 @@ package org.apache.curator.framework;
 
 import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.framework.api.*;
+import org.apache.curator.framework.api.transaction.CuratorMultiTransaction;
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.listen.Listenable;
@@ -127,6 +128,13 @@ public interface CuratorFramework extends Closeable
      * @return builder object
      */
     public CuratorTransaction inTransaction();
+
+    /**
+     * Start a transaction builder
+     *
+     * @return builder object
+     */
+    public CuratorMultiTransaction transaction();
 
     /**
      * Perform a sync on the given path - syncs are always in the background

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/CuratorEvent.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/CuratorEvent.java
@@ -18,6 +18,8 @@
  */
 package org.apache.curator.framework.api;
 
+import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
+import org.apache.zookeeper.OpResult;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
@@ -78,6 +80,11 @@ public interface CuratorEvent
      * @return any ACL list or null
      */
     public List<ACL> getACLList();
+
+    /**
+     * @return any operation results or null
+     */
+    public List<CuratorTransactionResult> getOpResults();
 
     /**
      * If {@link #getType()} returns {@link CuratorEventType#WATCHED} this will

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/CuratorEventType.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/CuratorEventType.java
@@ -69,6 +69,11 @@ public enum CuratorEventType
     SET_ACL,
 
     /**
+     * Corresponds to {@link CuratorFramework#transaction()}
+     */
+    TRANSACTION,
+
+    /**
      * Corresponds to {@link Watchable#usingWatcher(Watcher)} or {@link Watchable#watched()}
      */
     WATCHED,

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorMultiTransaction.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorMultiTransaction.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.api.transaction;
+
+import org.apache.curator.framework.api.Backgroundable;
+
+public interface CuratorMultiTransaction
+    extends Backgroundable<CuratorMultiTransactionMain>
+{
+}

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorMultiTransactionMain.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorMultiTransactionMain.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.api.transaction;
+
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.OpResult;
+import java.util.List;
+
+public interface CuratorMultiTransactionMain
+{
+    List<OpResult> forOperations(Op... operations) throws Exception;
+
+    List<OpResult> forOperations(List<Op> operations) throws Exception;
+}

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorMultiTransactionMain.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorMultiTransactionMain.java
@@ -28,7 +28,7 @@ public interface CuratorMultiTransactionMain
      * operation instances via {@link CuratorFramework#transactionOp()}
      *
      * @param operations operations that make up the transaction.
-     * @return result details
+     * @return result details for foreground operations or <code>null</code> for background operations
      * @throws Exception errors
      */
     List<CuratorTransactionResult> forOperations(CuratorOp... operations) throws Exception;
@@ -38,7 +38,7 @@ public interface CuratorMultiTransactionMain
      * operation instances via {@link CuratorFramework#transactionOp()}
      *
      * @param operations operations that make up the transaction.
-     * @return result details
+     * @return result details for foreground operations or <code>null</code> for background operations
      * @throws Exception errors
      */
     List<CuratorTransactionResult> forOperations(List<CuratorOp> operations) throws Exception;

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorMultiTransactionMain.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorMultiTransactionMain.java
@@ -18,11 +18,28 @@
  */
 package org.apache.curator.framework.api.transaction;
 
+import org.apache.curator.framework.CuratorFramework;
 import java.util.List;
 
 public interface CuratorMultiTransactionMain
 {
+    /**
+     * Commit the given operations as a single transaction. Create the
+     * operation instances via {@link CuratorFramework#transactionOp()}
+     *
+     * @param operations operations that make up the transaction.
+     * @return result details
+     * @throws Exception errors
+     */
     List<CuratorTransactionResult> forOperations(CuratorOp... operations) throws Exception;
 
+    /**
+     * Commit the given operations as a single transaction. Create the
+     * operation instances via {@link CuratorFramework#transactionOp()}
+     *
+     * @param operations operations that make up the transaction.
+     * @return result details
+     * @throws Exception errors
+     */
     List<CuratorTransactionResult> forOperations(List<CuratorOp> operations) throws Exception;
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorMultiTransactionMain.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorMultiTransactionMain.java
@@ -18,13 +18,11 @@
  */
 package org.apache.curator.framework.api.transaction;
 
-import org.apache.zookeeper.Op;
-import org.apache.zookeeper.OpResult;
 import java.util.List;
 
 public interface CuratorMultiTransactionMain
 {
-    List<OpResult> forOperations(Op... operations) throws Exception;
+    List<CuratorTransactionResult> forOperations(CuratorOp... operations) throws Exception;
 
-    List<OpResult> forOperations(List<Op> operations) throws Exception;
+    List<CuratorTransactionResult> forOperations(List<CuratorOp> operations) throws Exception;
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorOp.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorOp.java
@@ -20,6 +20,9 @@ package org.apache.curator.framework.api.transaction;
 
 import org.apache.zookeeper.Op;
 
+/**
+ * Internal representation of a transaction operation
+ */
 public interface CuratorOp
 {
     Op get();

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorOp.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorOp.java
@@ -18,10 +18,11 @@
  */
 package org.apache.curator.framework.api.transaction;
 
-import org.apache.curator.framework.api.Backgroundable;
+import org.apache.zookeeper.Op;
 
-public interface CuratorMultiTransaction extends
-    Backgroundable<CuratorMultiTransactionMain>,
-    CuratorMultiTransactionMain
+public interface CuratorOp
 {
+    Op get();
+
+    TypeAndPath getTypeAndPath();
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorTransaction.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorTransaction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.framework.api.transaction;
 
+import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.ZooKeeper;
 
 /**
@@ -49,6 +50,8 @@ import org.apache.zookeeper.ZooKeeper;
  *     <b>Important:</b> the operations are not submitted until
  *     {@link CuratorTransactionFinal#commit()} is called.
  * </p>
+ *
+ * @deprecated Use {@link CuratorFramework#transaction()}
  */
 public interface CuratorTransaction
 {
@@ -57,26 +60,26 @@ public interface CuratorTransaction
      *
      * @return builder object
      */
-    public TransactionCreateBuilder create();
+    public TransactionCreateBuilder<CuratorTransactionBridge> create();
 
     /**
      * Start a delete builder in the transaction
      *
      * @return builder object
      */
-    public TransactionDeleteBuilder delete();
+    public TransactionDeleteBuilder<CuratorTransactionBridge> delete();
 
     /**
      * Start a setData builder in the transaction
      *
      * @return builder object
      */
-    public TransactionSetDataBuilder setData();
+    public TransactionSetDataBuilder<CuratorTransactionBridge> setData();
 
     /**
      * Start a check builder in the transaction
      *ChildData
      * @return builder object
      */
-    public TransactionCheckBuilder check();
+    public TransactionCheckBuilder<CuratorTransactionBridge> check();
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorTransaction.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorTransaction.java
@@ -78,7 +78,7 @@ public interface CuratorTransaction
 
     /**
      * Start a check builder in the transaction
-     *ChildData
+     *
      * @return builder object
      */
     public TransactionCheckBuilder<CuratorTransactionBridge> check();

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorTransactionResult.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/CuratorTransactionResult.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.curator.framework.api.transaction;
 
 import com.google.common.base.Predicate;
@@ -27,9 +28,9 @@ import org.apache.zookeeper.data.Stat;
 public class CuratorTransactionResult
 {
     private final OperationType type;
-    private final String        forPath;
-    private final String        resultPath;
-    private final Stat          resultStat;
+    private final String forPath;
+    private final String resultPath;
+    private final Stat resultStat;
 
     /**
      * Utility that can be passed to Google Guava to find a particular result. E.g.
@@ -41,7 +42,7 @@ public class CuratorTransactionResult
      * @param forPath path
      * @return predicate
      */
-    public static Predicate<CuratorTransactionResult>       ofTypeAndPath(final OperationType type, final String forPath)
+    public static Predicate<CuratorTransactionResult> ofTypeAndPath(final OperationType type, final String forPath)
     {
         return new Predicate<CuratorTransactionResult>()
         {
@@ -73,7 +74,7 @@ public class CuratorTransactionResult
 
     /**
      * Returns the path that was passed to the operation when added
-     * 
+     *
      * @return operation input path
      */
     public String getForPath()

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/OperationType.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/OperationType.java
@@ -24,22 +24,22 @@ package org.apache.curator.framework.api.transaction;
 public enum OperationType
 {
     /**
-     * {@link CuratorTransaction#create()}
+     * {@link TransactionOp#create()}
      */
     CREATE,
 
     /**
-     * {@link CuratorTransaction#delete()}
+     * {@link TransactionOp#delete()}
      */
     DELETE,
 
     /**
-     * {@link CuratorTransaction#setData()}
+     * {@link TransactionOp#setData()}
      */
     SET_DATA,
 
     /**
-     * {@link CuratorTransaction#check()}
+     * {@link TransactionOp#check()}
      */
     CHECK
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionCheckBuilder.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionCheckBuilder.java
@@ -21,8 +21,8 @@ package org.apache.curator.framework.api.transaction;
 import org.apache.curator.framework.api.Pathable;
 import org.apache.curator.framework.api.Versionable;
 
-public interface TransactionCheckBuilder extends
-    Pathable<CuratorTransactionBridge>,
-    Versionable<Pathable<CuratorTransactionBridge>>
+public interface TransactionCheckBuilder<T> extends
+    Pathable<T>,
+    Versionable<Pathable<T>>
 {
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionCreateBuilder.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionCreateBuilder.java
@@ -23,10 +23,10 @@ import org.apache.curator.framework.api.Compressible;
 import org.apache.curator.framework.api.CreateModable;
 import org.apache.curator.framework.api.PathAndBytesable;
 
-public interface TransactionCreateBuilder extends
-    PathAndBytesable<CuratorTransactionBridge>,
-    CreateModable<ACLPathAndBytesable<CuratorTransactionBridge>>,
-    ACLPathAndBytesable<CuratorTransactionBridge>,
-    Compressible<ACLPathAndBytesable<CuratorTransactionBridge>>
+public interface TransactionCreateBuilder<T> extends
+    PathAndBytesable<T>,
+    CreateModable<ACLPathAndBytesable<T>>,
+    ACLPathAndBytesable<T>,
+    Compressible<ACLPathAndBytesable<T>>
 {
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionDeleteBuilder.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionDeleteBuilder.java
@@ -21,8 +21,8 @@ package org.apache.curator.framework.api.transaction;
 import org.apache.curator.framework.api.Pathable;
 import org.apache.curator.framework.api.Versionable;
 
-public interface TransactionDeleteBuilder extends
-    Pathable<CuratorTransactionBridge>,
-    Versionable<Pathable<CuratorTransactionBridge>>
+public interface TransactionDeleteBuilder<T> extends
+    Pathable<T>,
+    Versionable<Pathable<T>>
 {
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionOp.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionOp.java
@@ -18,10 +18,13 @@
  */
 package org.apache.curator.framework.api.transaction;
 
-import org.apache.curator.framework.api.Backgroundable;
-
-public interface CuratorMultiTransaction extends
-    Backgroundable<CuratorMultiTransactionMain>,
-    CuratorMultiTransactionMain
+public interface TransactionOp
 {
+    TransactionCreateBuilder<CuratorOp> create();
+
+    TransactionDeleteBuilder<CuratorOp> delete();
+
+    TransactionSetDataBuilder<CuratorOp> setData();
+
+    TransactionCheckBuilder<CuratorOp> check();
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionOp.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionOp.java
@@ -18,13 +18,39 @@
  */
 package org.apache.curator.framework.api.transaction;
 
+import org.apache.curator.framework.CuratorFramework;
+
+/**
+ * Builds operations that can be committed as a transaction
+ * via {@link CuratorFramework#transaction()}
+ */
 public interface TransactionOp
 {
+    /**
+     * Start a create builder in the transaction
+     *
+     * @return builder object
+     */
     TransactionCreateBuilder<CuratorOp> create();
 
+    /**
+     * Start a delete builder in the transaction
+     *
+     * @return builder object
+     */
     TransactionDeleteBuilder<CuratorOp> delete();
 
+    /**
+     * Start a setData builder in the transaction
+     *
+     * @return builder object
+     */
     TransactionSetDataBuilder<CuratorOp> setData();
 
+    /**
+     * Start a check builder in the transaction
+     *
+     * @return builder object
+     */
     TransactionCheckBuilder<CuratorOp> check();
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionSetDataBuilder.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TransactionSetDataBuilder.java
@@ -22,9 +22,9 @@ import org.apache.curator.framework.api.Compressible;
 import org.apache.curator.framework.api.PathAndBytesable;
 import org.apache.curator.framework.api.Versionable;
 
-public interface TransactionSetDataBuilder extends
-    PathAndBytesable<CuratorTransactionBridge>,
-    Versionable<PathAndBytesable<CuratorTransactionBridge>>,
-    Compressible<PathAndBytesable<CuratorTransactionBridge>>
+public interface TransactionSetDataBuilder<T> extends
+    PathAndBytesable<T>,
+    Versionable<PathAndBytesable<T>>,
+    Compressible<PathAndBytesable<T>>
 {
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TypeAndPath.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/transaction/TypeAndPath.java
@@ -16,38 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.curator.framework.imps;
+package org.apache.curator.framework.api.transaction;
 
-import com.google.common.collect.Lists;
-import org.apache.curator.framework.api.transaction.OperationType;
-import org.apache.curator.framework.api.transaction.TypeAndPath;
-import org.apache.zookeeper.MultiTransactionRecord;
-import org.apache.zookeeper.Op;
-import java.util.List;
-
-class CuratorMultiTransactionRecord extends MultiTransactionRecord
+public class TypeAndPath
 {
-    private final List<TypeAndPath>     metadata = Lists.newArrayList();
+    private final OperationType type;
+    private final String forPath;
 
-    @Override
-    public final void add(Op op)
+    public TypeAndPath(OperationType type, String forPath)
     {
-        throw new UnsupportedOperationException();
+        this.type = type;
+        this.forPath = forPath;
     }
 
-    void add(Op op, OperationType type, String forPath)
+    public OperationType getType()
     {
-        super.add(op);
-        metadata.add(new TypeAndPath(type, forPath));
+        return type;
     }
 
-    TypeAndPath     getMetadata(int index)
+    public String getForPath()
     {
-        return metadata.get(index);
-    }
-
-    int             metadataSize()
-    {
-        return metadata.size();
+        return forPath;
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/BackgroundSyncImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/BackgroundSyncImpl.java
@@ -46,7 +46,7 @@ class BackgroundSyncImpl implements BackgroundOperation<String>
                 public void processResult(int rc, String path, Object ctx)
                 {
                     trace.commit();
-                    CuratorEventImpl event = new CuratorEventImpl(client, CuratorEventType.SYNC, rc, path, null, ctx, null, null, null, null, null);
+                    CuratorEventImpl event = new CuratorEventImpl(client, CuratorEventType.SYNC, rc, path, null, ctx, null, null, null, null, null, null);
                     client.processBackgroundOperation(operationAndData, event);
                 }
             },

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
@@ -16,11 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.curator.framework.imps;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
@@ -29,16 +31,17 @@ import java.util.List;
 
 class CuratorEventImpl implements CuratorEvent
 {
-    private final CuratorEventType  type;
-    private final int               resultCode;
-    private final String            path;
-    private final String            name;
-    private final List<String>      children;
-    private final Object            context;
-    private final Stat              stat;
-    private final byte[]            data;
-    private final WatchedEvent      watchedEvent;
-    private final List<ACL>         aclList;
+    private final CuratorEventType type;
+    private final int resultCode;
+    private final String path;
+    private final String name;
+    private final List<String> children;
+    private final Object context;
+    private final Stat stat;
+    private final byte[] data;
+    private final WatchedEvent watchedEvent;
+    private final List<ACL> aclList;
+    private final List<CuratorTransactionResult> opResults;
 
     @Override
     public CuratorEventType getType()
@@ -101,6 +104,12 @@ class CuratorEventImpl implements CuratorEvent
     }
 
     @Override
+    public List<CuratorTransactionResult> getOpResults()
+    {
+        return opResults;
+    }
+
+    @Override
     public String toString()
     {
         return "CuratorEventImpl{" +
@@ -114,20 +123,22 @@ class CuratorEventImpl implements CuratorEvent
             ", data=" + Arrays.toString(data) +
             ", watchedEvent=" + watchedEvent +
             ", aclList=" + aclList +
+            ", opResults=" + opResults +
             '}';
     }
 
-    CuratorEventImpl(CuratorFrameworkImpl client, CuratorEventType type, int resultCode, String path, String name, Object context, Stat stat, byte[] data, List<String> children, WatchedEvent watchedEvent, List<ACL> aclList)
+    CuratorEventImpl(CuratorFrameworkImpl client, CuratorEventType type, int resultCode, String path, String name, Object context, Stat stat, byte[] data, List<String> children, WatchedEvent watchedEvent, List<ACL> aclList, List<CuratorTransactionResult> opResults)
     {
         this.type = type;
         this.resultCode = resultCode;
+        this.opResults = (opResults != null) ? ImmutableList.copyOf(opResults) : null;
         this.path = client.unfixForNamespace(path);
         this.name = name;
         this.context = context;
         this.stat = stat;
         this.data = data;
         this.children = children;
-        this.watchedEvent = (watchedEvent != null) ? new NamespaceWatchedEvent(client, watchedEvent) : watchedEvent;
+        this.watchedEvent = (watchedEvent != null) ? new NamespaceWatchedEvent(client, watchedEvent) : null;
         this.aclList = (aclList != null) ? ImmutableList.copyOf(aclList) : null;
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -31,7 +31,9 @@ import org.apache.curator.framework.AuthInfo;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.*;
+import org.apache.curator.framework.api.transaction.CuratorMultiTransaction;
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
+import org.apache.curator.framework.api.transaction.TransactionOp;
 import org.apache.curator.framework.listen.Listenable;
 import org.apache.curator.framework.listen.ListenerContainer;
 import org.apache.curator.framework.state.ConnectionState;
@@ -102,7 +104,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
             @Override
             public void process(WatchedEvent watchedEvent)
             {
-                CuratorEvent event = new CuratorEventImpl(CuratorFrameworkImpl.this, CuratorEventType.WATCHED, watchedEvent.getState().getIntValue(), unfixForNamespace(watchedEvent.getPath()), null, null, null, null, null, watchedEvent, null);
+                CuratorEvent event = new CuratorEventImpl(CuratorFrameworkImpl.this, CuratorEventType.WATCHED, watchedEvent.getState().getIntValue(), unfixForNamespace(watchedEvent.getPath()), null, null, null, null, null, watchedEvent, null, null);
                 processEvent(event);
             }
         }, builder.getRetryPolicy(), builder.canBeReadOnly());
@@ -276,7 +278,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
                 @Override
                 public Void apply(CuratorListener listener)
                 {
-                    CuratorEvent event = new CuratorEventImpl(CuratorFrameworkImpl.this, CuratorEventType.CLOSING, 0, null, null, null, null, null, null, null, null);
+                    CuratorEvent event = new CuratorEventImpl(CuratorFrameworkImpl.this, CuratorEventType.CLOSING, 0, null, null, null, null, null, null, null, null, null);
                     try
                     {
                         listener.eventReceived(CuratorFrameworkImpl.this, event);
@@ -403,6 +405,22 @@ public class CuratorFrameworkImpl implements CuratorFramework
         Preconditions.checkState(getState() == CuratorFrameworkState.STARTED, "instance must be started before calling this method");
 
         return new CuratorTransactionImpl(this);
+    }
+
+    @Override
+    public CuratorMultiTransaction transaction()
+    {
+        Preconditions.checkState(getState() == CuratorFrameworkState.STARTED, "instance must be started before calling this method");
+
+        return new CuratorMultiTransactionImpl(this);
+    }
+
+    @Override
+    public TransactionOp transactionOp()
+    {
+        Preconditions.checkState(getState() == CuratorFrameworkState.STARTED, "instance must be started before calling this method");
+
+        return new TransactionOpImpl(this);
     }
 
     @Override
@@ -822,7 +840,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
             if ( e instanceof CuratorConnectionLossException )
             {
                 WatchedEvent watchedEvent = new WatchedEvent(Watcher.Event.EventType.None, Watcher.Event.KeeperState.Disconnected, null);
-                CuratorEvent event = new CuratorEventImpl(this, CuratorEventType.WATCHED, KeeperException.Code.CONNECTIONLOSS.intValue(), null, null, operationAndData.getContext(), null, null, null, watchedEvent, null);
+                CuratorEvent event = new CuratorEventImpl(this, CuratorEventType.WATCHED, KeeperException.Code.CONNECTIONLOSS.intValue(), null, null, operationAndData.getContext(), null, null, null, watchedEvent, null, null);
                 if ( checkBackgroundRetry(operationAndData, event) )
                 {
                     queueOperation(operationAndData);

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorMultiTransactionImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorMultiTransactionImpl.java
@@ -38,9 +38,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 
-/**
- * @deprecated Use {@link CuratorFramework#transaction()}
- */
 public class CuratorMultiTransactionImpl implements
     CuratorMultiTransaction,
     CuratorMultiTransactionMain,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorMultiTransactionImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorMultiTransactionImpl.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.imps;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.curator.RetryLoop;
+import org.apache.curator.TimeTrace;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.transaction.CuratorMultiTransaction;
+import org.apache.curator.framework.api.transaction.CuratorMultiTransactionMain;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.OpResult;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+
+public class CuratorMultiTransactionImpl implements
+    CuratorMultiTransaction,
+    CuratorMultiTransactionMain,
+    BackgroundOperation<Void>
+{
+    private final CuratorFrameworkImpl client;
+    private Backgrounding backgrounding = new Backgrounding();
+
+    public CuratorMultiTransactionImpl(CuratorFrameworkImpl client)
+    {
+        this.client = client;
+    }
+
+    @Override
+    public CuratorMultiTransactionMain inBackground()
+    {
+        backgrounding = new Backgrounding(true);
+        return this;
+    }
+
+    @Override
+    public CuratorMultiTransactionMain inBackground(Object context)
+    {
+        backgrounding = new Backgrounding(context);
+        return this;
+    }
+
+    @Override
+    public CuratorMultiTransactionMain inBackground(BackgroundCallback callback)
+    {
+        backgrounding = new Backgrounding(callback);
+        return this;
+    }
+
+    @Override
+    public CuratorMultiTransactionMain inBackground(BackgroundCallback callback, Object context)
+    {
+        backgrounding = new Backgrounding(callback, context);
+        return this;
+    }
+
+    @Override
+    public CuratorMultiTransactionMain inBackground(BackgroundCallback callback, Executor executor)
+    {
+        backgrounding = new Backgrounding(callback, executor);
+        return this;
+    }
+
+    @Override
+    public CuratorMultiTransactionMain inBackground(BackgroundCallback callback, Object context, Executor executor)
+    {
+        backgrounding = new Backgrounding(client, callback, context, executor);
+        return this;
+    }
+
+    @Override
+    public List<OpResult> forOperations(Op... operations) throws Exception
+    {
+        List<Op> ops = (operations != null) ? Arrays.asList(operations) : Lists.<Op>newArrayList();
+        return forOperations(ops);
+    }
+
+    @Override
+    public List<OpResult> forOperations(List<Op> operations) throws Exception
+    {
+        operations = Preconditions.checkNotNull(operations, "operations cannot be null");
+        Preconditions.checkArgument(!operations.isEmpty(), "operations list cannot be empty");
+
+        if ( backgrounding.inBackground() )
+        {
+            client.processBackgroundOperation(new OperationAndData<>(this, null, backgrounding.getCallback(), null, backgrounding.getContext()), null);
+            return null;
+        }
+        else
+        {
+            return forOperationsInForeground(operations);
+        }
+    }
+
+    @Override
+    public void performBackgroundOperation(OperationAndData<Void> data) throws Exception
+    {
+
+    }
+
+    private List<OpResult> forOperationsInForeground(final List<Op> operations) throws Exception
+    {
+        TimeTrace trace = client.getZookeeperClient().startTracer("CuratorMultiTransactionImpl-Foreground");
+        List<OpResult> responseData = RetryLoop.callWithRetry
+        (
+            client.getZookeeperClient(),
+            new Callable<List<OpResult>>()
+            {
+                @Override
+                public List<OpResult> call() throws Exception
+                {
+                    return client.getZooKeeper().multi(operations);
+                }
+            }
+        );
+        trace.commit();
+
+        return responseData;
+    }
+}

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
@@ -119,7 +119,7 @@ class ExistsBuilderImpl implements ExistsBuilder, BackgroundOperation<String>
             public void processResult(int rc, String path, Object ctx, Stat stat)
             {
                 trace.commit();
-                CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.EXISTS, rc, path, null, ctx, stat, null, null, null, null);
+                CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.EXISTS, rc, path, null, ctx, stat, null, null, null, null, null);
                 client.processBackgroundOperation(operationAndData, event);
             }
         };

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ExtractingCuratorOp.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ExtractingCuratorOp.java
@@ -18,36 +18,42 @@
  */
 package org.apache.curator.framework.imps;
 
-import com.google.common.collect.Lists;
-import org.apache.curator.framework.api.transaction.OperationType;
+import com.google.common.base.Preconditions;
+import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.framework.api.transaction.TypeAndPath;
-import org.apache.zookeeper.MultiTransactionRecord;
 import org.apache.zookeeper.Op;
-import java.util.List;
 
-class CuratorMultiTransactionRecord extends MultiTransactionRecord
+class ExtractingCuratorOp implements CuratorOp
 {
-    private final List<TypeAndPath>     metadata = Lists.newArrayList();
+    private final CuratorMultiTransactionRecord record = new CuratorMultiTransactionRecord();
+
+    CuratorMultiTransactionRecord getRecord()
+    {
+        return record;
+    }
+
+    CuratorOp asCuratorOp()
+    {
+        return this;
+    }
 
     @Override
-    public final void add(Op op)
+    public TypeAndPath getTypeAndPath()
     {
-        throw new UnsupportedOperationException();
+        validate();
+        return record.getMetadata(0);
     }
 
-    void add(Op op, OperationType type, String forPath)
+    @Override
+    public Op get()
     {
-        super.add(op);
-        metadata.add(new TypeAndPath(type, forPath));
+        validate();
+        return record.iterator().next();
     }
 
-    TypeAndPath     getMetadata(int index)
+    private void validate()
     {
-        return metadata.get(index);
-    }
-
-    int             metadataSize()
-    {
-        return metadata.size();
+        Preconditions.checkArgument(record.size() > 0, "No operation has been added");
+        Preconditions.checkArgument(record.size() == 1, "Multiple operations added");
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ExtractingCuratorOp.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ExtractingCuratorOp.java
@@ -32,11 +32,6 @@ class ExtractingCuratorOp implements CuratorOp
         return record;
     }
 
-    CuratorOp asCuratorOp()
-    {
-        return this;
-    }
-
     @Override
     public TypeAndPath getTypeAndPath()
     {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetACLBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetACLBuilderImpl.java
@@ -104,7 +104,7 @@ class GetACLBuilderImpl implements GetACLBuilder, BackgroundOperation<String>
             public void processResult(int rc, String path, Object ctx, List<ACL> acl, Stat stat)
             {
                 trace.commit();
-                CuratorEventImpl event = new CuratorEventImpl(client, CuratorEventType.GET_ACL, rc, path, null, ctx, stat, null, null, null, acl);
+                CuratorEventImpl event = new CuratorEventImpl(client, CuratorEventType.GET_ACL, rc, path, null, ctx, stat, null, null, null, acl, null);
                 client.processBackgroundOperation(operationAndData, event);
             }
         };

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
@@ -162,7 +162,7 @@ class GetChildrenBuilderImpl implements GetChildrenBuilder, BackgroundOperation<
                 {
                     strings = Lists.newArrayList();
                 }
-                CuratorEventImpl event = new CuratorEventImpl(client, CuratorEventType.CHILDREN, rc, path, null, o, stat, null, strings, null, null);
+                CuratorEventImpl event = new CuratorEventImpl(client, CuratorEventType.CHILDREN, rc, path, null, o, stat, null, strings, null, null, null);
                 client.processBackgroundOperation(operationAndData, event);
             }
         };

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetConfigBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetConfigBuilderImpl.java
@@ -143,7 +143,7 @@ public class GetConfigBuilderImpl implements GetConfigBuilder, BackgroundOperati
             public void processResult(int rc, String path, Object ctx, byte[] data, Stat stat)
             {
                 trace.commit();
-                CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.GET_CONFIG, rc, path, null, ctx, stat, data, null, null, null);
+                CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.GET_CONFIG, rc, path, null, ctx, stat, data, null, null, null, null);
                 client.processBackgroundOperation(operationAndData, event);
             }
         };

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
@@ -250,7 +250,7 @@ class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<String>
                         rc = KeeperException.Code.DATAINCONSISTENCY.intValue();
                     }
                 }
-                CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.GET_DATA, rc, path, null, ctx, stat, data, null, null, null);
+                CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.GET_DATA, rc, path, null, ctx, stat, data, null, null, null, null);
                 client.processBackgroundOperation(operationAndData, event);
             }
         };

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ReconfigBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ReconfigBuilderImpl.java
@@ -476,7 +476,7 @@ public class ReconfigBuilderImpl implements
                 {
                     DataTree.copyStat(stat, responseStat);
                 }
-                CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.RECONFIG, rc, path, null, ctx, stat, bytes, null, null, null);
+                CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.RECONFIG, rc, path, null, ctx, stat, bytes, null, null, null, null);
                 client.processBackgroundOperation(data, event);
             }
         };

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetACLBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetACLBuilderImpl.java
@@ -138,7 +138,7 @@ class SetACLBuilderImpl implements SetACLBuilder, BackgroundPathable<Stat>, Back
                 public void processResult(int rc, String path, Object ctx, Stat stat)
                 {
                     trace.commit();
-                    CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.SET_ACL, rc, path, null, ctx, stat, null, null, null, null);
+                    CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.SET_ACL, rc, path, null, ctx, stat, null, null, null, null, null);
                     client.processBackgroundOperation(operationAndData, event);
                 }
             },

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SyncBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SyncBuilderImpl.java
@@ -93,7 +93,7 @@ public class SyncBuilderImpl implements SyncBuilder, BackgroundOperation<String>
             public void processResult(int rc, String path, Object ctx)
             {
                 trace.commit();
-                CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.SYNC, rc, path, path, ctx, null, null, null, null, null);
+                CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.SYNC, rc, path, path, ctx, null, null, null, null, null, null);
                 client.processBackgroundOperation(operationAndData, event);
             }
         };

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/TransactionOpImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/TransactionOpImpl.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.api.transaction.CuratorOp;
+import org.apache.curator.framework.api.transaction.TransactionCheckBuilder;
+import org.apache.curator.framework.api.transaction.TransactionCreateBuilder;
+import org.apache.curator.framework.api.transaction.TransactionDeleteBuilder;
+import org.apache.curator.framework.api.transaction.TransactionOp;
+import org.apache.curator.framework.api.transaction.TransactionSetDataBuilder;
+
+public class TransactionOpImpl implements TransactionOp
+{
+    private final CuratorFrameworkImpl client;
+
+    public TransactionOpImpl(CuratorFrameworkImpl client)
+    {
+        this.client = client;
+    }
+
+    @Override
+    public TransactionCreateBuilder<CuratorOp> create()
+    {
+        ExtractingCuratorOp op = new ExtractingCuratorOp();
+        return new CreateBuilderImpl(client).asTransactionCreateBuilder(op.asCuratorOp(), op.getRecord());
+    }
+
+    @Override
+    public TransactionDeleteBuilder<CuratorOp> delete()
+    {
+        ExtractingCuratorOp op = new ExtractingCuratorOp();
+        return new DeleteBuilderImpl(client).asTransactionDeleteBuilder(op.asCuratorOp(), op.getRecord());
+    }
+
+    @Override
+    public TransactionSetDataBuilder<CuratorOp> setData()
+    {
+        ExtractingCuratorOp op = new ExtractingCuratorOp();
+        return new SetDataBuilderImpl(client).asTransactionSetDataBuilder(op.asCuratorOp(), op.getRecord());
+    }
+
+    @Override
+    public TransactionCheckBuilder<CuratorOp> check()
+    {
+        ExtractingCuratorOp op = new ExtractingCuratorOp();
+        return CuratorTransactionImpl.makeTransactionCheckBuilder(client, op.asCuratorOp(), op.getRecord());
+    }
+
+}

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/TransactionOpImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/TransactionOpImpl.java
@@ -38,28 +38,28 @@ public class TransactionOpImpl implements TransactionOp
     public TransactionCreateBuilder<CuratorOp> create()
     {
         ExtractingCuratorOp op = new ExtractingCuratorOp();
-        return new CreateBuilderImpl(client).asTransactionCreateBuilder(op.asCuratorOp(), op.getRecord());
+        return new CreateBuilderImpl(client).<CuratorOp>asTransactionCreateBuilder(op, op.getRecord());
     }
 
     @Override
     public TransactionDeleteBuilder<CuratorOp> delete()
     {
         ExtractingCuratorOp op = new ExtractingCuratorOp();
-        return new DeleteBuilderImpl(client).asTransactionDeleteBuilder(op.asCuratorOp(), op.getRecord());
+        return new DeleteBuilderImpl(client).<CuratorOp>asTransactionDeleteBuilder(op, op.getRecord());
     }
 
     @Override
     public TransactionSetDataBuilder<CuratorOp> setData()
     {
         ExtractingCuratorOp op = new ExtractingCuratorOp();
-        return new SetDataBuilderImpl(client).asTransactionSetDataBuilder(op.asCuratorOp(), op.getRecord());
+        return new SetDataBuilderImpl(client).<CuratorOp>asTransactionSetDataBuilder(op, op.getRecord());
     }
 
     @Override
     public TransactionCheckBuilder<CuratorOp> check()
     {
         ExtractingCuratorOp op = new ExtractingCuratorOp();
-        return CuratorTransactionImpl.makeTransactionCheckBuilder(client, op.asCuratorOp(), op.getRecord());
+        return CuratorTransactionImpl.<CuratorOp>makeTransactionCheckBuilder(client, op, op.getRecord());
     }
 
 }

--- a/curator-framework/src/site/confluence/index.confluence
+++ b/curator-framework/src/site/confluence/index.confluence
@@ -42,7 +42,8 @@ h3. Methods
 |getData()|Begins an operation to get a ZNode's data. Call additional methods (watch, background or get stat) and finalize the operation by calling forPath()|
 |setData()|Begins an operation to set a ZNode's data. Call additional methods (version or background) and finalize the operation by calling forPath()|
 |getChildren()|Begins an operation to get a ZNode's list of children ZNodes. Call additional methods (watch, background or get stat) and finalize the operation by calling forPath()|
-|inTransaction()|Begins an atomic ZooKeeper transaction. Combine create, setData, check, and/or delete operations and then commit() as a unit.|
+|transactionOp()|Used to allocate operations to be used with transaction().|
+|transaction()|Atomically submit a set of operations as a transaction.|
 
 h3. Notifications
 Notifications for background operations and watches are published via the ClientListener interface. You register listeners with the
@@ -62,6 +63,10 @@ ClientEvent depend on the type of event which is exposed via the getType() metho
 |GET_DATA|getResultCode(), getPath(), getStat() and getData()|
 |SET_DATA|getResultCode(), getPath() and getStat()|
 |CHILDREN|getResultCode(), getPath(), getStat(), getChildren()|
+|SYNC|getResultCode(), getStat()|
+|GET\_ACL|getResultCode(), getACLList()|
+|SET\_ACL|getResultCode()|
+|TRANSACTION|getResultCode(), getOpResults()|
 |WATCHED|getWatchedEvent()|
 
 h2. Namespaces

--- a/curator-framework/src/site/confluence/index.confluence
+++ b/curator-framework/src/site/confluence/index.confluence
@@ -42,16 +42,12 @@ h3. Methods
 |getData()|Begins an operation to get a ZNode's data. Call additional methods (watch, background or get stat) and finalize the operation by calling forPath()|
 |setData()|Begins an operation to set a ZNode's data. Call additional methods (version or background) and finalize the operation by calling forPath()|
 |getChildren()|Begins an operation to get a ZNode's list of children ZNodes. Call additional methods (watch, background or get stat) and finalize the operation by calling forPath()|
-<<<<<<< HEAD
 |transactionOp()|Used to allocate operations to be used with transaction().|
 |transaction()|Atomically submit a set of operations as a transaction.|
-=======
-|inTransaction()|Begins an atomic ZooKeeper transaction. Combine create, setData, check, and/or delete operations and then commit() as a unit.|
 |getACL()|Begins an operation to return a ZNode's ACL settings. Call additional methods and finalize the operation by calling forPath()|
 |setACL()|Begins an operation to set a ZNode's ACL settings. Call additional methods and finalize the operation by calling forPath()|
 |getConfig()|Begins an operation to return the last committed configuration. Call additional methods and finalize the operation by calling forEnsemble()|
 |reconfig()|Begins an operation to change the configuration. Call additional methods and finalize the operation by calling forEnsemble()|
->>>>>>> CURATOR-3.0
 
 h3. Notifications
 Notifications for background operations and watches are published via the ClientListener interface. You register listeners with the

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionOld.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionOld.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.CompressionProvider;
+import org.apache.curator.retry.RetryOneTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SuppressWarnings("deprecation")
+public class TestCompressionInTransactionOld extends BaseClassForTests
+{
+    @Test
+    public void testSetData() throws Exception
+    {
+        final String path = "/a";
+        final byte[]            data = "here's a string".getBytes();
+
+        CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+
+            //Create uncompressed data in a transaction
+            client.inTransaction().create().forPath(path, data).and().commit();
+            Assert.assertEquals(data, client.getData().forPath(path));
+
+            //Create compressed data in transaction
+            client.inTransaction().setData().compressed().forPath(path, data).and().commit();
+            Assert.assertEquals(data, client.getData().decompressed().forPath(path));
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+    
+    @Test
+    public void testSetCompressedAndUncompressed() throws Exception
+    {
+        final String path1 = "/a";
+        final String path2 = "/b";
+        
+        final byte[]            data1 = "here's a string".getBytes();
+        final byte[]            data2 = "here's another string".getBytes();
+
+        CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+
+            //Create the nodes
+            client.inTransaction().create().compressed().forPath(path1).and().
+            create().forPath(path2).and().commit();
+
+            //Check they exist
+            Assert.assertNotNull(client.checkExists().forPath(path1));
+            Assert.assertNotNull(client.checkExists().forPath(path2));
+            
+            //Set the nodes, path1 compressed, path2 uncompressed.
+            client.inTransaction().setData().compressed().forPath(path1, data1).and().
+            setData().forPath(path2, data2).and().commit();
+            
+            Assert.assertNotEquals(data1, client.getData().forPath(path1));
+            Assert.assertEquals(data1, client.getData().decompressed().forPath(path1));
+      
+            Assert.assertEquals(data2, client.getData().forPath(path2));            
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }    
+    
+    @Test
+    public void testSimple() throws Exception
+    {
+        final String path1 = "/a";
+        final String path2 = "/a/b";
+        
+        final byte[]            data1 = "here's a string".getBytes();
+        final byte[]            data2 = "here's another string".getBytes();
+
+        CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+
+            client.inTransaction().create().compressed().forPath(path1, data1).and().
+            create().compressed().forPath(path2, data2).and().commit();
+
+            Assert.assertNotEquals(data1, client.getData().forPath(path1));
+            Assert.assertEquals(data1, client.getData().decompressed().forPath(path1));
+            
+            Assert.assertNotEquals(data2, client.getData().forPath(path2));
+            Assert.assertEquals(data2, client.getData().decompressed().forPath(path2));            
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }    
+    
+    /**
+     * Test the case where both uncompressed and compressed data is generated in
+     * the same transaction
+     * @throws Exception
+     */
+    @Test
+    public void testCreateCompressedAndUncompressed() throws Exception
+    {
+        final String path1 = "/a";
+        final String path2 = "/b";
+        
+        final byte[]            data1 = "here's a string".getBytes();
+        final byte[]            data2 = "here's another string".getBytes();
+
+        CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+
+            client.inTransaction().create().compressed().forPath(path1, data1).and().
+            create().forPath(path2, data2).and().commit();
+
+            Assert.assertNotEquals(data1, client.getData().forPath(path1));
+            Assert.assertEquals(data1, client.getData().decompressed().forPath(path1));
+      
+            Assert.assertEquals(data2, client.getData().forPath(path2));            
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsNew.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsNew.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.curator.framework.imps;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Queues;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.transaction.CuratorOp;
+import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
+import org.apache.curator.framework.api.transaction.OperationType;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+public class TestTransactionsNew extends BaseClassForTests
+{
+    @Test
+    public void testCheckVersion() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+            client.create().forPath("/foo");
+            Stat stat = client.setData().forPath("/foo", "new".getBytes());  // up the version
+
+            CuratorOp statOp = client.transactionOp().check().withVersion(stat.getVersion() + 1).forPath("/foo");
+            CuratorOp createOp = client.transactionOp().create().forPath("/bar");
+            try
+            {
+                client.transaction().forOperations(statOp, createOp);
+                Assert.fail();
+            }
+            catch ( KeeperException.BadVersionException correct )
+            {
+                // correct
+            }
+
+            Assert.assertNull(client.checkExists().forPath("/bar"));
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testWithNamespace() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
+        try
+        {
+            client.start();
+            CuratorOp createOp1 = client.transactionOp().create().forPath("/foo", "one".getBytes());
+            CuratorOp createOp2 = client.transactionOp().create().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/test-", "one".getBytes());
+            CuratorOp setDataOp = client.transactionOp().setData().forPath("/foo", "two".getBytes());
+            CuratorOp createOp3 = client.transactionOp().create().forPath("/foo/bar");
+            CuratorOp deleteOp = client.transactionOp().delete().forPath("/foo/bar");
+
+            Collection<CuratorTransactionResult> results = client.transaction().forOperations(createOp1, createOp2, setDataOp, createOp3, deleteOp);
+
+            Assert.assertTrue(client.checkExists().forPath("/foo") != null);
+            Assert.assertTrue(client.usingNamespace(null).checkExists().forPath("/galt/foo") != null);
+            Assert.assertEquals(client.getData().forPath("/foo"), "two".getBytes());
+            Assert.assertTrue(client.checkExists().forPath("/foo/bar") == null);
+
+            CuratorTransactionResult ephemeralResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/test-"));
+            Assert.assertNotNull(ephemeralResult);
+            Assert.assertNotEquals(ephemeralResult.getResultPath(), "/test-");
+            Assert.assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBasic() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+            CuratorOp createOp1 = client.transactionOp().create().forPath("/foo");
+            CuratorOp createOp2 = client.transactionOp().create().forPath("/foo/bar", "snafu".getBytes());
+
+            Collection<CuratorTransactionResult> results = client.transaction().forOperations(createOp1, createOp2);
+
+            Assert.assertTrue(client.checkExists().forPath("/foo/bar") != null);
+            Assert.assertEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
+
+            CuratorTransactionResult fooResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo"));
+            CuratorTransactionResult fooBarResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo/bar"));
+            Assert.assertNotNull(fooResult);
+            Assert.assertNotNull(fooBarResult);
+            Assert.assertNotSame(fooResult, fooBarResult);
+            Assert.assertEquals(fooResult.getResultPath(), "/foo");
+            Assert.assertEquals(fooBarResult.getResultPath(), "/foo/bar");
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackground() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+            CuratorOp createOp1 = client.transactionOp().create().forPath("/foo");
+            CuratorOp createOp2 = client.transactionOp().create().forPath("/foo/bar", "snafu".getBytes());
+
+            final BlockingQueue<List<CuratorTransactionResult>> queue = Queues.newLinkedBlockingQueue();
+            BackgroundCallback callback = new BackgroundCallback()
+            {
+                @Override
+                public void processResult(CuratorFramework client, CuratorEvent event) throws Exception
+                {
+                    queue.add(event.getOpResults());
+                }
+            };
+            client.transaction().inBackground(callback).forOperations(createOp1, createOp2);
+            Collection<CuratorTransactionResult> results = queue.poll(5, TimeUnit.SECONDS);
+
+            Assert.assertNotNull(results);
+            Assert.assertTrue(client.checkExists().forPath("/foo/bar") != null);
+            Assert.assertEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
+
+            CuratorTransactionResult fooResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo"));
+            CuratorTransactionResult fooBarResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo/bar"));
+            Assert.assertNotNull(fooResult);
+            Assert.assertNotNull(fooBarResult);
+            Assert.assertNotSame(fooResult, fooBarResult);
+            Assert.assertEquals(fooResult.getResultPath(), "/foo");
+            Assert.assertEquals(fooBarResult.getResultPath(), "/foo/bar");
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testBackgroundWithNamespace() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
+        try
+        {
+            client.start();
+            CuratorOp createOp1 = client.transactionOp().create().forPath("/foo", "one".getBytes());
+            CuratorOp createOp2 = client.transactionOp().create().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/test-", "one".getBytes());
+            CuratorOp setDataOp = client.transactionOp().setData().forPath("/foo", "two".getBytes());
+            CuratorOp createOp3 = client.transactionOp().create().forPath("/foo/bar");
+            CuratorOp deleteOp = client.transactionOp().delete().forPath("/foo/bar");
+
+            final BlockingQueue<List<CuratorTransactionResult>> queue = Queues.newLinkedBlockingQueue();
+            BackgroundCallback callback = new BackgroundCallback()
+            {
+                @Override
+                public void processResult(CuratorFramework client, CuratorEvent event) throws Exception
+                {
+                    queue.add(event.getOpResults());
+                }
+            };
+            client.transaction().inBackground(callback).forOperations(createOp1, createOp2, setDataOp, createOp3, deleteOp);
+
+            Collection<CuratorTransactionResult> results = queue.poll(5, TimeUnit.SECONDS);
+
+            Assert.assertNotNull(results);
+            Assert.assertTrue(client.checkExists().forPath("/foo") != null);
+            Assert.assertTrue(client.usingNamespace(null).checkExists().forPath("/galt/foo") != null);
+            Assert.assertEquals(client.getData().forPath("/foo"), "two".getBytes());
+            Assert.assertTrue(client.checkExists().forPath("/foo/bar") == null);
+
+            CuratorTransactionResult ephemeralResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/test-"));
+            Assert.assertNotNull(ephemeralResult);
+            Assert.assertNotEquals(ephemeralResult.getResultPath(), "/test-");
+            Assert.assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsOld.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsOld.java
@@ -25,6 +25,7 @@ import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
 import org.apache.curator.framework.api.transaction.OperationType;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
@@ -32,15 +33,16 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.util.Collection;
 
-public class TestTransactions extends BaseClassForTests
+@SuppressWarnings("deprecation")
+public class TestTransactionsOld extends BaseClassForTests
 {
     @Test
     public void     testCheckVersion() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
-        client.start();
         try
         {
+            client.start();
             client.create().forPath("/foo");
             Stat        stat = client.setData().forPath("/foo", "new".getBytes());  // up the version
 
@@ -64,7 +66,7 @@ public class TestTransactions extends BaseClassForTests
         }
         finally
         {
-            client.close();
+            CloseableUtils.closeQuietly(client);
         }
     }
 
@@ -72,9 +74,9 @@ public class TestTransactions extends BaseClassForTests
     public void     testWithNamespace() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
-        client.start();
         try
         {
+            client.start();
             Collection<CuratorTransactionResult>    results =
                 client.inTransaction()
                     .create().forPath("/foo", "one".getBytes())
@@ -101,7 +103,7 @@ public class TestTransactions extends BaseClassForTests
         }
         finally
         {
-            client.close();
+            CloseableUtils.closeQuietly(client);
         }
     }
 
@@ -109,9 +111,9 @@ public class TestTransactions extends BaseClassForTests
     public void     testBasic() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
-        client.start();
         try
         {
+            client.start();
             Collection<CuratorTransactionResult>    results =
                 client.inTransaction()
                     .create().forPath("/foo")
@@ -133,7 +135,7 @@ public class TestTransactions extends BaseClassForTests
         }
         finally
         {
-            client.close();
+            CloseableUtils.closeQuietly(client);
         }
     }
 }


### PR DESCRIPTION
I took this opportunity to re-write the transaction APIs. The old ones were far too clever and hard to use (though pretty!). At the same time, added support for ZK 3.5's async multi() APIs. Old Curator transaction APIs have been deprecated. This uses the old transactions internal code for consistency. However, this makes the implementation a bit cumbersome. In the future, this can all be cleaned up