### PR TITLE
CURATOR-235 LeaderSelector.internalRequeue should be private

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderSelector.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderSelector.java
@@ -230,7 +230,7 @@ public class LeaderSelector implements Closeable
         return internalRequeue();
     }
 
-    public synchronized boolean internalRequeue()
+    private synchronized boolean internalRequeue()
     {
         if ( !isQueued && (state.get() == State.STARTED) )
         {


### PR DESCRIPTION
I think this was left public unintentionally.