### PR TITLE
CURATOR-218 Reorder ConnectionState process event

### DIFF
--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestBlockUntilConnected.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestBlockUntilConnected.java
@@ -232,4 +232,28 @@ public class TestBlockUntilConnected extends BaseClassForTests
             CloseableUtils.closeQuietly(client);
         }
     }
+
+    /**
+     * Test that we are actually connected every time that we block until connection is established in a tight loop.
+     */
+    @Test
+    public void testBlockUntilConnectedTightLoop() throws InterruptedException
+    {
+        CuratorFramework client;
+        for(int i = 0 ; i < 50 ; i++)
+        {
+            client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(100));
+            try
+            {
+                client.start();
+                client.blockUntilConnected();
+
+                Assert.assertTrue(client.getZookeeperClient().isConnected(), "Not connected after blocking for connection #" + i);
+            }
+            finally
+            {
+                client.close();
+            }
+        }
+    }
 }


### PR DESCRIPTION
Address a race condition in ConnectionState.process where it will
trigger watchers first before updating its own state. This can lead to
inconsistencies when blocking until connected.