### PR TITLE
CURATOR-241: Write updated data on reconnect

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
@@ -338,7 +338,7 @@ public class PersistentEphemeralNode implements Closeable
         this.data.set(Arrays.copyOf(data, data.length));
         if ( isActive() )
         {
-            client.setData().inBackground().forPath(getActualPath(), this.data.get());
+            client.setData().inBackground().forPath(getActualPath(), getData());
         }
     }
 

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
@@ -338,11 +338,11 @@ public class PersistentEphemeralNode implements Closeable
         this.data.set(Arrays.copyOf(data, data.length));
         if ( isActive() )
         {
-            client.setData().inBackground().forPath(getActualPath(), getData());
+            client.setData().inBackground().forPath(getActualPath(), this.data.get());
         }
     }
 
-    byte[] getData() {
+    private byte[] getData() {
         return this.data.get();
     }
 

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
@@ -240,7 +240,7 @@ public class PersistentEphemeralNode implements Closeable
 
                     if(nodeExists)
                     {
-                    	client.setData().inBackground(setDataCallback).forPath(getActualPath(), data);
+                       client.setData().inBackground(setDataCallback).forPath(getActualPath(), getData());
                     }
                     else
                     {
@@ -338,8 +338,12 @@ public class PersistentEphemeralNode implements Closeable
         this.data.set(Arrays.copyOf(data, data.length));
         if ( isActive() )
         {
-            client.setData().inBackground().forPath(getActualPath(), this.data.get());
+            client.setData().inBackground().forPath(getActualPath(), getData());
         }
+    }
+
+    byte[] getData() {
+        return this.data.get();
     }
 
     private void deleteNode() throws Exception


### PR DESCRIPTION
PersistentEphemeralNode can be initialised with certain data, then later updated. If the client reconnects, the replacing ephemeral should write the updated data.