### PR TITLE
Better session expiration management

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/connection/ClassicConnectionHandlingPolicy.java
+++ b/curator-client/src/main/java/org/apache/curator/connection/ClassicConnectionHandlingPolicy.java
@@ -28,9 +28,9 @@ import java.util.concurrent.Callable;
 public class ClassicConnectionHandlingPolicy implements ConnectionHandlingPolicy
 {
     @Override
-    public boolean isEmulatingClassicHandling()
+    public int getSimulatedSessionExpirationPercent()
     {
-        return true;
+        return 0;
     }
 
     @Override

--- a/curator-client/src/main/java/org/apache/curator/connection/ConnectionHandlingPolicy.java
+++ b/curator-client/src/main/java/org/apache/curator/connection/ConnectionHandlingPolicy.java
@@ -29,11 +29,32 @@ import java.util.concurrent.Callable;
 public interface ConnectionHandlingPolicy
 {
     /**
-     * Return true if this policy should behave like the pre-3.0.0 version of Curator
+     * <p>
+     *     Prior to 3.0.0, Curator did not try to manage session expiration
+     *     other than the functionality provided by ZooKeeper itself. Starting with
+     *     3.0.0, Curator has the option of attempting to monitor session expiration
+     *     above what is provided by ZooKeeper. The percentage returned by this method
+     *     determines how and if Curator will check for session expiration.
+     * </p>
      *
-     * @return true/false
+     * <p>
+     *     If this method returns <tt>0</tt>, Curator does not
+     *     do any additional checking for session expiration.
+     * </p>
+     *
+     * <p>
+     *     If a positive number is returned, Curator will check for session expiration
+     *     as follows: when ZooKeeper sends a Disconnect event, Curator will start a timer.
+     *     If re-connection is not achieved before the elapsed time exceeds the negotiated
+     *     session time multiplied by the session expiration percent, Curator will simulate
+     *     a session expiration. Due to timing/network issues, it is <b>not possible</b> for
+     *     a client to match the server's session timeout with complete accuracy. Thus, the need
+     *     for a session expiration percentage.
+     * </p>
+     *
+     * @return a percentage from 0 to 100 (0 implied no extra session checking)
      */
-    boolean isEmulatingClassicHandling();
+    int getSimulatedSessionExpirationPercent();
 
     /**
      * Called by {@link RetryLoop#callWithRetry(CuratorZookeeperClient, Callable)} to do the work

--- a/curator-client/src/main/java/org/apache/curator/connection/StandardConnectionHandlingPolicy.java
+++ b/curator-client/src/main/java/org/apache/curator/connection/StandardConnectionHandlingPolicy.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.connection;
 
+import com.google.common.base.Preconditions;
 import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.RetryLoop;
 import org.slf4j.Logger;
@@ -32,11 +33,23 @@ import java.util.concurrent.Callable;
 public class StandardConnectionHandlingPolicy implements ConnectionHandlingPolicy
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
+    private final int expirationPercent;
+
+    public StandardConnectionHandlingPolicy()
+    {
+        this(100);
+    }
+
+    public StandardConnectionHandlingPolicy(int expirationPercent)
+    {
+        Preconditions.checkArgument((expirationPercent > 0) && (expirationPercent <= 100), "expirationPercent must be > 0 and <= 100");
+        this.expirationPercent = expirationPercent;
+    }
 
     @Override
-    public boolean isEmulatingClassicHandling()
+    public int getSimulatedSessionExpirationPercent()
     {
-        return false;
+        return expirationPercent;
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ClassicInternalConnectionHandler.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ClassicInternalConnectionHandler.java
@@ -33,12 +33,6 @@ class ClassicInternalConnectionHandler implements InternalConnectionHandler
     }
 
     @Override
-    public boolean checkSessionExpirationEnabled()
-    {
-        return false;
-    }
-
-    @Override
     public void suspendConnection(CuratorFrameworkImpl client)
     {
         if ( client.setToSuspended() )

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/InternalConnectionHandler.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/InternalConnectionHandler.java
@@ -23,6 +23,4 @@ interface InternalConnectionHandler
     void checkNewConnection(CuratorFrameworkImpl client);
 
     void suspendConnection(CuratorFrameworkImpl client);
-
-    boolean checkSessionExpirationEnabled();
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/StandardInternalConnectionHandler.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/StandardInternalConnectionHandler.java
@@ -27,12 +27,6 @@ class StandardInternalConnectionHandler implements InternalConnectionHandler
     }
 
     @Override
-    public boolean checkSessionExpirationEnabled()
-    {
-        return true;
-    }
-
-    @Override
     public void checkNewConnection(CuratorFrameworkImpl client)
     {
         client.checkInstanceIndex();


### PR DESCRIPTION
Added an option for session expiration management to be a fraction of the negotiated session timeout. This is meant to account for timing/network differences between the client and server.