### PR TITLE
[CURATOR-264] Duplicate ephemeral nodes with same owner id

### DIFF
--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkEdges.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkEdges.java
@@ -29,10 +29,10 @@ import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.framework.api.CuratorListener;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.KillSession;
-import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.utils.ZKPaths;
@@ -43,6 +43,7 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -54,6 +55,45 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class TestFrameworkEdges extends BaseClassForTests
 {
     private final Timing timing = new Timing();
+
+    @Test
+    public void testProtectedCreateNodeDeletion() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), 1, new RetryNTimes(0, 0));
+        try
+        {
+            client.start();
+
+            for ( int i = 0; i < 2; ++i )
+            {
+                CuratorFramework localClient = (i == 0) ? client : client.usingNamespace("nm");
+                localClient.create().forPath("/parent");
+                Assert.assertEquals(localClient.getChildren().forPath("/parent").size(), 0);
+
+                CreateBuilderImpl createBuilder = (CreateBuilderImpl)localClient.create();
+                createBuilder.failNextCreateForTesting = true;
+                try
+                {
+                    createBuilder.withProtection().forPath("/parent/test");
+                    Assert.fail("failNextCreateForTesting should have caused a ConnectionLossException");
+                }
+                catch ( KeeperException.ConnectionLossException e )
+                {
+                    // ignore, correct
+                }
+
+                timing.sleepABit();
+                List<String> children = localClient.getChildren().forPath("/parent");
+                Assert.assertEquals(children.size(), 0, children.toString()); // protected mode should have deleted the node
+
+                localClient.delete().forPath("/parent");
+            }
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
 
     @Test
     public void testPathsFromProtectingInBackground() throws Exception


### PR DESCRIPTION
CURATOR-45 added findAndDeleteProtectedNodeInBackground to handle cases where a protected node can get lost. However, the code wasn't correctly handling namespaces