### PR TITLE
[CURATOR-274] v2.9.0 broken EnsurePath behavior

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
@@ -18,7 +18,6 @@
  */
 package org.apache.curator.framework;
 
-import org.apache.curator.utils.EnsurePath;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**

--- a/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework;
+
+import org.apache.curator.utils.EnsurePath;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Similar to {@link EnsurePath} but creates containers.
+ *
+ */
+public class EnsureContainers
+{
+    private final CuratorFramework client;
+    private final String path;
+    private final AtomicBoolean ensureNeeded = new AtomicBoolean(true);
+
+    /**
+     * @param client the client
+     * @param path path to ensure is containers
+     */
+    public EnsureContainers(CuratorFramework client, String path)
+    {
+        this.client = client;
+        this.path = path;
+    }
+
+    /**
+     * The first time this method is called, all nodes in the
+     * path will be created as containers if needed
+     *
+     * @throws Exception errors
+     */
+    public void ensure() throws Exception
+    {
+        if ( ensureNeeded.get() )
+        {
+            internalEnsure();
+        }
+    }
+
+    private synchronized void internalEnsure() throws Exception
+    {
+        if ( ensureNeeded.compareAndSet(true, false) )
+        {
+            client.createContainers(path);
+        }
+    }
+}

--- a/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.framework;
 
+import org.apache.curator.utils.EnsurePath;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**

--- a/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
@@ -18,11 +18,10 @@
  */
 package org.apache.curator.framework;
 
-import org.apache.curator.utils.EnsurePath;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Similar to {@link EnsurePath} but creates containers.
+ * Similar to {@link org.apache.curator.utils.EnsurePath} but creates containers.
  *
  */
 public class EnsureContainers

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnsureContainers.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnsureContainers.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.imps;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.EnsureContainers;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestEnsureContainers extends BaseClassForTests
+{
+    @Test
+    public void testBasic() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+
+            EnsureContainers ensureContainers = new EnsureContainers(client, "/one/two/three");
+            ensureContainers.ensure();
+
+            Assert.assertNotNull(client.checkExists().forPath("/one/two/three"));
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testSingleExecution() throws Exception
+    {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+
+            EnsureContainers ensureContainers = new EnsureContainers(client, "/one/two/three");
+            ensureContainers.ensure();
+
+            Assert.assertNotNull(client.checkExists().forPath("/one/two/three"));
+
+            client.delete().forPath("/one/two/three");
+            ensureContainers.ensure();
+            Assert.assertNull(client.checkExists().forPath("/one/two/three"));
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/SimpleDistributedQueue.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/SimpleDistributedQueue.java
@@ -19,6 +19,7 @@
 package org.apache.curator.framework.recipes.queue;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.EnsureContainers;
 import org.apache.curator.utils.PathUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
@@ -49,6 +50,7 @@ public class SimpleDistributedQueue
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final CuratorFramework client;
     private final String path;
+    private final EnsureContainers ensureContainers;
 
     private final String PREFIX = "qn-";
 
@@ -60,6 +62,7 @@ public class SimpleDistributedQueue
     {
         this.client = client;
         this.path = PathUtils.validatePath(path);
+        ensureContainers = new EnsureContainers(client, path);
     }
 
     /**
@@ -174,6 +177,11 @@ public class SimpleDistributedQueue
         }
     }
 
+    protected void ensurePath() throws Exception
+    {
+        ensureContainers.ensure();
+    }
+
     private byte[] internalPoll(long timeout, TimeUnit unit) throws Exception
     {
         ensurePath();
@@ -213,11 +221,6 @@ public class SimpleDistributedQueue
                 latch.await();
             }
         }
-    }
-
-    private void ensurePath() throws Exception
-    {
-        client.createContainers(path);
     }
 
     private byte[] internalElement(boolean removeIt, Watcher watcher) throws Exception


### PR DESCRIPTION
Previous change to create containers broke some old behavior. Old EnsurePath class only created parents once. So, introduce new EnsureContainers class to do similar but for containers. Also, make usage in a protected method so that it can be turned off by users