### PR TITLE
CURATOR-281: Usage of TestingServer fails when upgrading to 3.0

### DIFF
--- a/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java
+++ b/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java
@@ -32,7 +32,6 @@ import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 import javax.management.JMException;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -132,7 +131,7 @@ public class TestingZooKeeperMain implements ZooKeeperMainFace
     @Override
     public void blockUntilStarted() throws Exception
     {
-        Assert.assertTrue(timing.awaitLatch(latch));
+        assert timing.awaitLatch(latch);
 
         if ( zkServer != null )
         {

--- a/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java
+++ b/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java
@@ -131,7 +131,8 @@ public class TestingZooKeeperMain implements ZooKeeperMainFace
     @Override
     public void blockUntilStarted() throws Exception
     {
-        assert timing.awaitLatch(latch);
+        if(!timing.awaitLatch(latch))
+            throw new IllegalStateException("Timed out waiting for watch removal");
 
         if ( zkServer != null )
         {


### PR DESCRIPTION
Replace testng assertion with java assertion