### PR TITLE
[CURATOR-209] Better handling of background errors

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -533,7 +533,10 @@ public class CuratorFrameworkImpl implements CuratorFramework
 
     <DATA_TYPE> void queueOperation(OperationAndData<DATA_TYPE> operationAndData)
     {
-        backgroundOperations.offer(operationAndData);
+        if ( getState() == CuratorFrameworkState.STARTED )
+        {
+            backgroundOperations.offer(operationAndData);
+        }
     }
 
     void logError(String reason, final Throwable e)

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.imps;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.curator.TimeTrace;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class FindAndDeleteProtectedNodeInBackground implements BackgroundOperation<Void>
+{
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final CuratorFrameworkImpl client;
+    private final String namespaceAdjustedParentPath;
+    private final String protectedId;
+
+    FindAndDeleteProtectedNodeInBackground(CuratorFrameworkImpl client, String namespaceAdjustedParentPath, String protectedId)
+    {
+        this.client = client;
+        this.namespaceAdjustedParentPath = namespaceAdjustedParentPath;
+        this.protectedId = protectedId;
+    }
+
+    void execute()
+    {
+        OperationAndData.ErrorCallback<Void> errorCallback = new OperationAndData.ErrorCallback<Void>()
+        {
+            @Override
+            public void retriesExhausted(OperationAndData<Void> operationAndData)
+            {
+                client.processBackgroundOperation(operationAndData, null);
+            }
+        };
+        OperationAndData<Void> operationAndData = new OperationAndData<Void>(this, null, null, errorCallback, null);
+        client.processBackgroundOperation(operationAndData, null);
+    }
+
+    @VisibleForTesting
+    static final AtomicBoolean debugInsertError = new AtomicBoolean(false);
+
+    @Override
+    public void performBackgroundOperation(final OperationAndData<Void> operationAndData) throws Exception
+    {
+        final TimeTrace trace = client.getZookeeperClient().startTracer("FindAndDeleteProtectedNodeInBackground");
+        AsyncCallback.Children2Callback callback = new AsyncCallback.Children2Callback()
+        {
+            @Override
+            public void processResult(int rc, String path, Object o, List<String> strings, Stat stat)
+            {
+                trace.commit();
+
+                if ( debugInsertError.compareAndSet(true, false) )
+                {
+                    rc = KeeperException.Code.CONNECTIONLOSS.intValue();
+                }
+
+                if ( rc == KeeperException.Code.OK.intValue() )
+                {
+                    final String node = CreateBuilderImpl.findNode(strings, "/", protectedId);  // due to namespacing, don't let CreateBuilderImpl.findNode adjust the path
+                    if ( node != null )
+                    {
+                        try
+                        {
+                            String deletePath = client.unfixForNamespace(ZKPaths.makePath(namespaceAdjustedParentPath, node));
+                            client.delete().guaranteed().inBackground().forPath(deletePath);
+                        }
+                        catch ( Exception e )
+                        {
+                            log.error("Could not start guaranteed delete for node: " + node);
+                            rc = KeeperException.Code.CONNECTIONLOSS.intValue();
+                        }
+                    }
+                }
+
+                if ( rc != KeeperException.Code.OK.intValue() )
+                {
+                    CuratorEventImpl event = new CuratorEventImpl(client, CuratorEventType.CHILDREN, rc, path, null, o, stat, null, strings, null, null);
+                    client.processBackgroundOperation(operationAndData, event);
+                }
+            }
+        };
+        client.getZooKeeper().getChildren(namespaceAdjustedParentPath, false, callback, null);
+    }
+}

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkEdges.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkEdges.java
@@ -72,6 +72,7 @@ public class TestFrameworkEdges extends BaseClassForTests
 
                 CreateBuilderImpl createBuilder = (CreateBuilderImpl)localClient.create();
                 createBuilder.failNextCreateForTesting = true;
+                FindAndDeleteProtectedNodeInBackground.debugInsertError.set(true);
                 try
                 {
                     createBuilder.withProtection().forPath("/parent/test");

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/DistributedQueue.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/DistributedQueue.java
@@ -583,7 +583,6 @@ public class DistributedQueue<T> implements QueueBase<T>
         final Semaphore processedLatch = new Semaphore(0);
         final boolean   isUsingLockSafety = (lockPath != null);
         int             min = minItemsBeforeRefresh;
-        int             submittedQty = 0;
         for ( final String itemNode : children )
         {
             if ( Thread.currentThread().isInterrupted() )
@@ -603,6 +602,7 @@ public class DistributedQueue<T> implements QueueBase<T>
             {
                 if ( refreshOnWatch && (currentVersion != childrenCache.getData().version) )
                 {
+                    processedLatch.release(children.size());
                     break;
                 }
             }
@@ -642,10 +642,9 @@ public class DistributedQueue<T> implements QueueBase<T>
                     }
                 }
             );
-            ++submittedQty;
         }
 
-        processedLatch.acquire(submittedQty);
+        processedLatch.acquire(children.size());
     }
 
     private enum ProcessMessageBytesCode

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/DistributedQueue.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/DistributedQueue.java
@@ -583,6 +583,7 @@ public class DistributedQueue<T> implements QueueBase<T>
         final Semaphore processedLatch = new Semaphore(0);
         final boolean   isUsingLockSafety = (lockPath != null);
         int             min = minItemsBeforeRefresh;
+        int             submittedQty = 0;
         for ( final String itemNode : children )
         {
             if ( Thread.currentThread().isInterrupted() )
@@ -602,7 +603,6 @@ public class DistributedQueue<T> implements QueueBase<T>
             {
                 if ( refreshOnWatch && (currentVersion != childrenCache.getData().version) )
                 {
-                    processedLatch.release(children.size());
                     break;
                 }
             }
@@ -642,9 +642,10 @@ public class DistributedQueue<T> implements QueueBase<T>
                     }
                 }
             );
+            ++submittedQty;
         }
 
-        processedLatch.acquire(children.size());
+        processedLatch.acquire(submittedQty);
     }
 
     private enum ProcessMessageBytesCode


### PR DESCRIPTION
1. Don't queue background operation if the client is closed
2. Moved findAndDeleteProtectedNodeInBackground code into separate operation that is processed through the standard Curator background code. This way, retries are applied (with sleep), etc. In the previous implementation, errors caused the background check to be run immediately and infinitely.