### PR TITLE
[CURATOR-208] General fix for catch-alls throughout the code and interrupts

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/ConnectionState.java
+++ b/curator-client/src/main/java/org/apache/curator/ConnectionState.java
@@ -22,6 +22,7 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.drivers.TracerDriver;
 import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.utils.DebugUtils;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZookeeperFactory;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
@@ -114,6 +115,7 @@ class ConnectionState implements Watcher, Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new IOException(e);
         }
         finally
@@ -277,6 +279,7 @@ class ConnectionState implements Watcher, Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             queueBackgroundException(e);
         }
     }
@@ -292,6 +295,7 @@ class ConnectionState implements Watcher, Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             queueBackgroundException(e);
         }
     }

--- a/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
+++ b/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
@@ -24,6 +24,7 @@ import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
 import org.apache.curator.utils.DefaultTracerDriver;
 import org.apache.curator.utils.DefaultZookeeperFactory;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZookeeperFactory;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
@@ -203,6 +204,7 @@ public class CuratorZookeeperClient implements Closeable
         }
         catch ( IOException e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error("", e);
         }
     }

--- a/curator-client/src/main/java/org/apache/curator/RetryLoop.java
+++ b/curator-client/src/main/java/org/apache/curator/RetryLoop.java
@@ -20,6 +20,7 @@ package org.apache.curator;
 
 import org.apache.curator.drivers.TracerDriver;
 import org.apache.curator.utils.DebugUtils;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,6 +110,7 @@ public class RetryLoop
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 retryLoop.takeException(e);
             }
         }

--- a/curator-client/src/main/java/org/apache/curator/SessionFailRetryLoop.java
+++ b/curator-client/src/main/java/org/apache/curator/SessionFailRetryLoop.java
@@ -21,6 +21,7 @@ package org.apache.curator;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
@@ -159,6 +160,7 @@ public class SessionFailRetryLoop implements Closeable
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     retryLoop.takeException(e);
                 }
             }

--- a/curator-client/src/main/java/org/apache/curator/ensemble/exhibitor/ExhibitorEnsembleProvider.java
+++ b/curator-client/src/main/java/org/apache/curator/ensemble/exhibitor/ExhibitorEnsembleProvider.java
@@ -251,6 +251,7 @@ public class ExhibitorEnsembleProvider implements EnsembleProvider
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error("Couldn't get backup connection string", e);
         }
         return values;
@@ -303,6 +304,7 @@ public class ExhibitorEnsembleProvider implements EnsembleProvider
                 }
                 catch ( Throwable e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     if ( retryPolicy.allowRetry(retries++, System.currentTimeMillis() - start, RetryLoop.getDefaultRetrySleeper()) )
                     {
                         log.warn("Couldn't get servers from Exhibitor. Retrying.", e);

--- a/curator-client/src/main/java/org/apache/curator/utils/ThreadUtils.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/ThreadUtils.java
@@ -18,7 +18,10 @@
  */
 package org.apache.curator.utils;
 
+import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -26,6 +29,8 @@ import java.util.concurrent.ThreadFactory;
 
 public class ThreadUtils
 {
+    private static final Logger log = LoggerFactory.getLogger(ThreadUtils.class);
+
     public static void checkInterrupted(Throwable e)
     {
         if ( e instanceof InterruptedException )
@@ -61,9 +66,19 @@ public class ThreadUtils
 
     public static ThreadFactory newGenericThreadFactory(String processName)
     {
+        Thread.UncaughtExceptionHandler uncaughtExceptionHandler = new Thread.UncaughtExceptionHandler()
+        {
+            @Override
+            public void uncaughtException(Thread t, Throwable e)
+            {
+                log.error("Unexpected exception in thread: " + t, e);
+                Throwables.propagate(e);
+            }
+        };
         return new ThreadFactoryBuilder()
             .setNameFormat(processName + "-%d")
             .setDaemon(true)
+            .setUncaughtExceptionHandler(uncaughtExceptionHandler)
             .build();
     }
 

--- a/curator-client/src/main/java/org/apache/curator/utils/ThreadUtils.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/ThreadUtils.java
@@ -26,6 +26,14 @@ import java.util.concurrent.ThreadFactory;
 
 public class ThreadUtils
 {
+    public static void checkInterrupted(Throwable e)
+    {
+        if ( e instanceof InterruptedException )
+        {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     public static ExecutorService newSingleThreadExecutor(String processName)
     {
         return Executors.newSingleThreadExecutor(newThreadFactory(processName));

--- a/curator-examples/src/main/java/locking/LockingExample.java
+++ b/curator-examples/src/main/java/locking/LockingExample.java
@@ -65,9 +65,14 @@ public class LockingExample
                                 example.doWork(10, TimeUnit.SECONDS);
                             }
                         }
-                        catch ( Throwable e )
+                        catch ( InterruptedException e )
+                        {
+                            Thread.currentThread().interrupt();
+                        }
+                        catch ( Exception e )
                         {
                             e.printStackTrace();
+                            // log or do something
                         }
                         finally
                         {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/Backgrounding.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/Backgrounding.java
@@ -21,6 +21,7 @@ package org.apache.curator.framework.imps;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.KeeperException;
 import java.util.concurrent.Executor;
 
@@ -110,6 +111,7 @@ class Backgrounding
                             }
                             catch ( Exception e )
                             {
+                                ThreadUtils.checkInterrupted(e);
                                 if ( e instanceof KeeperException )
                                 {
                                     client.validateConnection(client.codeToState(((KeeperException)e).code()));

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -28,6 +28,7 @@ import org.apache.curator.framework.api.*;
 import org.apache.curator.framework.api.transaction.CuratorTransactionBridge;
 import org.apache.curator.framework.api.transaction.OperationType;
 import org.apache.curator.framework.api.transaction.TransactionCreateBuilder;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
@@ -477,6 +478,7 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
         }
         catch ( Exception e)
         {
+            ThreadUtils.checkInterrupted(e);
             if ( ( e instanceof KeeperException.ConnectionLossException ||
                 !( e instanceof KeeperException )) && protectedId != null )
             {
@@ -667,6 +669,7 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
                         }
                         catch ( Exception e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             client.logError("Processing protected create for path: " + givenPath, e);
                         }
                         callSuper = false;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -271,6 +271,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             handleBackgroundOperationException(null, e);
         }
     }
@@ -293,6 +294,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
                     }
                     catch ( Exception e )
                     {
+                        ThreadUtils.checkInterrupted(e);
                         log.error("Exception while sending Closing event", e);
                     }
                     return null;
@@ -725,8 +727,9 @@ public class CuratorFrameworkImpl implements CuratorFramework
             {
                 e = (code != null) ? KeeperException.create(code) : null;
             }
-            catch ( Throwable ignore )
+            catch ( Throwable t )
             {
+                ThreadUtils.checkInterrupted(t);
             }
             if ( e == null )
             {
@@ -747,6 +750,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             handleBackgroundOperationException(operationAndData, e);
         }
     }
@@ -832,6 +836,8 @@ public class CuratorFrameworkImpl implements CuratorFramework
         }
         catch ( Throwable e )
         {
+            ThreadUtils.checkInterrupted(e);
+
             /**
              * Fix edge case reported as CURATOR-52. ConnectionState.checkTimeouts() throws KeeperException.ConnectionLossException
              * when the initial (or previously failed) connection cannot be re-established. This needs to be run through the retry policy
@@ -877,6 +883,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     logError("Event listener threw exception", e);
                 }
                 return null;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
@@ -31,6 +31,7 @@ import org.apache.curator.framework.api.Pathable;
 import org.apache.curator.framework.api.transaction.CuratorTransactionBridge;
 import org.apache.curator.framework.api.transaction.OperationType;
 import org.apache.curator.framework.api.transaction.TransactionDeleteBuilder;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.KeeperException;
@@ -259,6 +260,7 @@ class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<String>
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             //Only retry a guaranteed delete if it's a retryable error
             if( (RetryLoop.isRetryException(e) || (e instanceof InterruptedException)) && guaranteed )
             {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FailedDeleteManager.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FailedDeleteManager.java
@@ -19,6 +19,7 @@
 package org.apache.curator.framework.imps;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +57,7 @@ class FailedDeleteManager
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 addFailedDelete(path);
             }
         }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FailedDeleteManager.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FailedDeleteManager.java
@@ -46,8 +46,7 @@ class FailedDeleteManager
         {
             debugListener.pathAddedForDelete(path);
         }
-        
-        
+
         if ( client.getState() == CuratorFrameworkState.STARTED )
         {
             log.debug("Path being added to guaranteed delete set: " + path);

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
@@ -21,6 +21,7 @@ package org.apache.curator.framework.imps;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.curator.TimeTrace;
 import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.KeeperException;
@@ -89,6 +90,7 @@ class FindAndDeleteProtectedNodeInBackground implements BackgroundOperation<Void
                         }
                         catch ( Exception e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             log.error("Could not start guaranteed delete for node: " + node);
                             rc = KeeperException.Code.CONNECTIONLOSS.intValue();
                         }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
@@ -52,6 +52,7 @@ class FindAndDeleteProtectedNodeInBackground implements BackgroundOperation<Void
             @Override
             public void retriesExhausted(OperationAndData<Void> operationAndData)
             {
+                operationAndData.reset();
                 client.processBackgroundOperation(operationAndData, null);
             }
         };

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
@@ -29,6 +29,7 @@ import org.apache.curator.framework.api.GetDataBuilder;
 import org.apache.curator.framework.api.GetDataWatchBackgroundStatable;
 import org.apache.curator.framework.api.Pathable;
 import org.apache.curator.framework.api.WatchPathable;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Watcher;
@@ -246,6 +247,7 @@ class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<String>
                     }
                     catch ( Exception e )
                     {
+                        ThreadUtils.checkInterrupted(e);
                         log.error("Decompressing for path: " + path, e);
                         rc = KeeperException.Code.DATAINCONSISTENCY.intValue();
                     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceImpl.java
@@ -23,6 +23,7 @@ import org.apache.curator.RetryLoop;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.EnsurePath;
 import org.apache.curator.utils.PathUtils;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.ZooDefs;
 import java.util.concurrent.Callable;
@@ -95,6 +96,7 @@ class NamespaceImpl
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 client.logError("Ensure path threw exception", e);
             }
         }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceWatcher.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceWatcher.java
@@ -19,6 +19,7 @@
 package org.apache.curator.framework.imps;
 
 import org.apache.curator.framework.api.CuratorWatcher;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import java.io.Closeable;
@@ -68,6 +69,7 @@ class NamespaceWatcher implements Watcher, Closeable
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     client.logError("Watcher exception", e);
                 }
             }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/OperationAndData.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/OperationAndData.java
@@ -38,7 +38,7 @@ class OperationAndData<T> implements Delayed, RetrySleeper
     private final ErrorCallback<T> errorCallback;
     private final AtomicInteger retryCount = new AtomicInteger(0);
     private final AtomicLong sleepUntilTimeMs = new AtomicLong(0);
-    private final long ordinal = nextOrdinal.getAndIncrement();
+    private final AtomicLong ordinal = new AtomicLong();
     private final Object context;
 
     interface ErrorCallback<T>
@@ -53,6 +53,13 @@ class OperationAndData<T> implements Delayed, RetrySleeper
         this.callback = callback;
         this.errorCallback = errorCallback;
         this.context = context;
+        reset();
+    }
+
+    void reset()
+    {
+        retryCount.set(0);
+        ordinal.set(nextOrdinal.getAndIncrement());
     }
 
     Object getContext()
@@ -121,7 +128,7 @@ class OperationAndData<T> implements Delayed, RetrySleeper
         {
             if ( o instanceof OperationAndData )
             {
-                diff = ordinal - ((OperationAndData)o).ordinal;
+                diff = ordinal.get() - ((OperationAndData)o).ordinal.get();
             }
         }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/listen/ListenerContainer.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/listen/ListenerContainer.java
@@ -21,6 +21,7 @@ package org.apache.curator.framework.listen;
 import com.google.common.base.Function;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.curator.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Map;
@@ -93,6 +94,7 @@ public class ListenerContainer<T> implements Listenable<T>
                         }
                         catch ( Throwable e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             log.error(String.format("Listener (%s) threw an exception", entry.listener), e);
                         }
                     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/state/ConnectionStateManager.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/state/ConnectionStateManager.java
@@ -238,9 +238,9 @@ public class ConnectionStateManager implements Closeable
 
     private void processEvents()
     {
-        try
+        while ( state.get() == State.STARTED )
         {
-            while ( !Thread.currentThread().isInterrupted() )
+            try
             {
                 final ConnectionState newState = eventQueue.take();
 
@@ -262,10 +262,12 @@ public class ConnectionStateManager implements Closeable
                         }
                     );
             }
-        }
-        catch ( InterruptedException e )
-        {
-            Thread.currentThread().interrupt();
+            catch ( InterruptedException e )
+            {
+                // swallow the interrupt as it's only possible from either a background
+                // operation and, thus, doesn't apply to this loop or the instance
+                // is being closed in which case the while test will get it
+            }
         }
     }
 }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/AfterConnectionEstablished.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/AfterConnectionEstablished.java
@@ -57,6 +57,7 @@ public class AfterConnectionEstablished
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     log.error("An error occurred blocking until a connection is available", e);
                 }
                 finally

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/NodeCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/NodeCache.java
@@ -30,6 +30,7 @@ import org.apache.curator.framework.listen.ListenerContainer;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.PathUtils;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
@@ -77,6 +78,7 @@ public class NodeCache implements Closeable
                     }
                     catch ( Exception e )
                     {
+                        ThreadUtils.checkInterrupted(e);
                         log.error("Trying to reset after reconnection", e);
                     }
                 }
@@ -99,6 +101,7 @@ public class NodeCache implements Closeable
             }
             catch(Exception e)
             {
+                ThreadUtils.checkInterrupted(e);
                 handleException(e);
             }
         }
@@ -309,6 +312,7 @@ public class NodeCache implements Closeable
                         }
                         catch ( Exception e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             log.error("Calling listener", e);
                         }
                         return null;

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
@@ -118,6 +118,7 @@ public class PathChildrenCache implements Closeable
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 handleException(e);
             }
         }
@@ -519,6 +520,7 @@ public class PathChildrenCache implements Closeable
                         }
                         catch ( Exception e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             handleException(e);
                         }
                         return null;
@@ -644,6 +646,7 @@ public class PathChildrenCache implements Closeable
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 handleException(e);
             }
             break;
@@ -777,6 +780,7 @@ public class PathChildrenCache implements Closeable
                         }
                         catch ( Exception e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             handleException(e);
                         }
                     }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
@@ -347,6 +347,7 @@ public class TreeCache implements Closeable
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 handleException(e);
             }
         }
@@ -575,6 +576,7 @@ public class TreeCache implements Closeable
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 handleException(e);
             }
         }
@@ -710,6 +712,7 @@ public class TreeCache implements Closeable
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     handleException(e);
                 }
                 return null;
@@ -739,6 +742,7 @@ public class TreeCache implements Closeable
                     }
                     catch ( Exception e )
                     {
+                        ThreadUtils.checkInterrupted(e);
                         LOG.error("Exception handling exception", e);
                     }
                     return null;
@@ -766,6 +770,7 @@ public class TreeCache implements Closeable
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 handleException(e);
             }
             break;
@@ -778,6 +783,7 @@ public class TreeCache implements Closeable
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 handleException(e);
             }
             break;
@@ -815,6 +821,7 @@ public class TreeCache implements Closeable
                         }
                         catch ( Exception e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             handleException(e);
                         }
                     }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -32,6 +32,7 @@ import org.apache.curator.framework.recipes.locks.LockInternalsSorter;
 import org.apache.curator.framework.recipes.locks.StandardLockInternalsDriver;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -209,6 +210,7 @@ public class LeaderLatch implements Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new IOException(e);
         }
         finally
@@ -514,6 +516,7 @@ public class LeaderLatch implements Closeable
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 log.error("An error occurred checking resetting leadership.", e);
             }
         }
@@ -549,6 +552,7 @@ public class LeaderLatch implements Closeable
                         }
                         catch ( Exception ex )
                         {
+                            ThreadUtils.checkInterrupted(ex);
                             log.error("An error occurred checking the leadership.", ex);
                         }
                     }
@@ -606,6 +610,7 @@ public class LeaderLatch implements Closeable
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     log.error("Could not reset leader latch", e);
                     setLeadership(false);
                 }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderSelector.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderSelector.java
@@ -405,7 +405,7 @@ public class LeaderSelector implements Closeable
             }
             catch ( Throwable e )
             {
-                log.error("The leader threw an exception", e);
+                ThreadUtils.checkInterrupted(e);
             }
             finally
             {
@@ -417,10 +417,6 @@ public class LeaderSelector implements Closeable
             Thread.currentThread().interrupt();
             throw e;
         }
-        catch ( Exception e )
-        {
-            throw e;
-        }
         finally
         {
             hasLeadership = false;
@@ -428,8 +424,10 @@ public class LeaderSelector implements Closeable
             {
                 mutex.release();
             }
-            catch ( Exception ignore )
+            catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
+                log.error("The leader threw an exception", e);
                 // ignore errors - this is just a safety
             }
         }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/ChildReaper.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/ChildReaper.java
@@ -283,6 +283,7 @@ public class ChildReaper implements Closeable
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     log.error("Could not get children for path: " + path, e);
                 }
             }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMultiLock.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMultiLock.java
@@ -21,6 +21,7 @@ package org.apache.curator.framework.recipes.locks;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ThreadUtils;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -110,6 +111,7 @@ public class InterProcessMultiLock implements InterProcessLock
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 success = false;
                 exception = e;
             }
@@ -125,6 +127,7 @@ public class InterProcessMultiLock implements InterProcessLock
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     // ignore
                 }
             }
@@ -156,6 +159,7 @@ public class InterProcessMultiLock implements InterProcessLock
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 if ( baseException == null )
                 {
                     baseException = e;

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessSemaphore.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessSemaphore.java
@@ -25,6 +25,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.shared.SharedCountListener;
 import org.apache.curator.framework.recipes.shared.SharedCountReader;
 import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -183,6 +184,7 @@ public class InterProcessSemaphore
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             returnAll(builder.build());
             throw e;
         }
@@ -250,6 +252,7 @@ public class InterProcessSemaphore
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             returnAll(builder.build());
             throw e;
         }
@@ -274,6 +277,7 @@ public class InterProcessSemaphore
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     throw new IOException(e);
                 }
             }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessSemaphoreV2.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessSemaphoreV2.java
@@ -31,6 +31,7 @@ import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.recipes.shared.SharedCountListener;
 import org.apache.curator.framework.recipes.shared.SharedCountReader;
 import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -413,6 +414,7 @@ public class InterProcessSemaphoreV2
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     throw new IOException(e);
                 }
             }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java
@@ -27,6 +27,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.CuratorWatcher;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.utils.PathUtils;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -317,6 +318,7 @@ public class LockInternals
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             doDelete = true;
             throw e;
         }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/Reaper.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/Reaper.java
@@ -315,6 +315,7 @@ public class Reaper implements Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error("Trying to reap: " + holder.path, e);
         }
 

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/GroupMember.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/GroupMember.java
@@ -26,6 +26,7 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.utils.CloseableUtils;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import java.io.Closeable;
 import java.util.Map;
@@ -77,6 +78,7 @@ public class GroupMember implements Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             Throwables.propagate(e);
         }
     }
@@ -94,6 +96,7 @@ public class GroupMember implements Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             Throwables.propagate(e);
         }
     }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentEphemeralNode.java
@@ -30,6 +30,7 @@ import org.apache.curator.framework.api.CuratorWatcher;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.PathUtils;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
@@ -325,6 +326,7 @@ public class PersistentEphemeralNode implements Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new IOException(e);
         }
     }
@@ -396,6 +398,7 @@ public class PersistentEphemeralNode implements Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RuntimeException("Creating node. BasePath: " + basePath, e);  // should never happen unless there's a programming error - so throw RuntimeException
         }
     }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/DistributedQueue.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/DistributedQueue.java
@@ -545,33 +545,38 @@ public class DistributedQueue<T> implements QueueBase<T>
         long         maxWaitMs = -1;
         try
         {
-            while ( !Thread.currentThread().isInterrupted()  )
+            while ( state.get() == State.STARTED  )
             {
-                ChildrenCache.Data      data = (maxWaitMs > 0) ? childrenCache.blockingNextGetData(currentVersion, maxWaitMs, TimeUnit.MILLISECONDS) : childrenCache.blockingNextGetData(currentVersion);
-                currentVersion = data.version;
-
-                List<String>        children = Lists.newArrayList(data.children);
-                sortChildren(children); // makes sure items are processed in the correct order
-
-                if ( children.size() > 0 )
+                try
                 {
-                    maxWaitMs = getDelay(children.get(0));
-                    if ( maxWaitMs > 0 )
+                    ChildrenCache.Data      data = (maxWaitMs > 0) ? childrenCache.blockingNextGetData(currentVersion, maxWaitMs, TimeUnit.MILLISECONDS) : childrenCache.blockingNextGetData(currentVersion);
+                    currentVersion = data.version;
+
+                    List<String>        children = Lists.newArrayList(data.children);
+                    sortChildren(children); // makes sure items are processed in the correct order
+
+                    if ( children.size() > 0 )
+                    {
+                        maxWaitMs = getDelay(children.get(0));
+                        if ( maxWaitMs > 0 )
+                        {
+                            continue;
+                        }
+                    }
+                    else
                     {
                         continue;
                     }
-                }
-                else
-                {
-                    continue;
-                }
 
-                processChildren(children, currentVersion);
+                    processChildren(children, currentVersion);
+                }
+                catch ( InterruptedException e )
+                {
+                    // swallow the interrupt as it's only possible from either a background
+                    // operation and, thus, doesn't apply to this loop or the instance
+                    // is being closed in which case the while test will get it
+                }
             }
-        }
-        catch ( InterruptedException ignore )
-        {
-            Thread.currentThread().interrupt();
         }
         catch ( Exception e )
         {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/DistributedQueue.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/DistributedQueue.java
@@ -31,6 +31,7 @@ import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.listen.ListenerContainer;
 import org.apache.curator.framework.recipes.leader.LeaderSelector;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -633,6 +634,7 @@ public class DistributedQueue<T> implements QueueBase<T>
                         }
                         catch ( Exception e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             log.error("Error processing message at " + itemNode, e);
                         }
                         finally
@@ -663,6 +665,7 @@ public class DistributedQueue<T> implements QueueBase<T>
         }
         catch ( Throwable e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error("Corrupted queue item: " + itemNode, e);
             return resultCode;
         }
@@ -681,6 +684,7 @@ public class DistributedQueue<T> implements QueueBase<T>
             }
             catch ( Throwable e )
             {
+                ThreadUtils.checkInterrupted(e);
                 log.error("Exception processing queue item: " + itemNode, e);
                 if ( errorMode.get() == ErrorMode.REQUEUE )
                 {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueSharder.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueSharder.java
@@ -124,17 +124,19 @@ public class QueueSharder<U, T extends QueueBase<U>> implements Closeable
                 @Override
                 public Void call() throws Exception
                 {
-                    try
+                    while ( state.get() == State.STARTED )
                     {
-                        while ( !Thread.currentThread().isInterrupted() && (state.get() == State.STARTED) )
+                        try
                         {
                             Thread.sleep(policies.getThresholdCheckMs());
                             checkThreshold();
                         }
-                    }
-                    catch ( InterruptedException e )
-                    {
-                        Thread.currentThread().interrupt();
+                        catch ( InterruptedException e )
+                        {
+                            // swallow the interrupt as it's only possible from either a background
+                            // operation and, thus, doesn't apply to this loop or the instance
+                            // is being closed in which case the while test will get it
+                        }
                     }
                     return null;
                 }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueSharder.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueSharder.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Sets;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -279,6 +280,7 @@ public class QueueSharder<U, T extends QueueBase<U>> implements Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error("Checking queue counts against threshold", e);
         }
     }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedValue.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedValue.java
@@ -27,6 +27,7 @@ import org.apache.curator.framework.listen.ListenerContainer;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.PathUtils;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.data.Stat;
@@ -261,6 +262,7 @@ public class SharedValue implements Closeable, SharedValueReader
                         }
                         catch ( Exception e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             log.error("From SharedValue listener", e);
                         }
                         return null;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/client/TestResetConnectionWithBackgroundFailure.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/client/TestResetConnectionWithBackgroundFailure.java
@@ -19,44 +19,41 @@
 
 package org.apache.curator.framework.client;
 
+import com.google.common.collect.Queues;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.CuratorFrameworkImpl;
 import org.apache.curator.framework.recipes.leader.LeaderSelector;
 import org.apache.curator.framework.recipes.leader.LeaderSelectorListener;
 import org.apache.curator.framework.recipes.leader.LeaderSelectorListenerAdapter;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
-import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 public class TestResetConnectionWithBackgroundFailure extends BaseClassForTests
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
-
-    @BeforeMethod
-    @Override
-    public void setup() throws Exception
-    {
-        super.setup();
-    }
 
     @Test
     public void testConnectionStateListener() throws Exception
     {
         server.stop();
 
-        final StringBuilder listenerSequence = new StringBuilder();
         LeaderSelector selector = null;
         Timing timing = new Timing();
-        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(100));
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
         try
         {
             client.start();
@@ -74,33 +71,36 @@ public class TestResetConnectionWithBackgroundFailure extends BaseClassForTests
             selector.autoRequeue();
             selector.start();
 
+            final BlockingQueue<ConnectionState> listenerSequence = Queues.newLinkedBlockingQueue();
             ConnectionStateListener listener1 = new ConnectionStateListener()
             {
                 @Override
                 public void stateChanged(CuratorFramework client, ConnectionState newState)
                 {
-                    listenerSequence.append("-").append(newState);
+                    listenerSequence.add(newState);
                 }
             };
+
+            Timing forWaiting = timing.forWaiting();
 
             client.getConnectionStateListenable().addListener(listener1);
             log.debug("Starting ZK server");
             server.restart();
-            timing.forWaiting().sleepABit();
+            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
 
             log.debug("Stopping ZK server");
             server.stop();
-            timing.forWaiting().sleepABit();
+            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
 
             log.debug("Starting ZK server");
             server.restart();
-            timing.forWaiting().sleepABit();
+            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
 
             log.debug("Stopping ZK server");
             server.close();
-            timing.forWaiting().sleepABit();
-
-            Assert.assertEquals(listenerSequence.toString(), "-CONNECTED-SUSPENDED-LOST-RECONNECTED-SUSPENDED-LOST");
+            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
         }
         finally
         {

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceInstanceMarshaller.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceInstanceMarshaller.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.x.discovery.server.entity;
 
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.ServiceInstanceBuilder;
 import org.apache.curator.x.discovery.ServiceType;
@@ -95,6 +96,7 @@ public class JsonServiceInstanceMarshaller<T> implements MessageBodyReader<Servi
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new WebApplicationException(e);
         }
 
@@ -144,6 +146,7 @@ public class JsonServiceInstanceMarshaller<T> implements MessageBodyReader<Servi
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new WebApplicationException(e);
         }
     }

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceInstancesMarshaller.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceInstancesMarshaller.java
@@ -19,6 +19,7 @@
 package org.apache.curator.x.discovery.server.entity;
 
 import com.google.common.collect.Lists;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.server.rest.DiscoveryContext;
 import org.codehaus.jackson.JsonNode;
@@ -91,6 +92,7 @@ public class JsonServiceInstancesMarshaller<T> implements MessageBodyReader<Serv
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new WebApplicationException(e);
         }
     }

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/rest/DiscoveryResource.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/rest/DiscoveryResource.java
@@ -19,6 +19,7 @@
 package org.apache.curator.x.discovery.server.rest;
 
 import com.google.common.collect.Lists;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.ServiceType;
 import org.apache.curator.x.discovery.details.InstanceProvider;
@@ -101,6 +102,7 @@ public abstract class DiscoveryResource<T>
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error("Trying to register service", e);
             return Response.serverError().build();
         }
@@ -123,6 +125,7 @@ public abstract class DiscoveryResource<T>
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error("Trying to delete service", e);
             return Response.serverError().build();
         }
@@ -176,6 +179,7 @@ public abstract class DiscoveryResource<T>
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error(String.format("Trying to get instances from service (%s)", name), e);
             return Response.serverError().build();
         }
@@ -208,6 +212,7 @@ public abstract class DiscoveryResource<T>
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error(String.format("Trying to get any instance from service (%s)", name), e);
             return Response.serverError().build();
         }
@@ -231,6 +236,7 @@ public abstract class DiscoveryResource<T>
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error(String.format("Trying to get instance (%s) from service (%s)", id, name), e);
             return Response.serverError().build();
         }

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/rest/InstanceCleanup.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/rest/InstanceCleanup.java
@@ -96,6 +96,7 @@ public class InstanceCleanup implements Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error("GC for service names", e);
         }
     }
@@ -118,6 +119,7 @@ public class InstanceCleanup implements Closeable
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error(String.format("GC for service: %s", name), e);
         }
     }

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
@@ -79,6 +79,7 @@ public class ServiceDiscoveryImpl<T> implements ServiceDiscovery<T>
                 }
                 catch ( Exception e )
                 {
+                    ThreadUtils.checkInterrupted(e);
                     log.error("Could not re-register instances after reconnection", e);
                 }
             }
@@ -160,6 +161,7 @@ public class ServiceDiscoveryImpl<T> implements ServiceDiscovery<T>
             }
             catch ( Exception e )
             {
+                ThreadUtils.checkInterrupted(e);
                 log.error("Could not unregister instance: " + entry.service.getName(), e);
             }
         }
@@ -458,6 +460,7 @@ public class ServiceDiscoveryImpl<T> implements ServiceDiscovery<T>
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             log.error("Could not start node cache for: " + instance, e);
         }
         NodeCacheListener listener = new NodeCacheListener()

--- a/curator-x-rpc/src/main/java/org/apache/curator/x/rpc/idl/discovery/DiscoveryService.java
+++ b/curator-x-rpc/src/main/java/org/apache/curator/x/rpc/idl/discovery/DiscoveryService.java
@@ -23,6 +23,7 @@ import com.facebook.swift.service.ThriftService;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.x.discovery.DownInstancePolicy;
 import org.apache.curator.x.discovery.ProviderStrategy;
 import org.apache.curator.x.discovery.ServiceDiscovery;
@@ -70,6 +71,7 @@ public class DiscoveryService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -109,6 +111,7 @@ public class DiscoveryService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -168,6 +171,7 @@ public class DiscoveryService
                     }
                     catch ( IOException e )
                     {
+                        ThreadUtils.checkInterrupted(e);
                         log.error("Could not close ServiceProvider with serviceName: " + serviceName, e);
                     }
                 }
@@ -177,6 +181,7 @@ public class DiscoveryService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -193,6 +198,7 @@ public class DiscoveryService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -222,6 +228,7 @@ public class DiscoveryService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -245,6 +252,7 @@ public class DiscoveryService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }

--- a/curator-x-rpc/src/main/java/org/apache/curator/x/rpc/idl/discovery/DiscoveryServiceLowLevel.java
+++ b/curator-x-rpc/src/main/java/org/apache/curator/x/rpc/idl/discovery/DiscoveryServiceLowLevel.java
@@ -23,6 +23,7 @@ import com.facebook.swift.service.ThriftService;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.rpc.connections.ConnectionManager;
@@ -53,6 +54,7 @@ public class DiscoveryServiceLowLevel
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -69,6 +71,7 @@ public class DiscoveryServiceLowLevel
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -85,6 +88,7 @@ public class DiscoveryServiceLowLevel
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -101,6 +105,7 @@ public class DiscoveryServiceLowLevel
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -117,6 +122,7 @@ public class DiscoveryServiceLowLevel
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -146,6 +152,7 @@ public class DiscoveryServiceLowLevel
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }

--- a/curator-x-rpc/src/main/java/org/apache/curator/x/rpc/idl/services/CuratorProjectionService.java
+++ b/curator-x-rpc/src/main/java/org/apache/curator/x/rpc/idl/services/CuratorProjectionService.java
@@ -153,6 +153,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -184,6 +185,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -220,6 +222,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -257,6 +260,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -285,6 +289,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -314,6 +319,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -329,6 +335,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -351,6 +358,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -380,6 +388,7 @@ public class CuratorProjectionService
                         }
                         catch ( Exception e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             log.error("Could not release left-over lock for path: " + path, e);
                         }
                     }
@@ -390,6 +399,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -415,6 +425,7 @@ public class CuratorProjectionService
                     }
                     catch ( IOException e )
                     {
+                        ThreadUtils.checkInterrupted(e);
                         log.error("Could not close left-over leader latch for path: " + path, e);
                     }
                 }
@@ -446,6 +457,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -475,6 +487,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -491,6 +504,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -516,6 +530,7 @@ public class CuratorProjectionService
                     }
                     catch ( IOException e )
                     {
+                        ThreadUtils.checkInterrupted(e);
                         log.error("Could not close left-over PathChildrenCache for path: " + path, e);
                     }
                 }
@@ -536,6 +551,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -563,6 +579,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -579,6 +596,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -604,6 +622,7 @@ public class CuratorProjectionService
                     }
                     catch ( IOException e )
                     {
+                        ThreadUtils.checkInterrupted(e);
                         log.error("Could not close left-over NodeCache for path: " + path, e);
                     }
                 }
@@ -624,6 +643,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -640,6 +660,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -665,6 +686,7 @@ public class CuratorProjectionService
                     }
                     catch ( Exception e )
                     {
+                        ThreadUtils.checkInterrupted(e);
                         log.error("Could not release left-over persistent ephemeral node for path: " + path, e);
                     }
                 }
@@ -674,6 +696,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }
@@ -706,6 +729,7 @@ public class CuratorProjectionService
                         }
                         catch ( Exception e )
                         {
+                            ThreadUtils.checkInterrupted(e);
                             log.error("Could not release semaphore leases for path: " + path, e);
                         }
                     }
@@ -716,6 +740,7 @@ public class CuratorProjectionService
         }
         catch ( Exception e )
         {
+            ThreadUtils.checkInterrupted(e);
             throw new RpcException(e);
         }
     }


### PR DESCRIPTION
General fix for catch-alls throughout the code. This is overkill but it strikes me as the safest way to address the problem. Everywhere there is a catch-all add a check for InterruptedException and reset the thread's interrupted state