### PR TITLE
Don't allow NamespaceWatcher to compare equal to a raw Watcher

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceWatcher.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceWatcher.java
@@ -121,17 +121,6 @@ class NamespaceWatcher implements Watcher, Closeable
             return curatorWatcher != null ? curatorWatcher.equals(watcher.curatorWatcher) : watcher.curatorWatcher == null;
         }
 
-        if ( Watcher.class.isAssignableFrom(o.getClass()) )
-        {
-            return actualWatcher == o;
-        }
-
-        //noinspection SimplifiableIfStatement
-        if ( CuratorWatcher.class.isAssignableFrom(o.getClass()) )
-        {
-            return curatorWatcher == o;
-        }
-
         return false;
     }
 


### PR DESCRIPTION
Don't allow NamespaceWatcher to compare equal to a raw Watcher or CuratorWatcher. It can't be done reciprocally in a raw Watcher and is actually unnecessary. NOTE: a Curator Tech Note should be written to warn that Watchers are wrapped internally