### PR TITLE
Support EPHEMERAL_SEQUENTIAL nodes for ServiceDiscovery instances

### DIFF
--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/rest/DiscoveryResource.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/rest/DiscoveryResource.java
@@ -90,7 +90,7 @@ public abstract class DiscoveryResource<T>
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
         
-        if ( instance.getServiceType() == ServiceType.DYNAMIC )
+        if ( instance.getServiceType() == ServiceType.DYNAMIC || instance.getServiceType() == ServiceType.DYNAMIC_SEQUENTIAL )
         {
             log.info("Service type cannot be dynamic");
             return Response.status(Response.Status.BAD_REQUEST).build();

--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/rest/DiscoveryResource.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/rest/DiscoveryResource.java
@@ -90,7 +90,7 @@ public abstract class DiscoveryResource<T>
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
         
-        if ( instance.getServiceType() == ServiceType.DYNAMIC || instance.getServiceType() == ServiceType.DYNAMIC_SEQUENTIAL )
+        if ( instance.getServiceType().isDynamic() )
         {
             log.info("Service type cannot be dynamic");
             return Response.status(Response.Status.BAD_REQUEST).build();

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceType.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceType.java
@@ -23,5 +23,9 @@ public enum ServiceType
     DYNAMIC,
     STATIC,
     PERMANENT, 
-    DYNAMIC_SEQUENTIAL
+    DYNAMIC_SEQUENTIAL;
+
+	public boolean isDynamic() {
+		return this == DYNAMIC || this == DYNAMIC_SEQUENTIAL;
+	}
 }

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceType.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceType.java
@@ -22,5 +22,6 @@ public enum ServiceType
 {
     DYNAMIC,
     STATIC,
-    PERMANENT
+    PERMANENT, 
+    DYNAMIC_SEQUENTIAL
 }

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
@@ -220,7 +220,17 @@ public class ServiceDiscoveryImpl<T> implements ServiceDiscovery<T>
         {
             try
             {
-                CreateMode mode = (service.getServiceType() == ServiceType.DYNAMIC) ? CreateMode.EPHEMERAL : CreateMode.PERSISTENT;
+            	CreateMode mode;
+            	switch (service.getServiceType()){
+            	case DYNAMIC:
+            		mode =  CreateMode.EPHEMERAL;
+            		break; 
+            	case  DYNAMIC_SEQUENTIAL:
+            		mode =  CreateMode.EPHEMERAL_SEQUENTIAL;
+            		break; 
+            	default:
+            		mode = CreateMode.PERSISTENT;
+            	}
                 client.create().creatingParentContainersIfNeeded().withMode(mode).forPath(path, bytes);
                 isDone = true;
             }

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
@@ -230,6 +230,7 @@ public class ServiceDiscoveryImpl<T> implements ServiceDiscovery<T>
             		break; 
             	default:
             		mode = CreateMode.PERSISTENT;
+            		break; 
             	}
                 client.create().creatingParentContainersIfNeeded().withMode(mode).forPath(path, bytes);
                 isDone = true;

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java
@@ -220,18 +220,18 @@ public class ServiceDiscoveryImpl<T> implements ServiceDiscovery<T>
         {
             try
             {
-            	CreateMode mode;
-            	switch (service.getServiceType()){
-            	case DYNAMIC:
-            		mode =  CreateMode.EPHEMERAL;
-            		break; 
-            	case  DYNAMIC_SEQUENTIAL:
-            		mode =  CreateMode.EPHEMERAL_SEQUENTIAL;
-            		break; 
-            	default:
-            		mode = CreateMode.PERSISTENT;
-            		break; 
-            	}
+				CreateMode mode;
+				switch (service.getServiceType()) {
+				case DYNAMIC:
+					mode = CreateMode.EPHEMERAL;
+					break;
+				case DYNAMIC_SEQUENTIAL:
+					mode = CreateMode.EPHEMERAL_SEQUENTIAL;
+					break;
+				default:
+					mode = CreateMode.PERSISTENT;
+					break;
+				}
                 client.create().creatingParentContainersIfNeeded().withMode(mode).forPath(path, bytes);
                 isDone = true;
             }


### PR DESCRIPTION
Added a new DYNAMIC_SEQUENTIAL  ServiceType for ServiceDiscovery instances, which creates EPHEMERAL_SEQUENTIAL nodes in Zookeeper. Before this patch only EPHEMERAL or PERSISTENT nodes were supported by Service Discovery.  
[Jira issue](https://issues.apache.org/jira/browse/CURATOR-304)
