### PR TITLE
[CURATOR-310] Race in PersistentNode startup

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNode.java
@@ -309,7 +309,10 @@ public class PersistentNode implements Closeable
     }
 
     /**
-     * Set data that node should set in ZK also writes the data to the node
+     * Set data that node should set in ZK also writes the data to the node. NOTE: it
+     * is an error to call this method after {@link #start()} but before the initial create
+     * has completed. Use {@link #waitForInitialCreate(long, TimeUnit)} to ensure initial
+     * creation.
      *
      * @param data new data value
      * @throws Exception errors

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNode.java
@@ -317,6 +317,7 @@ public class PersistentNode implements Closeable
     public void setData(byte[] data) throws Exception
     {
         data = Preconditions.checkNotNull(data, "data cannot be null");
+        Preconditions.checkState(nodePath.get() != null, "initial create has not been processed. Call waitForInitialCreate() to ensure.");
         this.data.set(Arrays.copyOf(data, data.length));
         if ( isActive() )
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentNode.java
@@ -32,6 +32,37 @@ import java.util.concurrent.TimeUnit;
 public class TestPersistentNode extends BaseClassForTests
 {
     @Test
+    public void testQuickSetData() throws Exception
+    {
+        final byte[] TEST_DATA = "hey".getBytes();
+        final byte[] ALT_TEST_DATA = "there".getBytes();
+
+        Timing timing = new Timing();
+        PersistentNode pen = null;
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+            pen = new PersistentNode(client, CreateMode.PERSISTENT, false, "/test", TEST_DATA);
+            pen.start();
+            try
+            {
+                pen.setData(ALT_TEST_DATA);
+                Assert.fail("IllegalStateException should have been thrown");
+            }
+            catch ( IllegalStateException dummy )
+            {
+                // expected
+            }
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(pen);
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
     public void testBasic() throws Exception
     {
         final byte[] TEST_DATA = "hey".getBytes();


### PR DESCRIPTION
This is a semi-punt but a reasonable one. The simple solution is for the client to call waitForInitialCreate() before calling setData(). So, now, setData() throws an exception if the initial create has not occurred.