### PR TITLE
[CURATOR-314] Listenable support for GroupMember recipe

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/GroupData.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/GroupData.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.recipes.nodes;
+
+import java.util.Arrays;
+
+public class GroupData
+{
+    private final String id;
+    private final byte[] data;
+
+    public GroupData(String id, byte[] data)
+    {
+        this.id = id;
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        GroupData groupData = (GroupData) o;
+
+        if (!id.equals(groupData.id))
+        {
+            return false;
+        }
+        return Arrays.equals(data, groupData.data);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = id.hashCode();
+        result = 31 * result + Arrays.hashCode(data);
+        return result;
+    }
+
+    /**
+     * <p>Returns the data associated with this group member</p>
+     *
+     * <p><b>NOTE:</b> the byte array returned is the raw reference of this instance's field. If you change
+     * the values in the array any other callers to this method will see the change.</p>
+     *
+     * @return node data or null
+     */
+    public byte[] getData()
+    {
+        return data;
+    }
+
+    /**
+     * Returns the id of the group member
+     *
+     * @return id or null
+     */
+    public String getId()
+    {
+        return id;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "GroupData{" +
+                "id='" + id + '\'' +
+                ", data=" + Arrays.toString(data) +
+                '}';
+    }
+}

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/GroupMemberEvent.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/GroupMemberEvent.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.recipes.nodes;
+
+/**
+ * POJO that abstracts a change to a group membership
+ */
+public class GroupMemberEvent
+{
+    private final Type type;
+    private final GroupData data;
+
+    /**
+     * Type of change
+     */
+    public enum Type
+    {
+        /**
+         * A new member joined group
+         */
+        MEMBER_JOINED,
+
+        /**
+         * An existing member left the group
+         */
+        MEMBER_LEFT,
+
+        /**
+         * The data for a member was updated
+         */
+        MEMBER_UPDATED
+    }
+
+    /**
+     * @param type event type
+     * @param data event data or null
+     */
+    public GroupMemberEvent(Type type, GroupData data)
+    {
+        this.type = type;
+        this.data = data;
+    }
+
+    /**
+     * @return change type
+     */
+    public Type getType()
+    {
+        return type;
+    }
+
+    /**
+     * @return the node's data
+     */
+    public GroupData getData()
+    {
+        return data;
+    }
+}

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/GroupMemberListener.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/GroupMemberListener.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.recipes.nodes;
+
+import org.apache.curator.framework.CuratorFramework;
+
+/**
+ * Listener for GroupMember changes
+ */
+public interface GroupMemberListener {
+    /**
+     * Called when a change has occurred
+     *
+     * @param client the client
+     * @param event describes the change
+     * @throws Exception errors
+     */
+    public void     groupEvent(CuratorFramework client, GroupMemberEvent event) throws Exception;
+}

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestGroupMemberListener.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestGroupMemberListener.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.framework.recipes.nodes;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+public class TestGroupMemberListener extends BaseClassForTests
+{
+    @Test
+    public void testBasic() throws Exception
+    {
+        Timing timing = new Timing();
+        GroupMember groupMember1 = null;
+        GroupMember groupMember2 = null;
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+
+            groupMember1 = new GroupMember(client, "/member", "1");
+            groupMember1.start();
+
+            final CountDownLatch memberAddedLatch = new CountDownLatch(1);
+            final CountDownLatch memberLeftLatch = new CountDownLatch(1);
+            final CountDownLatch memberUpdatedLatch = new CountDownLatch(1);
+            GroupMemberListener listener = new GroupMemberListener()
+            {
+                @Override
+                public void groupEvent(CuratorFramework client, GroupMemberEvent event) throws Exception
+                {
+                    if (event.getType() == GroupMemberEvent.Type.MEMBER_JOINED)
+                    {
+                        memberAddedLatch.countDown();
+                    }
+                    else if (event.getType() == GroupMemberEvent.Type.MEMBER_LEFT)
+                    {
+                        memberLeftLatch.countDown();
+                    }
+                    else if (event.getType() == GroupMemberEvent.Type.MEMBER_UPDATED)
+                    {
+                        memberUpdatedLatch.countDown();
+                    }
+                }
+            };
+            groupMember1.getListenable().addListener(listener);
+
+            groupMember2 = new GroupMember(client, "/member", "2");
+            groupMember2.start();
+            timing.sleepABit();
+            Assert.assertTrue(timing.awaitLatch(memberAddedLatch));
+            groupMember2.setThisData("new data".getBytes());
+            timing.sleepABit();
+            Assert.assertTrue(timing.awaitLatch(memberUpdatedLatch));
+            CloseableUtils.closeQuietly(groupMember2);
+            timing.sleepABit();
+            Assert.assertTrue(timing.awaitLatch(memberLeftLatch));
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(groupMember1);
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+}


### PR DESCRIPTION
I've added support for listenable events to the GroupMember recipe. Its built on the event support provided by the underlying PathChildenCache object being used by GroupMember
