### PR TITLE
[CURATOR-315] Reconnect during InterProcessSemaphoreV2.acquire can lead to orphaned node

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessSemaphoreV2.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessSemaphoreV2.java
@@ -346,12 +346,15 @@ public class InterProcessSemaphoreV2
         {
             lock.acquire();
         }
+
+        Lease lease = null;
+
         try
         {
             PathAndBytesable<String> createBuilder = client.create().creatingParentContainersIfNeeded().withProtection().withMode(CreateMode.EPHEMERAL_SEQUENTIAL);
             String path = (nodeData != null) ? createBuilder.forPath(ZKPaths.makePath(leasesPath, LEASE_BASE_NAME), nodeData) : createBuilder.forPath(ZKPaths.makePath(leasesPath, LEASE_BASE_NAME));
             String nodeName = ZKPaths.getNodeFromPath(path);
-            builder.add(makeLease(path));
+            lease = makeLease(path);
 
             synchronized(this)
             {
@@ -361,6 +364,7 @@ public class InterProcessSemaphoreV2
                     if ( !children.contains(nodeName) )
                     {
                         log.error("Sequential path not found: " + path);
+                        returnLease(lease);
                         return InternalAcquireResult.RETRY_DUE_TO_MISSING_NODE;
                     }
 
@@ -373,6 +377,7 @@ public class InterProcessSemaphoreV2
                         long thisWaitMs = getThisWaitMs(startMs, waitMs);
                         if ( thisWaitMs <= 0 )
                         {
+                            returnLease(lease);
                             return InternalAcquireResult.RETURN_NULL;
                         }
                         wait(thisWaitMs);
@@ -388,6 +393,7 @@ public class InterProcessSemaphoreV2
         {
             lock.release();
         }
+        builder.add(Preconditions.checkNotNull(lease));
         return InternalAcquireResult.CONTINUE;
     }
 


### PR DESCRIPTION
Only add successfully acquired leases to the builder passed to internalAcquire1Lease. Close leases on other return paths.
This ensures that acquire does not return more leases than requested, as it is expected by the convenience methods for acquiring a single lease.