### PR TITLE
CURATOR-317: changed a deprecation comment to provide a better equivalent

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/api/CreateBuilder.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/CreateBuilder.java
@@ -46,7 +46,7 @@ public interface CreateBuilder extends
     /**
      * @deprecated this has been generalized to support all create modes. Instead, use:
      * <pre>
-     *     client.create().withProtection().withMode(CreateMode.PERSISTENT_SEQUENTIAL)...
+     *     client.create().withProtection().withMode(CreateMode.EPHEMERAL_SEQUENTIAL)...
      * </pre>
      * @return this
      */


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CURATOR-317

Now anyone looking at the deprecated annotation will find code that is a drop in replacement.