### PR TITLE
[CURATOR-299] WatcherRemovalManager must be updated when there's an exception, retry, etc.

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/Backgrounding.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/Backgrounding.java
@@ -112,10 +112,15 @@ class Backgrounding
         return callback;
     }
 
-    void checkError(Throwable e) throws Exception
+    void checkError(Throwable e, Watching watching) throws Exception
     {
         if ( e != null )
         {
+            if ( watching != null )
+            {
+                watching.resetCurrentWatcher();
+            }
+
             if ( errorListener != null )
             {
                 errorListener.unhandledError("n/a", e);

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ClassicInternalConnectionHandler.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ClassicInternalConnectionHandler.java
@@ -65,6 +65,6 @@ class ClassicInternalConnectionHandler implements InternalConnectionHandler
                 }
             }
         };
-        client.performBackgroundOperation(new OperationAndData<String>(operation, "/", null, errorCallback, null));
+        client.performBackgroundOperation(new OperationAndData<String>(operation, "/", null, errorCallback, null, null));
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -613,7 +613,7 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
         }
         catch ( Throwable e )
         {
-            backgrounding.checkError(e);
+            backgrounding.checkError(e, null);
         }
     }
     
@@ -714,7 +714,7 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
                 client.queueOperation(mainOperationAndData);
             }
         };
-        OperationAndData<T> parentOperation = new OperationAndData<T>(operation, mainOperationAndData.getData(), null, null, backgrounding.getContext());
+        OperationAndData<T> parentOperation = new OperationAndData<T>(operation, mainOperationAndData.getData(), null, null, backgrounding.getContext(), null);
         client.queueOperation(parentOperation);
     }
 
@@ -751,7 +751,7 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
                 client.queueOperation(mainOperationAndData);
             }
         };
-        client.queueOperation(new OperationAndData<>(operation, null, null, null, null));
+        client.queueOperation(new OperationAndData<>(operation, null, null, null, null, null));
     }
 
     private void sendBackgroundResponse(int rc, String path, Object ctx, String name, Stat stat, OperationAndData<PathAndBytes> operationAndData)
@@ -974,7 +974,8 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
                     }
                 }
             },
-            backgrounding.getContext())
+            backgrounding.getContext(),
+            null)
         {
             @Override
             void callPerformBackgroundOperation() throws Exception

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -533,7 +533,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
     protected void internalSync(CuratorFrameworkImpl impl, String path, Object context)
     {
         BackgroundOperation<String> operation = new BackgroundSyncImpl(impl, context);
-        performBackgroundOperation(new OperationAndData<String>(operation, path, null, null, context));
+        performBackgroundOperation(new OperationAndData<String>(operation, path, null, null, context, null));
     }
 
     @Override
@@ -898,6 +898,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
 
     void performBackgroundOperation(OperationAndData<?> operationAndData)
     {
+        operationAndData.resetCurrentWatcher();
         try
         {
             if ( !operationAndData.isConnectionRequired() || client.isConnected() )
@@ -917,6 +918,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
         }
         catch ( Throwable e )
         {
+            operationAndData.resetCurrentWatcher();
             ThreadUtils.checkInterrupted(e);
 
             /**

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorMultiTransactionImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorMultiTransactionImpl.java
@@ -124,7 +124,7 @@ public class CuratorMultiTransactionImpl implements
 
         if ( backgrounding.inBackground() )
         {
-            client.processBackgroundOperation(new OperationAndData<>(this, record, backgrounding.getCallback(), null, backgrounding.getContext()), null);
+            client.processBackgroundOperation(new OperationAndData<>(this, record, backgrounding.getCallback(), null, backgrounding.getContext(), null), null);
             return null;
         }
         else
@@ -154,7 +154,7 @@ public class CuratorMultiTransactionImpl implements
         }
         catch ( Throwable e )
         {
-            backgrounding.checkError(e);
+            backgrounding.checkError(e, null);
         }
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
@@ -184,7 +184,7 @@ class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<String>, E
         }
         catch ( Throwable e )
         {
-            backgrounding.checkError(e);
+            backgrounding.checkError(e, null);
         }
     }
 
@@ -206,7 +206,7 @@ class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<String>, E
                 client.queueOperation(mainOperationAndData);
             }
         };
-        OperationAndData<String> parentOperation = new OperationAndData<String>(operation, mainOperationAndData.getData(), null, null, backgrounding.getContext());
+        OperationAndData<String> parentOperation = new OperationAndData<String>(operation, mainOperationAndData.getData(), null, null, backgrounding.getContext(), null);
         client.queueOperation(parentOperation);
     }
 
@@ -230,7 +230,7 @@ class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<String>, E
                     }
                 };
             }
-            client.processBackgroundOperation(new OperationAndData<String>(this, path, backgrounding.getCallback(), errorCallback, backgrounding.getContext()), null);
+            client.processBackgroundOperation(new OperationAndData<String>(this, path, backgrounding.getCallback(), errorCallback, backgrounding.getContext(), null), null);
         }
         else
         {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
@@ -56,7 +56,7 @@ class FindAndDeleteProtectedNodeInBackground implements BackgroundOperation<Void
                 client.processBackgroundOperation(operationAndData, null);
             }
         };
-        OperationAndData<Void> operationAndData = new OperationAndData<Void>(this, null, null, errorCallback, null);
+        OperationAndData<Void> operationAndData = new OperationAndData<Void>(this, null, null, errorCallback, null, null);
         client.processBackgroundOperation(operationAndData, null);
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetACLBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetACLBuilderImpl.java
@@ -123,7 +123,7 @@ class GetACLBuilderImpl implements GetACLBuilder, BackgroundOperation<String>, E
         }
         catch ( Throwable e )
         {
-            backgrounding.checkError(e);
+            backgrounding.checkError(e, null);
         }
     }
 
@@ -135,7 +135,7 @@ class GetACLBuilderImpl implements GetACLBuilder, BackgroundOperation<String>, E
         List<ACL>       result = null;
         if ( backgrounding.inBackground() )
         {
-            client.processBackgroundOperation(new OperationAndData<String>(this, path, backgrounding.getCallback(), null, backgrounding.getContext()), null);
+            client.processBackgroundOperation(new OperationAndData<String>(this, path, backgrounding.getCallback(), null, backgrounding.getContext(), null), null);
         }
         else
         {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/OperationAndData.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/OperationAndData.java
@@ -41,13 +41,14 @@ class OperationAndData<T> implements Delayed, RetrySleeper
     private final AtomicLong ordinal = new AtomicLong();
     private final Object context;
     private final boolean connectionRequired;
+    private final Watching watching;
 
     interface ErrorCallback<T>
     {
         void retriesExhausted(OperationAndData<T> operationAndData);
     }
     
-    OperationAndData(BackgroundOperation<T> operation, T data, BackgroundCallback callback, ErrorCallback<T> errorCallback, Object context, boolean connectionRequired)
+    OperationAndData(BackgroundOperation<T> operation, T data, BackgroundCallback callback, ErrorCallback<T> errorCallback, Object context, boolean connectionRequired, Watching watching)
     {
         this.operation = operation;
         this.data = data;
@@ -55,6 +56,7 @@ class OperationAndData<T> implements Delayed, RetrySleeper
         this.errorCallback = errorCallback;
         this.context = context;
         this.connectionRequired = connectionRequired;
+        this.watching = watching;
         reset();
     }
 
@@ -64,9 +66,9 @@ class OperationAndData<T> implements Delayed, RetrySleeper
         ordinal.set(nextOrdinal.getAndIncrement());
     }
 
-    OperationAndData(BackgroundOperation<T> operation, T data, BackgroundCallback callback, ErrorCallback<T> errorCallback, Object context)
+    OperationAndData(BackgroundOperation<T> operation, T data, BackgroundCallback callback, ErrorCallback<T> errorCallback, Object context, Watching watching)
     {
-        this(operation, data, callback, errorCallback, context, true);
+        this(operation, data, callback, errorCallback, context, true, watching);
     }
 
     Object getContext()
@@ -113,6 +115,14 @@ class OperationAndData<T> implements Delayed, RetrySleeper
     BackgroundOperation<T> getOperation()
     {
         return operation;
+    }
+
+    void resetCurrentWatcher()
+    {
+        if ( watching != null )
+        {
+            watching.resetCurrentWatcher();
+        }
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ReconfigBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ReconfigBuilderImpl.java
@@ -51,7 +51,7 @@ public class ReconfigBuilderImpl implements ReconfigBuilder, BackgroundOperation
     {
         if ( backgrounding.inBackground() )
         {
-            client.processBackgroundOperation(new OperationAndData<>(this, null, backgrounding.getCallback(), null, backgrounding.getContext()), null);
+            client.processBackgroundOperation(new OperationAndData<>(this, null, backgrounding.getCallback(), null, backgrounding.getContext(), null), null);
             return new byte[0];
         }
         else
@@ -261,7 +261,7 @@ public class ReconfigBuilderImpl implements ReconfigBuilder, BackgroundOperation
         }
         catch ( Throwable e )
         {
-            backgrounding.checkError(e);
+            backgrounding.checkError(e, null);
         }
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/RemoveWatchesBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/RemoveWatchesBuilderImpl.java
@@ -209,7 +209,7 @@ public class RemoveWatchesBuilderImpl implements RemoveWatchesBuilder, RemoveWat
         }
         
         client.processBackgroundOperation(new OperationAndData<String>(this, path, backgrounding.getCallback(),
-                                                                       errorCallback, backgrounding.getContext(), !local), null);
+                                                                       errorCallback, backgrounding.getContext(), !local, null), null);
     }
     
     private void pathInForeground(final String path) throws Exception
@@ -329,7 +329,7 @@ public class RemoveWatchesBuilderImpl implements RemoveWatchesBuilder, RemoveWat
         }
         catch ( Throwable e )
         {
-            backgrounding.checkError(e);
+            backgrounding.checkError(e, null);
         }
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetACLBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetACLBuilderImpl.java
@@ -119,7 +119,7 @@ class SetACLBuilderImpl implements SetACLBuilder, BackgroundPathable<Stat>, Back
         Stat        resultStat = null;
         if ( backgrounding.inBackground()  )
         {
-            client.processBackgroundOperation(new OperationAndData<String>(this, path, backgrounding.getCallback(), null, backgrounding.getContext()), null);
+            client.processBackgroundOperation(new OperationAndData<String>(this, path, backgrounding.getCallback(), null, backgrounding.getContext(), null), null);
         }
         else
         {
@@ -156,7 +156,7 @@ class SetACLBuilderImpl implements SetACLBuilder, BackgroundPathable<Stat>, Back
         }
         catch ( Throwable e )
         {
-            backgrounding.checkError(e);
+            backgrounding.checkError(e, null);
         }
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
@@ -228,7 +228,7 @@ class SetDataBuilderImpl implements SetDataBuilder, BackgroundOperation<PathAndB
         }
         catch ( Throwable e )
         {
-            backgrounding.checkError(e);
+            backgrounding.checkError(e, null);
         }
     }
 
@@ -251,7 +251,7 @@ class SetDataBuilderImpl implements SetDataBuilder, BackgroundOperation<PathAndB
         Stat        resultStat = null;
         if ( backgrounding.inBackground()  )
         {
-            client.processBackgroundOperation(new OperationAndData<>(this, new PathAndBytes(path, data), backgrounding.getCallback(), null, backgrounding.getContext()), null);
+            client.processBackgroundOperation(new OperationAndData<>(this, new PathAndBytes(path, data), backgrounding.getCallback(), null, backgrounding.getContext(), null), null);
         }
         else
         {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SyncBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SyncBuilderImpl.java
@@ -112,14 +112,14 @@ public class SyncBuilderImpl implements SyncBuilder, BackgroundOperation<String>
         }
         catch ( Throwable e )
         {
-            backgrounding.checkError(e);
+            backgrounding.checkError(e, null);
         }
     }
 
     @Override
     public Void forPath(String path) throws Exception
     {
-        OperationAndData<String> operationAndData = new OperationAndData<String>(this, path, backgrounding.getCallback(), null, backgrounding.getContext());
+        OperationAndData<String> operationAndData = new OperationAndData<String>(this, path, backgrounding.getCallback(), null, backgrounding.getContext(), null);
         client.processBackgroundOperation(operationAndData, null);
         return null;
     }


### PR DESCRIPTION
If there's an exeption, retries exceeded, etc., the watcher was still being stored in WatcherRemovalManager thus causing it to be incorrectly removed. This fix removes the watch from the WatcherRemovalmanager on exceptions, retries exceeded, etc.