### PR TITLE
[CURATOR-308] Parent container deletions could cause a hang

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
@@ -54,6 +54,9 @@ public class EnsureContainers
         }
     }
 
+    /**
+     * Reset so that the next call to {@link #ensure()} will attempt to create containers
+     */
     public void reset()
     {
         ensureNeeded.set(true);

--- a/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/EnsureContainers.java
@@ -54,6 +54,11 @@ public class EnsureContainers
         }
     }
 
+    public void reset()
+    {
+        ensureNeeded.set(true);
+    }
+
     private synchronized void internalEnsure() throws Exception
     {
         if ( ensureNeeded.compareAndSet(true, false) )

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/SimpleDistributedQueue.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/SimpleDistributedQueue.java
@@ -200,7 +200,17 @@ public class SimpleDistributedQueue
                     latch.countDown();
                 }
             };
-            byte[]      bytes = internalElement(true, watcher);
+            byte[]      bytes = new byte[0];
+            try
+            {
+                bytes = internalElement(true, watcher);
+            }
+            catch ( NoSuchElementException dummy )
+            {
+                log.debug("Parent containers appear to have lapsed - recreate and retry");
+                ensureContainers.reset();
+                continue;
+            }
             if ( bytes != null )
             {
                 return bytes;
@@ -234,7 +244,7 @@ public class SimpleDistributedQueue
         }
         catch ( KeeperException.NoNodeException dummy )
         {
-            return null;
+            throw new NoSuchElementException();
         }
         Collections.sort(nodes);
 

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/SimpleDistributedQueue.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/SimpleDistributedQueue.java
@@ -200,7 +200,7 @@ public class SimpleDistributedQueue
                     latch.countDown();
                 }
             };
-            byte[]      bytes = new byte[0];
+            byte[]      bytes;
             try
             {
                 bytes = internalElement(true, watcher);


### PR DESCRIPTION
Parent container deletions could cause a hang as the watcher would never fire. If parent containers get deleted now, reset and recreate them