### PR TITLE
CURATOR-329 - SharedValue does not update to current value if zookeeper node version is 0

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedValue.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedValue.java
@@ -44,6 +44,8 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class SharedValue implements Closeable, SharedValueReader
 {
+	private static final int UNINITIALIZED_VERSION = -1;
+
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final ListenerContainer<SharedValueListener> listeners = new ListenerContainer<SharedValueListener>();
     private final CuratorFramework client;
@@ -91,7 +93,7 @@ public class SharedValue implements Closeable, SharedValueReader
         this.client = client;
         this.path = PathUtils.validatePath(path);
         this.seedValue = Arrays.copyOf(seedValue, seedValue.length);
-        currentValue = new AtomicReference<VersionedValue<byte[]>>(new VersionedValue<byte[]>(0, Arrays.copyOf(seedValue, seedValue.length)));
+        currentValue = new AtomicReference<VersionedValue<byte[]>>(new VersionedValue<byte[]>(UNINITIALIZED_VERSION, Arrays.copyOf(seedValue, seedValue.length)));
     }
 
     @Override

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/shared/TestSharedCount.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/shared/TestSharedCount.java
@@ -256,4 +256,31 @@ public class TestSharedCount extends BaseClassForTests
             CloseableUtils.closeQuietly(client1);
         }
     }
+
+
+    @Test
+    public void testMultiClientDifferentSeed() throws Exception
+    {
+        CuratorFramework client1 = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        CuratorFramework client2 = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        SharedCount count1 = new SharedCount(client1, "/count", 10);
+        SharedCount count2 = new SharedCount(client2, "/count", 20);
+        try
+        {
+            client1.start();
+            client2.start();
+            count1.start();
+            count2.start();
+
+            Assert.assertEquals(count1.getCount(), 10);
+            Assert.assertEquals(count2.getCount(), 10);
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(count2);
+            CloseableUtils.closeQuietly(count1);
+            CloseableUtils.closeQuietly(client2);
+            CloseableUtils.closeQuietly(client1);
+        }
+    }
 }


### PR DESCRIPTION
Fixed SharedValue class to correctly update its value on start() call to value stored in Zookeeper node if node version is zero.