### PR TITLE
[CURATOR-332] Internal watcher tracking for new WatcherRemoveCuratorFramework feature is not correct

### DIFF
--- a/curator-framework/pom.xml
+++ b/curator-framework/pom.xml
@@ -88,4 +88,18 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/Backgrounding.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/Backgrounding.java
@@ -116,11 +116,6 @@ class Backgrounding
     {
         if ( e != null )
         {
-            if ( watching != null )
-            {
-                watching.resetCurrentWatcher();
-            }
-
             if ( errorListener != null )
             {
                 errorListener.unhandledError("n/a", e);

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -910,7 +910,6 @@ public class CuratorFrameworkImpl implements CuratorFramework
 
     void performBackgroundOperation(OperationAndData<?> operationAndData)
     {
-        operationAndData.resetCurrentWatcher();
         try
         {
             if ( !operationAndData.isConnectionRequired() || client.isConnected() )
@@ -930,7 +929,6 @@ public class CuratorFrameworkImpl implements CuratorFramework
         }
         catch ( Throwable e )
         {
-            operationAndData.resetCurrentWatcher();
             ThreadUtils.checkInterrupted(e);
 
             /**

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -149,11 +149,11 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
             try
             {
                 client.getConfig().usingWatcher(this).inBackground(backgroundCallback).forEnsemble();
+                outstanding.incrementAndGet();  // finally block will decrement
             }
-            catch ( Exception e )
+            finally
             {
                 outstanding.decrementAndGet();
-                throw e;
             }
         }
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/OperationAndData.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/OperationAndData.java
@@ -41,14 +41,13 @@ class OperationAndData<T> implements Delayed, RetrySleeper
     private final AtomicLong ordinal = new AtomicLong();
     private final Object context;
     private final boolean connectionRequired;
-    private final Watching watching;
 
     interface ErrorCallback<T>
     {
         void retriesExhausted(OperationAndData<T> operationAndData);
     }
     
-    OperationAndData(BackgroundOperation<T> operation, T data, BackgroundCallback callback, ErrorCallback<T> errorCallback, Object context, boolean connectionRequired, Watching watching)
+    OperationAndData(BackgroundOperation<T> operation, T data, BackgroundCallback callback, ErrorCallback<T> errorCallback, Object context, boolean connectionRequired)
     {
         this.operation = operation;
         this.data = data;
@@ -56,7 +55,6 @@ class OperationAndData<T> implements Delayed, RetrySleeper
         this.errorCallback = errorCallback;
         this.context = context;
         this.connectionRequired = connectionRequired;
-        this.watching = watching;
         reset();
     }
 
@@ -68,7 +66,7 @@ class OperationAndData<T> implements Delayed, RetrySleeper
 
     OperationAndData(BackgroundOperation<T> operation, T data, BackgroundCallback callback, ErrorCallback<T> errorCallback, Object context, Watching watching)
     {
-        this(operation, data, callback, errorCallback, context, true, watching);
+        this(operation, data, callback, errorCallback, context, true);
     }
 
     Object getContext()
@@ -115,14 +113,6 @@ class OperationAndData<T> implements Delayed, RetrySleeper
     BackgroundOperation<T> getOperation()
     {
         return operation;
-    }
-
-    void resetCurrentWatcher()
-    {
-        if ( watching != null )
-        {
-            watching.resetCurrentWatcher();
-        }
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/RemoveWatchesBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/RemoveWatchesBuilderImpl.java
@@ -209,7 +209,7 @@ public class RemoveWatchesBuilderImpl implements RemoveWatchesBuilder, RemoveWat
         }
         
         client.processBackgroundOperation(new OperationAndData<String>(this, path, backgrounding.getCallback(),
-                                                                       errorCallback, backgrounding.getContext(), !local, null), null);
+                                                                       errorCallback, backgrounding.getContext(), !local), null);
     }
     
     private void pathInForeground(final String path) throws Exception

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCleanState.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCleanState.java
@@ -48,17 +48,39 @@ public class TestCleanState
             ZooKeeper zooKeeper = internalClient.getZooKeeper();
             if ( zooKeeper != null )
             {
-                if ( WatchersDebug.getChildWatches(zooKeeper).size() != 0 )
+                final int maxLoops = 3;
+                for ( int i = 0; i < maxLoops; ++i )    // it takes time for the watcher removals to settle due to async/watchers, etc. So, if there are remaining watchers, sleep a bit
                 {
-                    throw new AssertionError("One or more child watchers are still registered: " + WatchersDebug.getChildWatches(zooKeeper));
-                }
-                if ( WatchersDebug.getExistWatches(zooKeeper).size() != 0 )
-                {
-                    throw new AssertionError("One or more exists watchers are still registered: " + WatchersDebug.getExistWatches(zooKeeper));
-                }
-                if ( WatchersDebug.getDataWatches(zooKeeper).size() != 0 )
-                {
-                    throw new AssertionError("One or more data watchers are still registered: " + WatchersDebug.getDataWatches(zooKeeper));
+                    if ( i > 0 )
+                    {
+                        Thread.sleep(500);
+                    }
+                    boolean isLast = (i + 1) == maxLoops;
+                    if ( WatchersDebug.getChildWatches(zooKeeper).size() != 0 )
+                    {
+                        if ( isLast )
+                        {
+                            throw new AssertionError("One or more child watchers are still registered: " + WatchersDebug.getChildWatches(zooKeeper));
+                        }
+                        continue;
+                    }
+                    if ( WatchersDebug.getExistWatches(zooKeeper).size() != 0 )
+                    {
+                        if ( isLast )
+                        {
+                            throw new AssertionError("One or more exists watchers are still registered: " + WatchersDebug.getExistWatches(zooKeeper));
+                        }
+                        continue;
+                    }
+                    if ( WatchersDebug.getDataWatches(zooKeeper).size() != 0 )
+                    {
+                        if ( isLast )
+                        {
+                            throw new AssertionError("One or more data watchers are still registered: " + WatchersDebug.getDataWatches(zooKeeper));
+                        }
+                        continue;
+                    }
+                    break;
                 }
             }
         }

--- a/curator-recipes/pom.xml
+++ b/curator-recipes/pom.xml
@@ -52,6 +52,13 @@
 
         <dependency>
             <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
@@ -493,6 +493,7 @@ public class PathChildrenCache implements Closeable
             {
                 if (PathChildrenCache.this.state.get().equals(State.CLOSED)) {
                     // This ship is closed, don't handle the callback
+                    PathChildrenCache.this.client.removeWatchers();
                     return;
                 }
                 if ( event.getResultCode() == KeeperException.Code.OK.intValue() )

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,13 @@
 
             <dependency>
                 <groupId>org.apache.curator</groupId>
+                <artifactId>curator-framework</artifactId>
+                <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Reworked WatcherRemovalManager. It now stores watchers only on successful operations. This is more like how ZK does it.

Also, exists watcher must be stored when there is a NoNode result.