### PR TITLE
CURATOR-350 allow to close executor service on shutdown

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
@@ -206,7 +206,20 @@ public class PathChildrenCache implements Closeable
      */
     public PathChildrenCache(CuratorFramework client, String path, boolean cacheData, boolean dataIsCompressed, final ExecutorService executorService)
     {
-        this(client, path, cacheData, dataIsCompressed, new CloseableExecutorService(executorService));
+        this(client, path, cacheData, dataIsCompressed, executorService, false);
+    }
+
+    /**
+     * @param client           the client
+     * @param path             path to watch
+     * @param cacheData        if true, node contents are cached in addition to the stat
+     * @param dataIsCompressed if true, data in the path is compressed
+     * @param executorService  ExecutorService to use for the PathChildrenCache's background thread. This service should be single threaded, otherwise the cache may see inconsistent results.
+     * @param shutdownOnClose if true, shutdown the executor service when this is closed
+     */
+    public PathChildrenCache(CuratorFramework client, String path, boolean cacheData, boolean dataIsCompressed, final ExecutorService executorService, boolean shutdownOnClose)
+    {
+        this(client, path, cacheData, dataIsCompressed, new CloseableExecutorService(executorService, shutdownOnClose));
     }
 
     /**


### PR DESCRIPTION
if you pass your executor service when creating your service,
you still want to be able to decide wether it should be closed on
shutdown or not