### PR TITLE
[CURATOR-349] Trace the session id even when it is disconnected

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/ConnectionState.java
+++ b/curator-client/src/main/java/org/apache/curator/ConnectionState.java
@@ -163,7 +163,7 @@ class ConnectionState implements Watcher, Closeable
         for ( Watcher parentWatcher : parentWatchers )
         {
 
-            OperationTrace trace = new OperationTrace("connection-state-parent-process", tracer.get());
+            OperationTrace trace = new OperationTrace("connection-state-parent-process", tracer.get(), getSessionId());
             parentWatcher.process(event);
             trace.commit();
         }
@@ -213,16 +213,14 @@ class ConnectionState implements Watcher, Closeable
      * Return the current session id
      */
     public long getSessionId() {
-        long sessionId = -1;
-        if (isConnected()) {
-            try {
-                ZooKeeper zk = zooKeeper.getZooKeeper();
-                if (zk != null) {
-                    sessionId = zk.getSessionId();
-                }
-            } catch (Exception e) {
-                // Ignore the exception
+        long sessionId = 0;
+        try {
+            ZooKeeper zk = zooKeeper.getZooKeeper();
+            if (zk != null) {
+                sessionId = zk.getSessionId();
             }
+        } catch (Exception e) {
+            // Ignore the exception
         }
         return sessionId;
     }


### PR DESCRIPTION
The default session id inside ZooKeeper is 0, we should keep consistent with it in tracker.