### PR TITLE
[CURATOR-361] Prevent removal of leading slash from path when empty namespace used

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceImpl.java
@@ -64,7 +64,7 @@ class NamespaceImpl
         if ( (namespace != null) && (path != null) )
         {
             String      namespacePath = ZKPaths.makePath(namespace, null);
-            if ( path.startsWith(namespacePath) )
+            if ( !namespacePath.equals("/") && path.startsWith(namespacePath) )
             {
                 path = (path.length() > namespacePath.length()) ? path.substring(namespacePath.length()) : "/";
             }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
@@ -229,4 +229,14 @@ public class TestNamespaceFacade extends BaseClassForTests
             //Expected
         }
     }
+
+    @Test
+    public void testUnfixForEmptyNamespace() {
+        CuratorFramework client = CuratorFrameworkFactory.builder().namespace("").retryPolicy(new RetryOneTime(1)).connectString("").build();
+        CuratorFrameworkImpl clientImpl = (CuratorFrameworkImpl) client;
+
+        Assert.assertEquals(clientImpl.unfixForNamespace("/foo/bar"), "/foo/bar");
+
+        CloseableUtils.closeQuietly(client);
+    }
 }


### PR DESCRIPTION
In the test, I'm casting `CuratorFramework` to `CuratorFrameworkImpl` to get access to `unfixForNamespace()`. It was the most direct way to write the test, but I'm open to suggestions for cleaner code.