### PR TITLE
[CURATOR-369] Improve log for new configuration events

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -181,13 +181,10 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
     {
         Properties properties = new Properties();
         properties.load(new ByteArrayInputStream(data));
+        log.info("New config event received: {}", properties);
+
         QuorumMaj newConfig = new QuorumMaj(properties);
         currentConfig.set(newConfig);
-
-        if ( log.isInfoEnabled() )
-        {
-            log.info("New config event received: " + properties.toString());
-        }
 
         String connectionString = configToConnectionString(newConfig);
         if ( connectionString.trim().length() > 0 )

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -179,12 +179,15 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
 
     private void processConfigData(byte[] data) throws Exception
     {
-        log.info("New config event received: " + Arrays.toString(data));
-
         Properties properties = new Properties();
         properties.load(new ByteArrayInputStream(data));
         QuorumMaj newConfig = new QuorumMaj(properties);
         currentConfig.set(newConfig);
+
+        if ( log.isInfoEnabled() )
+        {
+            log.info("New config event received: " + properties.toString());
+        }
 
         String connectionString = configToConnectionString(newConfig);
         if ( connectionString.trim().length() > 0 )


### PR DESCRIPTION
Logging the configuration data only after it has been parsed into a `Properties` object. This allows logging readable text instead of an array of bytes.

Also guarded the log statement with a test on the log level, as `Properties.toString()` is a costly operation.