### PR TITLE
CURATOR-372 Removed Path from the Compression Provider

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/api/CompressionProvider.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/CompressionProvider.java
@@ -20,7 +20,7 @@ package org.apache.curator.framework.api;
 
 public interface CompressionProvider
 {
-    public byte[]       compress(String path, byte[] data) throws Exception;
+    public byte[]       compress(byte[] data) throws Exception;
 
-    public byte[]       decompress(String path, byte[] compressedData) throws Exception;
+    public byte[]       decompress(byte[] compressedData) throws Exception;
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -108,7 +108,7 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
             {
                 if ( compress )
                 {
-                    data = client.getCompressionProvider().compress(path, data);
+                    data = client.getCompressionProvider().compress(data);
                 }
 
                 String fixedPath = client.fixForNamespace(path);
@@ -459,7 +459,7 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
     {
         if ( compress )
         {
-            data = client.getCompressionProvider().compress(givenPath, data);
+            data = client.getCompressionProvider().compress(data);
         }
 
         final String adjustedPath = adjustPath(client.fixForNamespace(givenPath, createMode.isSequential()));

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
@@ -244,7 +244,7 @@ class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<String>,
                     {
                         try
                         {
-                            data = client.getCompressionProvider().decompress(path, data);
+                            data = client.getCompressionProvider().decompress(data);
                         }
                         catch ( Exception e )
                         {
@@ -315,6 +315,6 @@ class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<String>,
         );
         trace.setResponseBytesLength(responseData).setPath(path).setWithWatcher(watching.getWatcher() != null).setStat(responseStat).commit();
 
-        return decompress ? client.getCompressionProvider().decompress(path, responseData) : responseData;
+        return decompress ? client.getCompressionProvider().decompress(responseData) : responseData;
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GzipCompressionProvider.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GzipCompressionProvider.java
@@ -27,7 +27,7 @@ import java.util.zip.GZIPOutputStream;
 public class GzipCompressionProvider implements CompressionProvider
 {
     @Override
-    public byte[] compress(String path, byte[] data) throws Exception
+    public byte[] compress(byte[] data) throws Exception
     {
         ByteArrayOutputStream       bytes = new ByteArrayOutputStream();
         GZIPOutputStream            out = new GZIPOutputStream(bytes);
@@ -41,7 +41,7 @@ public class GzipCompressionProvider implements CompressionProvider
     }
 
     @Override
-    public byte[] decompress(String path, byte[] compressedData) throws Exception
+    public byte[] decompress(byte[] compressedData) throws Exception
     {
         ByteArrayOutputStream       bytes = new ByteArrayOutputStream(compressedData.length);
         GZIPInputStream             in = new GZIPInputStream(new ByteArrayInputStream(compressedData));

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
@@ -55,7 +55,7 @@ class SetDataBuilderImpl implements SetDataBuilder, BackgroundOperation<PathAndB
             {
                 if ( compress )
                 {
-                    data = client.getCompressionProvider().compress(path, data);
+                    data = client.getCompressionProvider().compress(data);
                 }
 
                 String      fixedPath = client.fixForNamespace(path);
@@ -246,7 +246,7 @@ class SetDataBuilderImpl implements SetDataBuilder, BackgroundOperation<PathAndB
     {
         if ( compress )
         {
-            data = client.getCompressionProvider().compress(path, data);
+            data = client.getCompressionProvider().compress(data);
         }
 
         path = client.fixForNamespace(path);

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
@@ -73,6 +73,6 @@ class TempGetDataBuilderImpl implements TempGetDataBuilder
         );
         trace.setResponseBytesLength(responseData).setPath(path).setStat(responseStat).commit();
 
-        return decompress ? client.getCompressionProvider().decompress(path, responseData) : responseData;
+        return decompress ? client.getCompressionProvider().decompress(responseData) : responseData;
     }
 }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompression.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompression.java
@@ -40,7 +40,7 @@ public class TestCompression extends BaseClassForTests
         CompressionProvider     compressionProvider = new CompressionProvider()
         {
             @Override
-            public byte[] compress(String path, byte[] data) throws Exception
+            public byte[] compress(byte[] data) throws Exception
             {
                 compressCounter.incrementAndGet();
 
@@ -51,7 +51,7 @@ public class TestCompression extends BaseClassForTests
             }
 
             @Override
-            public byte[] decompress(String path, byte[] compressedData) throws Exception
+            public byte[] decompress(byte[] compressedData) throws Exception
             {
                 decompressCounter.incrementAndGet();
 


### PR DESCRIPTION
This is in accordance to this ISSUE https://issues.apache.org/jira/browse/CURATOR-372

We are unnecessarily passing this information to the compression provider. 