### PR TITLE
[CURATOR-375] - fix thread interruption being reported twice

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/ConnectionState.java
+++ b/curator-client/src/main/java/org/apache/curator/ConnectionState.java
@@ -117,7 +117,6 @@ class ConnectionState implements Watcher, Closeable
         }
         catch ( Exception e )
         {
-            ThreadUtils.checkInterrupted(e);
             throw new IOException(e);
         }
         finally

--- a/curator-client/src/main/java/org/apache/curator/utils/ThreadUtils.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/ThreadUtils.java
@@ -31,12 +31,14 @@ public class ThreadUtils
 {
     private static final Logger log = LoggerFactory.getLogger(ThreadUtils.class);
 
-    public static void checkInterrupted(Throwable e)
+    public static boolean checkInterrupted(Throwable e)
     {
         if ( e instanceof InterruptedException )
         {
             Thread.currentThread().interrupt();
+            return true;
         }
+        return false;
     }
 
     public static ExecutorService newSingleThreadExecutor(String processName)

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -485,7 +485,6 @@ class CreateBuilderImpl implements CreateBuilder, BackgroundOperation<PathAndByt
         }
         catch ( Exception e)
         {
-            ThreadUtils.checkInterrupted(e);
             if ( ( e instanceof KeeperException.ConnectionLossException ||
                 !( e instanceof KeeperException )) && protectedId != null )
             {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
@@ -267,7 +267,6 @@ class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<String>, E
         }
         catch ( Exception e )
         {
-            ThreadUtils.checkInterrupted(e);
             //Only retry a guaranteed delete if it's a retryable error
             if( (RetryLoop.isRetryException(e) || (e instanceof InterruptedException)) && guaranteed )
             {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNode.java
@@ -293,8 +293,10 @@ public class PersistentNode implements Closeable
         }
         catch ( Exception e )
         {
-            ThreadUtils.checkInterrupted(e);
-            throw new IOException(e);
+            if ( !ThreadUtils.checkInterrupted(e) )
+            {
+                throw new IOException(e);
+            }
         }
     }
 
@@ -369,7 +371,6 @@ public class PersistentNode implements Closeable
         }
         catch ( Exception e )
         {
-            ThreadUtils.checkInterrupted(e);
             throw new RuntimeException("Creating node. BasePath: " + basePath, e);  // should never happen unless there's a programming error - so throw RuntimeException
         }
     }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentNode.java
@@ -152,20 +152,33 @@ public class TestPersistentNode extends BaseClassForTests
 
             pen = new PersistentNode(client, CreateMode.PERSISTENT, false, "/test", new byte[0]);
             pen.start();
+            Assert.assertTrue(pen.waitForInitialCreate(timing.milliseconds(), TimeUnit.MILLISECONDS));
 
             // interrupt once
             Thread.currentThread().interrupt();
+
+            int interruptCount = 0;
 
             try {
                 pen.close();
             }
             catch (IOException expected) {
-                if (!(expected.getCause() instanceof InterruptedException)) {
+                if (expected.getCause() instanceof InterruptedException) {
+                    interruptCount++;
+                }
+                else {
                     throw expected;
                 }
             }
 
-            timing.sleepABit();
+            try {
+                timing.sleepABit();
+            }
+            catch (InterruptedException expected) {
+                interruptCount++;
+            }
+
+            Assert.assertEquals(interruptCount, 1);
         }
         finally
         {


### PR DESCRIPTION
In some classes, thread interruption was being reported twice - by setting the thread interrupted flag and re-throwing the `InterruptedException` - this made it look like the thread was actually interrupted twice, and generally causes spurious interruption - even if the `InterruptedException` is handled, the thread interruption status is still set, meaning the next async operation that happens will also fail.

Affected classes:
- `ConnectionState` - `closeAndClear` can never throw `InterruptedException` canyway, so remove the check completely
- `PersistentNode` - as mentioned in the docs for `AutoCloseable`, close methods shouldn't throw InterruptedException anyway. The delete operation is guaranteed, so even if `deleteNode` throws an exception, the node will still (probably) be deleted
- `CreateBuilderImpl`/`DeleteBuilderImpl` - the exception is being re-thrown, so don't need to re-set the interrupt status