### PR TITLE
[CURATOR-376] InterProcessSemaphoreMutex is not thread safe

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessSemaphoreMutex.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessSemaphoreMutex.java
@@ -61,16 +61,10 @@ public class InterProcessSemaphoreMutex implements InterProcessLock
     @Override
     public void release() throws Exception
     {
+        Lease lease = this.lease;
         Preconditions.checkState(lease != null, "Not acquired");
-
-        try
-        {
-            lease.close();
-        }
-        finally
-        {
-            lease = null;
-        }
+        this.lease = null;
+        lease.close();
     }
 
     @Override


### PR DESCRIPTION
Set this.lease to null before lease.close.