### PR TITLE
[CURATOR-379] unfixForNamespace corrupts child path when it contains namespace

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceImpl.java
@@ -20,12 +20,11 @@ package org.apache.curator.framework.imps;
 
 import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.RetryLoop;
-import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.EnsurePath;
 import org.apache.curator.utils.PathUtils;
 import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
-import org.apache.zookeeper.ZooDefs;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -63,7 +62,7 @@ class NamespaceImpl
     {
         if ( (namespace != null) && (path != null) )
         {
-            String      namespacePath = ZKPaths.makePath(namespace, null);
+            String      namespacePath = ZKPaths.makePath(namespace, null) + "/";
             if ( !namespacePath.equals("/") && path.startsWith(namespacePath) )
             {
                 path = (path.length() > namespacePath.length()) ? path.substring(namespacePath.length()) : "/";

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceImpl.java
@@ -24,7 +24,6 @@ import org.apache.curator.utils.EnsurePath;
 import org.apache.curator.utils.PathUtils;
 import org.apache.curator.utils.ThreadUtils;
 import org.apache.curator.utils.ZKPaths;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
@@ -18,19 +18,19 @@
  */
 package org.apache.curator.framework.imps;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
-import org.apache.curator.utils.CloseableUtils;
-import org.apache.zookeeper.KeeperException.NoAuthException;
 import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.KeeperException.NoAuthException;
 import org.apache.zookeeper.data.ACL;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.List;
 
 public class TestNamespaceFacade extends BaseClassForTests
 {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
@@ -18,20 +18,19 @@
  */
 package org.apache.curator.framework.imps;
 
-import java.util.Collections;
-import java.util.List;
-
-import org.apache.curator.test.BaseClassForTests;
-import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.zookeeper.ZooDefs;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException.NoAuthException;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 public class TestNamespaceFacade extends BaseClassForTests
 {
@@ -190,7 +189,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         client.close();
         Assert.assertEquals(client.getState(), namespaced.getState(), "Namespaced state did not match true state after call to close.");
     }
-    
+
     /**
      * Test that ACLs work on a NamespaceFacade. See CURATOR-132
      * @throws Exception
@@ -205,7 +204,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         client.create().creatingParentsIfNeeded().forPath("/parent/child", "A string".getBytes());
         CuratorFramework client2 = client.usingNamespace("parent");
 
-        Assert.assertNotNull(client2.getData().forPath("/child"));  
+        Assert.assertNotNull(client2.getData().forPath("/child"));
         client.setACL().withACL(Collections.singletonList(
             new ACL(ZooDefs.Perms.WRITE, ZooDefs.Ids.ANYONE_ID_UNSAFE))).
                 forPath("/parent/child");
@@ -236,6 +235,17 @@ public class TestNamespaceFacade extends BaseClassForTests
         CuratorFrameworkImpl clientImpl = (CuratorFrameworkImpl) client;
 
         Assert.assertEquals(clientImpl.unfixForNamespace("/foo/bar"), "/foo/bar");
+
+        CloseableUtils.closeQuietly(client);
+    }
+
+    @Test
+    public void testUnfixForChildPathStartingWithNamespace(){
+        CuratorFramework client = CuratorFrameworkFactory.builder().namespace("foo").retryPolicy(new RetryOneTime(1)).connectString("").build();
+        CuratorFrameworkImpl clientImpl = (CuratorFrameworkImpl) client;
+
+        Assert.assertEquals(clientImpl.unfixForNamespace("/foobar"), "/foobar");
+        Assert.assertEquals(clientImpl.unfixForNamespace("/foobar/baz"), "/foobar/baz");
 
         CloseableUtils.closeQuietly(client);
     }


### PR DESCRIPTION
When a child path starts with the namespace unfixForNamespace removes the namespace string, thus creating a invalid path.
With namespace "foo" the result of unfixForNamespace("/foobar") is "bar".
