### PR TITLE
[CURATOR-386] Allow listener to be passed in to PersistentNode

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNode.java
@@ -19,6 +19,7 @@
 
 package org.apache.curator.framework.recipes.nodes;
 
+import com.google.common.base.Function;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.curator.framework.CuratorFramework;
@@ -28,6 +29,7 @@ import org.apache.curator.framework.api.CreateBuilder;
 import org.apache.curator.framework.api.CreateModable;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.CuratorWatcher;
+import org.apache.curator.framework.listen.ListenerContainer;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.PathUtils;
@@ -69,6 +71,7 @@ public class PersistentNode implements Closeable
     private final BackgroundCallback backgroundCallback;
     private final boolean useProtection;
     private final AtomicReference<CreateModable<ACLBackgroundPathAndBytesable<String>>> createMethod = new AtomicReference<CreateModable<ACLBackgroundPathAndBytesable<String>>>(null);
+    private final ListenerContainer<PersistentNodeListener> listeners = new ListenerContainer<PersistentNodeListener>();
     private final CuratorWatcher watcher = new CuratorWatcher()
     {
         @Override
@@ -117,8 +120,8 @@ public class PersistentNode implements Closeable
             {
                 //Update is ok, mark initialisation as complete if required.
                 initialisationComplete();
-            } 
-            else if ( event.getResultCode() == KeeperException.Code.NOAUTH.intValue() ) 
+            }
+            else if ( event.getResultCode() == KeeperException.Code.NOAUTH.intValue() )
             {
                 log.warn("Client does not have authorisation to write node at path {}", event.getPath());
                 authFailure.set(true);
@@ -235,6 +238,7 @@ public class PersistentNode implements Closeable
             else
             {
                 initialisationComplete();
+                notifyListeners();
             }
         }
         else
@@ -300,6 +304,16 @@ public class PersistentNode implements Closeable
             ThreadUtils.checkInterrupted(e);
             throw new IOException(e);
         }
+    }
+
+    /**
+     * Returns the listenable
+     *
+     * @return listenable
+     */
+    public ListenerContainer<PersistentNodeListener> getListenable()
+    {
+        return listeners;
     }
 
     /**
@@ -425,6 +439,30 @@ public class PersistentNode implements Closeable
         {
             client.checkExists().usingWatcher(watcher).inBackground(checkExistsCallback).forPath(localNodePath);
         }
+    }
+
+    private void notifyListeners()
+    {
+        final String path = getActualPath();
+        listeners.forEach(
+             new Function<PersistentNodeListener, Void>()
+             {
+                 @Override
+                 public Void apply(PersistentNodeListener listener)
+                 {
+                     try
+                    {
+                        listener.nodeCreated(path);
+                    }
+                    catch ( Exception e )
+                    {
+                        ThreadUtils.checkInterrupted(e);
+                        log.error("From PersistentNode listener", e);
+                    }
+                    return null;
+                }
+             }
+        );
     }
 
     private boolean isActive()

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNodeListener.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNodeListener.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.curator.framework.recipes.nodes;
+
+/**
+ * Listener for changes to a PersistentNode
+ */
+public interface PersistentNodeListener {
+    /**
+     * Called on a persistentNode event when node is created
+     *
+     * @param path Path of the znode
+     * @throws Exception errors
+     */
+    void nodeCreated(String path) throws Exception;
+}


### PR DESCRIPTION
This provides ability to hook into events from PersistentNode when a
node gets created.  PersistentNode would then notify any registered listeners that the 
node was created, along with the path created (useful when protection is used). 