### PR TITLE
[CURATOR-391] Cannot use only Stat version to determine node change

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -694,12 +695,21 @@ public class PathChildrenCache implements Closeable
             {
                 offerOperation(new EventOperation(this, new PathChildrenCacheEvent(PathChildrenCacheEvent.Type.CHILD_ADDED, data)));
             }
-            else if ( previousData.getStat().getVersion() != stat.getVersion() )
+            else if ( hasChanged(stat, previousData, data) )
             {
                 offerOperation(new EventOperation(this, new PathChildrenCacheEvent(PathChildrenCacheEvent.Type.CHILD_UPDATED, data)));
             }
             updateInitialSet(ZKPaths.getNodeFromPath(fullPath), data);
         }
+    }
+
+    private boolean hasChanged(Stat stat, ChildData previousData, ChildData newData)
+    {
+        if ( cacheData )
+        {
+            return !Arrays.equals(previousData.getData(), newData.getData());
+        }
+        return previousData.getStat().getVersion() != stat.getVersion();
     }
 
     private void updateInitialSet(String name, ChildData data)

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -695,21 +694,12 @@ public class PathChildrenCache implements Closeable
             {
                 offerOperation(new EventOperation(this, new PathChildrenCacheEvent(PathChildrenCacheEvent.Type.CHILD_ADDED, data)));
             }
-            else if ( hasChanged(stat, previousData, data) )
+            else if ( stat.getMzxid() != previousData.getStat().getMzxid() )
             {
                 offerOperation(new EventOperation(this, new PathChildrenCacheEvent(PathChildrenCacheEvent.Type.CHILD_UPDATED, data)));
             }
             updateInitialSet(ZKPaths.getNodeFromPath(fullPath), data);
         }
-    }
-
-    private boolean hasChanged(Stat stat, ChildData previousData, ChildData newData)
-    {
-        if ( cacheData )
-        {
-            return !Arrays.equals(previousData.getData(), newData.getData());
-        }
-        return previousData.getStat().getVersion() != stat.getVersion();
     }
 
     private void updateInitialSet(String name, ChildData data)

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestPathChildrenCacheInCluster.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestPathChildrenCacheInCluster.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.framework.recipes.cache;
 
+import com.google.common.collect.Queues;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -27,12 +28,71 @@ import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.Timing;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class TestPathChildrenCacheInCluster
 {
+    @Test
+    public void testMissedDelete() throws Exception
+    {
+        Timing timing = new Timing();
+        PathChildrenCache cache = null;
+        CuratorFramework client1 = null;
+        CuratorFramework client2 = null;
+        TestingCluster cluster = new TestingCluster(3);
+        try
+        {
+            cluster.start();
+
+            // client 1 only connects to 1 server
+            InstanceSpec client1Instance = cluster.getInstances().iterator().next();
+            client1 = CuratorFrameworkFactory.newClient(client1Instance.getConnectString(), 1000, 1000, new RetryOneTime(1));
+            cache = new PathChildrenCache(client1, "/test", true);
+            final BlockingQueue<PathChildrenCacheEvent.Type> events = Queues.newLinkedBlockingQueue();
+            PathChildrenCacheListener listener = new PathChildrenCacheListener()
+            {
+                @Override
+                public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception
+                {
+                    events.add(event.getType());
+                }
+            };
+            cache.getListenable().addListener(listener);
+
+            client2 = CuratorFrameworkFactory.newClient(cluster.getConnectString(), 1000, 1000, new RetryOneTime(1));
+
+            client1.start();
+            client2.start();
+            cache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
+            Assert.assertEquals(events.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CONNECTION_RECONNECTED);
+            Assert.assertEquals(events.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.INITIALIZED);
+
+            client2.create().creatingParentsIfNeeded().forPath("/test/node", "first".getBytes());
+            Assert.assertEquals(events.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
+
+            cluster.killServer(client1Instance);
+            Assert.assertEquals(events.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CONNECTION_SUSPENDED);
+            Assert.assertEquals(events.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CONNECTION_LOST);
+
+            client2.delete().forPath("/test/node");
+            client2.create().forPath("/test/node", "second".getBytes());
+            cluster.restartServer(client1Instance);
+
+            Assert.assertEquals(events.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CONNECTION_RECONNECTED);
+            Assert.assertEquals(events.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_UPDATED);  // "/test/node" is different - should register as updated
+        }
+        finally
+        {
+            CloseableUtils.closeQuietly(client1);
+            CloseableUtils.closeQuietly(client2);
+            CloseableUtils.closeQuietly(cache);
+            CloseableUtils.closeQuietly(cluster);
+        }
+    }
+
     @Test
     public void     testServerLoss() throws Exception
     {


### PR DESCRIPTION
Using only Stat version to note node change (for UPDATE event) is not enough. In a split brain if a node delete plus a recreate is missed, the Stat version can appear to be the same. So, when data is available in the cache, compare the data not the stat version