### PR TITLE
[CURATOR-392] Fixing connection string construction for wildcard client addresses

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -42,8 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -175,9 +173,8 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
             {
                 sb.append(",");
             }
-            InetAddress wildcardAddress = new InetSocketAddress(0).getAddress();
             String hostAddress;
-            if ( wildcardAddress.equals(server.clientAddr.getAddress()) )
+            if ( server.clientAddr.getAddress().isAnyLocalAddress() )
             {
                 hostAddress = server.addr.getAddress().getHostAddress();
             }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -20,7 +20,6 @@
 package org.apache.curator.framework.imps;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import org.apache.curator.ensemble.EnsembleProvider;
@@ -40,10 +39,11 @@ import org.apache.zookeeper.server.quorum.flexible.QuorumMaj;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.Arrays;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -166,12 +166,26 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
         StringBuilder sb = new StringBuilder();
         for ( QuorumPeer.QuorumServer server : data.getAllMembers().values() )
         {
+            if ( server.clientAddr == null )
+            {
+                // Invalid client address configuration in zoo.cfg
+                continue;
+            }
             if ( sb.length() != 0 )
             {
                 sb.append(",");
             }
-            InetSocketAddress address = Objects.firstNonNull(server.clientAddr, server.addr);
-            sb.append(address.getAddress().getHostAddress()).append(":").append(address.getPort());
+            InetAddress wildcardAddress = new InetSocketAddress(0).getAddress();
+            String hostAddress;
+            if ( wildcardAddress.equals(server.clientAddr.getAddress()) )
+            {
+                hostAddress = server.addr.getAddress().getHostAddress();
+            }
+            else
+            {
+                hostAddress = server.clientAddr.getAddress().getHostAddress();
+            }
+            sb.append(hostAddress).append(":").append(server.clientAddr.getPort());
         }
 
         return sb.toString();
@@ -183,13 +197,19 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
         properties.load(new ByteArrayInputStream(data));
         log.info("New config event received: {}", properties);
 
-        QuorumMaj newConfig = new QuorumMaj(properties);
-        currentConfig.set(newConfig);
-
-        String connectionString = configToConnectionString(newConfig);
-        if ( connectionString.trim().length() > 0 )
+        if (!properties.isEmpty())
         {
-            ensembleProvider.setConnectionString(connectionString);
+            QuorumMaj newConfig = new QuorumMaj(properties);
+            String connectionString = configToConnectionString(newConfig);
+            if (connectionString.trim().length() > 0)
+            {
+                currentConfig.set(newConfig);
+                ensembleProvider.setConnectionString(connectionString);
+            }
+            else
+            {
+                log.error("Invalid config event received: {}", properties);
+            }
         }
         else
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
@@ -313,6 +313,38 @@ public class TestReconfiguration extends BaseClassForTests
         }
     }
 
+    @Test
+    public void testConfigToConnectionStringNormal() throws Exception
+    {
+        String config = "server.1=10.1.2.3:2888:3888:participant;10.2.3.4:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        Assert.assertEquals("10.2.3.4:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringNoClientAddr() throws Exception
+    {
+        String config = "server.1=10.1.2.3:2888:3888:participant;2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        Assert.assertEquals("10.1.2.3:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringWildcardClientAddr() throws Exception
+    {
+        String config = "server.1=10.1.2.3:2888:3888:participant;0.0.0.0:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        Assert.assertEquals("10.1.2.3:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringNoClientAddrOrPort() throws Exception
+    {
+        String config = "server.1=10.1.2.3:2888:3888:participant";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        Assert.assertEquals("", configString);
+    }
+
     private CuratorFramework newClient()
     {
         final AtomicReference<String> connectString = new AtomicReference<>(cluster.getConnectString());

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
@@ -334,7 +334,7 @@ public class TestReconfiguration extends BaseClassForTests
     }
 
     @Test
-    public void testConfigToConnectionStringNormal() throws Exception
+    public void testConfigToConnectionStringIPv4Normal() throws Exception
     {
         String config = "server.1=10.1.2.3:2888:3888:participant;10.2.3.4:2181";
         String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
@@ -342,7 +342,15 @@ public class TestReconfiguration extends BaseClassForTests
     }
 
     @Test
-    public void testConfigToConnectionStringNoClientAddr() throws Exception
+    public void testConfigToConnectionStringIPv6Normal() throws Exception
+    {
+        String config = "server.1=[1010:0001:0002:0003:0004:0005:0006:0007]:2888:3888:participant;[2001:db8:85a3:0:0:8a2e:370:7334]:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        Assert.assertEquals("2001:db8:85a3:0:0:8a2e:370:7334:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringIPv4NoClientAddr() throws Exception
     {
         String config = "server.1=10.1.2.3:2888:3888:participant;2181";
         String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
@@ -350,7 +358,7 @@ public class TestReconfiguration extends BaseClassForTests
     }
 
     @Test
-    public void testConfigToConnectionStringWildcardClientAddr() throws Exception
+    public void testConfigToConnectionStringIPv4WildcardClientAddr() throws Exception
     {
         String config = "server.1=10.1.2.3:2888:3888:participant;0.0.0.0:2181";
         String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
@@ -363,6 +371,38 @@ public class TestReconfiguration extends BaseClassForTests
         String config = "server.1=10.1.2.3:2888:3888:participant";
         String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
         Assert.assertEquals("", configString);
+    }
+
+    @Test
+    public void testIPv6Wildcard1() throws Exception
+    {
+        String config = "server.1=[2001:db8:85a3:0:0:8a2e:370:7334]:2888:3888:participant;[::]:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        Assert.assertEquals("2001:db8:85a3:0:0:8a2e:370:7334:2181", configString);
+    }
+
+    @Test
+    public void testIPv6Wildcard2() throws Exception
+    {
+        String config = "server.1=[1010:0001:0002:0003:0004:0005:0006:0007]:2888:3888:participant;[::0]:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        Assert.assertEquals("1010:1:2:3:4:5:6:7:2181", configString);
+    }
+
+    @Test
+    public void testMixedIPv1() throws Exception
+    {
+        String config = "server.1=10.1.2.3:2888:3888:participant;[::]:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        Assert.assertEquals("10.1.2.3:2181", configString);
+    }
+
+    @Test
+    public void testMixedIPv2() throws Exception
+    {
+        String config = "server.1=[2001:db8:85a3:0:0:8a2e:370:7334]:2888:3888:participant;127.0.0.1:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        Assert.assertEquals("127.0.0.1:2181", configString);
     }
 
     private CuratorFramework newClient()


### PR DESCRIPTION
The client address in Zookeeper can be a wildcard (0.0.0.0), and if this is used by Curator, it will attempt to create a new connection to 0.0.0.0 instead of the correct server address. It is also possible that no client address or port is set, which should be counted as invalid by Curator, since the appropriate information isn't contained in the data sent.