### PR TITLE
[CURATOR-400] upgrade clirr to fix the check error on java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dropwizard-version>0.7.0</dropwizard-version>
         <maven-shade-plugin-version>2.4.3</maven-shade-plugin-version>
         <slf4j-version>1.7.6</slf4j-version>
-        <clirr-maven-plugin-version>2.6.1</clirr-maven-plugin-version>
+        <clirr-maven-plugin-version>2.8</clirr-maven-plugin-version>
 
         <!-- OSGi Properties -->
         <osgi.export.package />


### PR DESCRIPTION
Currently, the `mvn compile` failed on CURATOR-3.0 branch, it turns out clirr maven plugin has bug and can fail on Java 8, the latest 2.8 version fixed those bug, and compiled without error.

Error details:
-------------------
[ERROR] Failed to execute goal org.codehaus.mojo:clirr-maven-plugin:2.6.1:check (default) on project curator-x-async: Execution default of goal org.codehaus.mojo:clirr-maven-plugin:2.6.1:check failed: Invalid byte tag in constant pool: 15