### PR TITLE
Fix guava version incompatibility with MoreExecutors.sameThreadExecutor()

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/listen/ListenerContainer.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/listen/ListenerContainer.java
@@ -38,7 +38,7 @@ public class ListenerContainer<T> implements Listenable<T>
     @Override
     public void addListener(T listener)
     {
-        addListener(listener, MoreExecutors.sameThreadExecutor());
+        addListener(listener, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMutex.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMutex.java
@@ -173,7 +173,7 @@ public class InterProcessMutex implements InterProcessLock, Revocable<InterProce
     @Override
     public void makeRevocable(RevocationListener<InterProcessMutex> listener)
     {
-        makeRevocable(listener, MoreExecutors.sameThreadExecutor());
+        makeRevocable(listener, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueBuilder.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueBuilder.java
@@ -187,7 +187,7 @@ public class QueueBuilder<T>
     }
 
     /**
-     * Change the executor used. The default is {@link MoreExecutors.directExecutor()}
+     * Change the executor used. The default is {@link MoreExecutors#directExecutor()}
      *
      * @param executor new executor to use
      * @return this

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueBuilder.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueBuilder.java
@@ -187,7 +187,7 @@ public class QueueBuilder<T>
     }
 
     /**
-     * Change the executor used. The default is {@link MoreExecutors#sameThreadExecutor()}
+     * Change the executor used. The default is {@link MoreExecutors.directExecutor()}
      *
      * @param executor new executor to use
      * @return this
@@ -269,6 +269,6 @@ public class QueueBuilder<T>
         this.queuePath = PathUtils.validatePath(queuePath);
 
         factory = defaultThreadFactory;
-        executor = MoreExecutors.sameThreadExecutor();
+        executor = MoreExecutors.directExecutor();
     }
 }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedCount.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedCount.java
@@ -114,7 +114,7 @@ public class SharedCount implements Closeable, SharedCountReader, Listenable<Sha
     @Override
     public void     addListener(SharedCountListener listener)
     {
-        addListener(listener, MoreExecutors.sameThreadExecutor());
+        addListener(listener, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedQueue.java
@@ -705,7 +705,7 @@ public class TestDistributedQueue extends BaseClassForTests
         try
         {
             final AtomicBoolean     firstTime = new AtomicBoolean(true);
-            queue = new DistributedQueue<TestQueueItem>(client, null, serializer, "/test", new ThreadFactoryBuilder().build(), MoreExecutors.sameThreadExecutor(), 10, true, null, QueueBuilder.NOT_SET, true, 0)
+            queue = new DistributedQueue<TestQueueItem>(client, null, serializer, "/test", new ThreadFactoryBuilder().build(), MoreExecutors.directExecutor(), 10, true, null, QueueBuilder.NOT_SET, true, 0)
             {
                 @Override
                 void internalCreateNode(final String path, final byte[] bytes, final BackgroundCallback callback) throws Exception

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <jetty-version>6.1.26</jetty-version>
         <scannotation-version>1.0.2</scannotation-version>
         <resteasy-jaxrs-version>2.3.0.GA</resteasy-jaxrs-version>
-        <guava-version>16.0.1</guava-version>
+        <guava-version>18.0</guava-version>
         <testng-version>6.10</testng-version>
         <swift-version>0.12.0</swift-version>
         <dropwizard-version>0.7.0</dropwizard-version>


### PR DESCRIPTION
Before I went to create this PR, I see similar ones have been closed several times, suggesting that it was addressed in https://github.com/apache/curator/pull/190 as part of https://issues.apache.org/jira/browse/CURATOR-200

This doesn't appear to actually address the issue, as this error occurs:

```
java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor()Lcom/google/common/util/concurrent/ListeningExecutorService;
        at org.apache.curator.framework.listen.ListenerContainer.addListener(ListenerContainer.java:40)
        at org.apache.curator.framework.imps.CuratorFrameworkImpl.start(CuratorFrameworkImpl.java:256)
        at XXX.start(XXX.java:88)
```

I'm not familiar with shading, but it appears it's either not implemented or not working properly in this case (does shading rewrite the curator source files?). This error occurs with both 2.12.0 and 3.3.0.