### PR TITLE
CURATOR-401: Make InterProcessMutex.isOwnedByCurrentThread public

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMutex.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMutex.java
@@ -195,7 +195,12 @@ public class InterProcessMutex implements InterProcessLock, Revocable<InterProce
         internals = new LockInternals(client, driver, path, lockName, maxLeases);
     }
 
-    boolean isOwnedByCurrentThread()
+    /**
+     * Returns true if the mutex is acquired by the calling thread
+     * 
+     * @return true/false
+     */
+    public boolean isOwnedByCurrentThread()
     {
         LockData lockData = threadData.get(Thread.currentThread());
         return (lockData != null) && (lockData.lockCount.get() > 0);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/CURATOR-401