### PR TITLE
 CURATOR-106: Ensure background operations happen in the background thread to avoid stack overflows when retrying guaranteed operations

### DIFF
--- a/curator-framework/pom.xml
+++ b/curator-framework/pom.xml
@@ -67,6 +67,12 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -504,7 +504,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
         boolean isInitialExecution = (event == null);
         if ( isInitialExecution )
         {
-            performBackgroundOperation(operationAndData);
+            queueOperation(operationAndData);
             return;
         }
 

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
@@ -53,7 +53,7 @@ public class TestNamespaceFacade extends BaseClassForTests
     public void     testGetNamespace() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
-        CuratorFramework    client2 = CuratorFrameworkFactory.builder().namespace("snafu").retryPolicy(new RetryOneTime(1)).connectString("").build();
+        CuratorFramework    client2 = CuratorFrameworkFactory.builder().namespace("snafu").retryPolicy(new RetryOneTime(1)).connectString(server.getConnectString()).build();
         try
         {
             client.start();
@@ -232,7 +232,7 @@ public class TestNamespaceFacade extends BaseClassForTests
 
     @Test
     public void testUnfixForEmptyNamespace() {
-        CuratorFramework client = CuratorFrameworkFactory.builder().namespace("").retryPolicy(new RetryOneTime(1)).connectString("").build();
+        CuratorFramework client = CuratorFrameworkFactory.builder().namespace("").retryPolicy(new RetryOneTime(1)).connectString(server.getConnectString()).build();
         CuratorFrameworkImpl clientImpl = (CuratorFrameworkImpl) client;
 
         Assert.assertEquals(clientImpl.unfixForNamespace("/foo/bar"), "/foo/bar");

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentEphemeralNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentEphemeralNode.java
@@ -633,7 +633,11 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
             node.waitForInitialCreate(timing.forWaiting().seconds(), TimeUnit.SECONDS);
             assertTrue(Arrays.equals(curator.getData().forPath(node.getActualPath()), initialData));
 
+            Trigger dataChangedTrigger = Trigger.dataChanged();
+            curator.getData().usingWatcher(dataChangedTrigger).forPath(node.getActualPath());
+            
             node.setData(updatedData);
+            assertTrue(dataChangedTrigger.firedWithin(timing.forWaiting().seconds(), TimeUnit.SECONDS));
             assertTrue(Arrays.equals(curator.getData().forPath(node.getActualPath()), updatedData));
 
             server.restart();


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/CURATOR-106?focusedCommentId=15979112&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15979112

Also a few tests in TestNamespaceFacade were not passing because they were using blank connect strings. I'd be happy to open a separate issue for that change if necessary, or remove it if I misunderstood the tests.