### PR TITLE
CURATOR-402: Curator should not use QuorumServer.addr when updating the connect string dynamically

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -170,8 +170,10 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
             {
                 sb.append(",");
             }
-            InetSocketAddress address = Objects.firstNonNull(server.clientAddr, server.addr);
-            sb.append(address.getAddress().getHostAddress()).append(":").append(address.getPort());
+            InetSocketAddress clientAddress = server.clientAddr;
+            if(clientAddress != null) {
+                sb.append(clientAddress.getAddress().getHostAddress()).append(":").append(clientAddress.getPort());
+            }
         }
 
         return sb.toString();


### PR DESCRIPTION
…e the client connect string, resulting in a client unable to reconnect

See https://issues.apache.org/jira/browse/CURATOR-402.

I took a look at adding a test for this, but both addresses are null when using a single testing server, and I couldn't find a way to start a testing cluster where clientAddr is null.