### PR TITLE
[CURATOR-404] AsyncTransactionCreateBuilder has API mistake

### DIFF
--- a/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncTransactionCreateBuilder.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncTransactionCreateBuilder.java
@@ -34,7 +34,7 @@ public interface AsyncTransactionCreateBuilder extends AsyncPathAndBytesable<Cur
      * @param createMode mode
      * @return this
      */
-    AsyncPathable<CuratorOp> withMode(CreateMode createMode);
+    AsyncPathAndBytesable<CuratorOp> withMode(CreateMode createMode);
 
     /**
      * Set an ACL list (default is {@link org.apache.zookeeper.ZooDefs.Ids#OPEN_ACL_UNSAFE})
@@ -42,14 +42,14 @@ public interface AsyncTransactionCreateBuilder extends AsyncPathAndBytesable<Cur
      * @param aclList the ACL list to use
      * @return this
      */
-    AsyncPathable<CuratorOp> withACL(List<ACL> aclList);
+    AsyncPathAndBytesable<CuratorOp> withACL(List<ACL> aclList);
 
     /**
      * Cause the data to be compressed using the configured compression provider
      *
      * @return this
      */
-    AsyncPathable<CuratorOp> compressed();
+    AsyncPathAndBytesable<CuratorOp> compressed();
 
     /**
      * Specify mode, acl list and compression
@@ -62,5 +62,5 @@ public interface AsyncTransactionCreateBuilder extends AsyncPathAndBytesable<Cur
      * @see #compressed()
      * @return this
      */
-    AsyncPathable<CuratorOp> withOptions(CreateMode createMode, List<ACL> aclList, boolean compressed);
+    AsyncPathAndBytesable<CuratorOp> withOptions(CreateMode createMode, List<ACL> aclList, boolean compressed);
 }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
@@ -56,28 +56,28 @@ class AsyncTransactionOpImpl implements AsyncTransactionOp
             private boolean compressed = false;
 
             @Override
-            public AsyncPathable<CuratorOp> withMode(CreateMode createMode)
+            public AsyncPathAndBytesable<CuratorOp> withMode(CreateMode createMode)
             {
                 this.createMode = Objects.requireNonNull(createMode, "createMode cannot be null");
                 return this;
             }
 
             @Override
-            public AsyncPathable<CuratorOp> withACL(List<ACL> aclList)
+            public AsyncPathAndBytesable<CuratorOp> withACL(List<ACL> aclList)
             {
                 this.aclList = aclList;
                 return this;
             }
 
             @Override
-            public AsyncPathable<CuratorOp> compressed()
+            public AsyncPathAndBytesable<CuratorOp> compressed()
             {
                 compressed = true;
                 return this;
             }
 
             @Override
-            public AsyncPathable<CuratorOp> withOptions(CreateMode createMode, List<ACL> aclList, boolean compressed)
+            public AsyncPathAndBytesable<CuratorOp> withOptions(CreateMode createMode, List<ACL> aclList, boolean compressed)
             {
                 this.createMode = Objects.requireNonNull(createMode, "createMode cannot be null");
                 this.aclList = aclList;


### PR DESCRIPTION
intermediate AsyncTransactionCreateBuilder DSL methods should return AsyncPathAndBytesable not AsyncPathable.

The good news here is the 99.9% of old clients will still work as this is an intermediate API call only. e.g.

`client.transactionOp().create().compressed().forPath()` still works. It merely now gains the ability to set the byte array (as it should).