### PR TITLE
CURATOR-409: Fix unintentional override of getQuorumPeer in TestingQu…

### DIFF
--- a/curator-test/src/main/java/org/apache/curator/test/TestingQuorumPeerMain.java
+++ b/curator-test/src/main/java/org/apache/curator/test/TestingQuorumPeerMain.java
@@ -52,8 +52,7 @@ class TestingQuorumPeerMain extends QuorumPeerMain implements ZooKeeperMainFace
         }
     }
 
-    @Override
-    public QuorumPeer getQuorumPeer()
+    public QuorumPeer getTestingQuorumPeer()
     {
         return quorumPeer;
     }

--- a/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java
+++ b/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java
@@ -28,7 +28,6 @@ import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
-import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,12 +136,6 @@ public class TestingZooKeeperMain implements ZooKeeperMainFace
             startingException.set(e);
             throw e;
         }
-    }
-
-    @Override
-    public QuorumPeer getQuorumPeer()
-    {
-        throw new UnsupportedOperationException();
     }
 
     @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")

--- a/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperServer.java
+++ b/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperServer.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Thanks to Jeremie BORDIER (ahfeel) for this code
  */
-public class TestingZooKeeperServer extends QuorumPeerMain implements Closeable
+public class TestingZooKeeperServer implements Closeable
 {
     private static final Logger logger = LoggerFactory.getLogger(TestingZooKeeperServer.class);
 
@@ -55,12 +55,19 @@ public class TestingZooKeeperServer extends QuorumPeerMain implements Closeable
     {
         this.configBuilder = configBuilder;
         this.thisInstanceIndex = thisInstanceIndex;
-        main = (configBuilder.size() > 1) ? new TestingQuorumPeerMain() : new TestingZooKeeperMain();
+        main = isCluster() ? new TestingQuorumPeerMain() : new TestingZooKeeperMain();
     }
 
+    private boolean isCluster() {
+        return configBuilder.size() > 1;
+    }
+    
     public QuorumPeer getQuorumPeer()
     {
-        return main.getQuorumPeer();
+        if (isCluster()) {
+            return ((TestingQuorumPeerMain) main).getTestingQuorumPeer();
+        }
+        throw new UnsupportedOperationException();
     }
 
     public Collection<InstanceSpec> getInstanceSpecs()
@@ -99,7 +106,7 @@ public class TestingZooKeeperServer extends QuorumPeerMain implements Closeable
         // Set to a LATENT state so we can restart
         state.set(State.LATENT);
 
-        main = (configBuilder.size() > 1) ? new TestingQuorumPeerMain() : new TestingZooKeeperMain();
+        main = isCluster() ? new TestingQuorumPeerMain() : new TestingZooKeeperMain();
         start();
     }
 

--- a/curator-test/src/main/java/org/apache/curator/test/ZooKeeperMainFace.java
+++ b/curator-test/src/main/java/org/apache/curator/test/ZooKeeperMainFace.java
@@ -18,7 +18,6 @@
  */
 package org.apache.curator.test;
 
-import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import java.io.Closeable;
 
@@ -29,6 +28,4 @@ public interface ZooKeeperMainFace extends Closeable
     public void blockUntilStarted() throws Exception;
 
     public void kill();
-
-    public QuorumPeer getQuorumPeer();
 }


### PR DESCRIPTION
…orumPeerMain

https://issues.apache.org/jira/browse/CURATOR-409

I don't know if QuorumPeer is useful to users of curator-test, but getQuorumPeer isn't used anywhere in the code, so if it is possible to remove it entirely that's probably a nicer solution. 