### PR TITLE
CURATOR-417: Update Guava to 22-android version ( supports jdk 1.7) 

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -20,7 +20,7 @@
 package org.apache.curator.framework.imps;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import org.apache.curator.ensemble.EnsembleProvider;
@@ -170,7 +170,7 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
             {
                 sb.append(",");
             }
-            InetSocketAddress address = Objects.firstNonNull(server.clientAddr, server.addr);
+            InetSocketAddress address = MoreObjects.firstNonNull(server.clientAddr, server.addr);
             sb.append(address.getAddress().getHostAddress()).append(":").append(address.getPort());
         }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/listen/ListenerContainer.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/listen/ListenerContainer.java
@@ -38,7 +38,7 @@ public class ListenerContainer<T> implements Listenable<T>
     @Override
     public void addListener(T listener)
     {
-        addListener(listener, MoreExecutors.sameThreadExecutor());
+        addListener(listener, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/schema/SchemaViolation.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/schema/SchemaViolation.java
@@ -18,7 +18,7 @@
  */
 package org.apache.curator.framework.schema;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import org.apache.zookeeper.data.ACL;
 import java.util.Arrays;
@@ -148,6 +148,6 @@ public class SchemaViolation extends RuntimeException
 
     private static String toString(Schema schema, String violation, ViolatorData violatorData)
     {
-        return Objects.firstNonNull(violation, "") + " " + schema + " " + violatorData;
+        return MoreObjects.firstNonNull(violation, "") + " " + schema + " " + violatorData;
     }
 }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMutex.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMutex.java
@@ -173,7 +173,7 @@ public class InterProcessMutex implements InterProcessLock, Revocable<InterProce
     @Override
     public void makeRevocable(RevocationListener<InterProcessMutex> listener)
     {
-        makeRevocable(listener, MoreExecutors.sameThreadExecutor());
+        makeRevocable(listener, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueBuilder.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueBuilder.java
@@ -269,6 +269,6 @@ public class QueueBuilder<T>
         this.queuePath = PathUtils.validatePath(queuePath);
 
         factory = defaultThreadFactory;
-        executor = MoreExecutors.sameThreadExecutor();
+        executor = MoreExecutors.directExecutor();
     }
 }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedCount.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedCount.java
@@ -114,7 +114,7 @@ public class SharedCount implements Closeable, SharedCountReader, Listenable<Sha
     @Override
     public void     addListener(SharedCountListener listener)
     {
-        addListener(listener, MoreExecutors.sameThreadExecutor());
+        addListener(listener, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedQueue.java
@@ -705,7 +705,7 @@ public class TestDistributedQueue extends BaseClassForTests
         try
         {
             final AtomicBoolean     firstTime = new AtomicBoolean(true);
-            queue = new DistributedQueue<TestQueueItem>(client, null, serializer, "/test", new ThreadFactoryBuilder().build(), MoreExecutors.sameThreadExecutor(), 10, true, null, QueueBuilder.NOT_SET, true, 0)
+            queue = new DistributedQueue<TestQueueItem>(client, null, serializer, "/test", new ThreadFactoryBuilder().build(), MoreExecutors.directExecutor(), 10, true, null, QueueBuilder.NOT_SET, true, 0)
             {
                 @Override
                 void internalCreateNode(final String path, final byte[] bytes, final BackgroundCallback callback) throws Exception

--- a/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_resteasy/TestStringsWithRestEasy.java
+++ b/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_resteasy/TestStringsWithRestEasy.java
@@ -19,7 +19,7 @@
 package org.apache.curator.x.discovery.server.jetty_resteasy;
 
 import com.google.common.collect.Lists;
-import com.google.common.io.ByteStreams;
+import com.google.common.io.ByteSource;
 import com.google.common.io.CharStreams;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.x.discovery.ServiceInstance;
@@ -133,7 +133,7 @@ public class TestStringsWithRestEasy
             urlConnection.setDoOutput(true);
 
             OutputStream        out = urlConnection.getOutputStream();
-            ByteStreams.copy(ByteStreams.newInputStreamSupplier(body.getBytes()), out);
+            ByteSource.wrap(body.getBytes()).copyTo(out);
         }
         BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
         try

--- a/curator-x-rpc/src/main/java/org/apache/curator/x/rpc/idl/discovery/DiscoveryInstance.java
+++ b/curator-x-rpc/src/main/java/org/apache/curator/x/rpc/idl/discovery/DiscoveryInstance.java
@@ -20,7 +20,7 @@ package org.apache.curator.x.rpc.idl.discovery;
 
 import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.codec.ThriftStruct;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.ServiceType;
 import org.apache.curator.x.discovery.UriSpec;
@@ -66,8 +66,8 @@ public class DiscoveryInstance
             this.name = instance.getName();
             this.id = instance.getId();
             this.address = instance.getAddress();
-            this.port = Objects.firstNonNull(instance.getPort(), 0);
-            this.sslPort = Objects.firstNonNull(instance.getSslPort(), 0);
+            this.port = MoreObjects.firstNonNull(instance.getPort(), 0);
+            this.sslPort = MoreObjects.firstNonNull(instance.getSslPort(), 0);
             this.payload = instance.getPayload();
             this.registrationTimeUTC = instance.getRegistrationTimeUTC();
             this.serviceType = DiscoveryInstanceType.valueOf(instance.getServiceType().name());

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <jetty-version>6.1.26</jetty-version>
         <scannotation-version>1.0.2</scannotation-version>
         <resteasy-jaxrs-version>2.3.0.GA</resteasy-jaxrs-version>
-        <guava-version>16.0.1</guava-version>
+        <guava-version>22.0-android</guava-version>
         <testng-version>6.10</testng-version>
         <swift-version>0.12.0</swift-version>
         <dropwizard-version>0.7.0</dropwizard-version>


### PR DESCRIPTION
* Update pom.xml to use latest version of guava 
https://github.com/google/guava 
Guava comes in two flavors.
The main flavor requires JDK 1.8 or higher.
If you need support for JDK 1.7 or Android, use the Android flavor. You can find the Android Guava source in the android directory.
* Move from Objects.firstNotNull ( removed from guava ) to MoreObjects.firstNotNull
* Move from MoreExecutors.sameThreadExecutor() ( removed from guava in version 19)  to MoreExecutors. directExecutor()