### PR TITLE
SharedCount: fix removeListener

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedCount.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedCount.java
@@ -141,7 +141,10 @@ public class SharedCount implements Closeable, SharedCountReader, Listenable<Sha
     @Override
     public void     removeListener(SharedCountListener listener)
     {
-        listeners.remove(listener);
+        SharedValueListener valueListener = listeners.remove(listener);
+        if(valueListener != null) {
+            sharedValue.getListenable().removeListener(valueListener);
+        }
     }
 
     /**


### PR DESCRIPTION
`removeListener` only removed the listener from the SharedCount's `listeners` member, which had no effect.
This fix retrieves the `SharedValueListener` created for wrapping the `SharedCountListener` and removes it from the SharedValue's listeners.