### PR TITLE
[CURATOR-430] deletingChildrenIfNeeded maybe cannot delete children completely when multi-client delete concurrently

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/utils/ZKPaths.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/ZKPaths.java
@@ -313,7 +313,13 @@ public class ZKPaths
     {
         PathUtils.validatePath(path);
 
-        List<String> children = zookeeper.getChildren(path, null);
+        List<String> children;
+        try {
+            children = zookeeper.getChildren(path, null);
+        } catch (KeeperException.NoNodeException e) {
+            // someone else has deleted the node it since we checked
+            return;
+        }
         for ( String child : children )
         {
             String fullPath = makePath(path, child);

--- a/curator-client/src/main/java/org/apache/curator/utils/ZKPaths.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/ZKPaths.java
@@ -317,7 +317,7 @@ public class ZKPaths
         try {
             children = zookeeper.getChildren(path, null);
         } catch (KeeperException.NoNodeException e) {
-            // someone else has deleted the node it since we checked
+            // someone else has deleted the node since we checked
             return;
         }
         for ( String child : children )
@@ -339,7 +339,7 @@ public class ZKPaths
             }
             catch ( KeeperException.NoNodeException e )
             {
-                // ignore... someone else has deleted the node it since we checked
+                // ignore... someone else has deleted the node since we checked
             }
         }
     }


### PR DESCRIPTION
use `curatorFramework.delete().deletingChildrenIfNeeded().forPath(path)`, this sync api doesn't ignore the NoNodeException, causes the rest of children nodes will not be deleted perhaps.  

`zookeeper.getChildren(path, null)` maybe throw NoNodeException, if the path doesn't exist.