### PR TITLE
CURATOR-431 - Fixed stat population during create

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -38,6 +38,8 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.server.DataTree;
+
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -640,17 +642,7 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
 
                     if ( (stat != null) && (storingStat != null) )
                     {
-                        storingStat.setAversion(stat.getAversion());
-                        storingStat.setCtime(stat.getCtime());
-                        storingStat.setCversion(stat.getCversion());
-                        storingStat.setCzxid(stat.getCzxid());
-                        storingStat.setDataLength(stat.getDataLength());
-                        storingStat.setEphemeralOwner(stat.getEphemeralOwner());
-                        storingStat.setMtime(stat.getMtime());
-                        storingStat.setMzxid(stat.getMzxid());
-                        storingStat.setNumChildren(stat.getNumChildren());
-                        storingStat.setPzxid(stat.getPzxid());
-                        storingStat.setVersion(stat.getVersion());
+                        DataTree.copyStat(stat, storingStat);
                     }
 
                     if ( (rc == KeeperException.Code.NONODE.intValue()) && createParentsIfNeeded )
@@ -1215,17 +1207,7 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
                                     Stat setStat = client.getZooKeeper().setData(path, data, setDataIfExistsVersion);
                                     if(storingStat != null)
                                     {
-                                        storingStat.setAversion(setStat.getAversion());
-                                        storingStat.setCtime(setStat.getCtime());
-                                        storingStat.setCversion(setStat.getCversion());
-                                        storingStat.setCzxid(setStat.getCzxid());
-                                        storingStat.setDataLength(setStat.getDataLength());
-                                        storingStat.setEphemeralOwner(setStat.getEphemeralOwner());
-                                        storingStat.setMtime(setStat.getMtime());
-                                        storingStat.setMzxid(setStat.getMzxid());
-                                        storingStat.setNumChildren(setStat.getNumChildren());
-                                        storingStat.setPzxid(setStat.getPzxid());
-                                        storingStat.setVersion(setStat.getVersion());
+                                        DataTree.copyStat(setStat, storingStat);
                                     }
                                     createdPath = path;
                                 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -1212,7 +1212,21 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
                             {
                                 if ( setDataIfExists )
                                 {
-                                    client.getZooKeeper().setData(path, data, setDataIfExistsVersion);
+                                    Stat setStat = client.getZooKeeper().setData(path, data, setDataIfExistsVersion);
+                                    if(storingStat != null)
+                                    {
+                                        storingStat.setAversion(setStat.getAversion());
+                                        storingStat.setCtime(setStat.getCtime());
+                                        storingStat.setCversion(setStat.getCversion());
+                                        storingStat.setCzxid(setStat.getCzxid());
+                                        storingStat.setDataLength(setStat.getDataLength());
+                                        storingStat.setEphemeralOwner(setStat.getEphemeralOwner());
+                                        storingStat.setMtime(setStat.getMtime());
+                                        storingStat.setMzxid(setStat.getMzxid());
+                                        storingStat.setNumChildren(setStat.getNumChildren());
+                                        storingStat.setPzxid(setStat.getPzxid());
+                                        storingStat.setVersion(setStat.getVersion());
+                                    }
                                     createdPath = path;
                                 }
                                 else

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreateReturningStat.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreateReturningStat.java
@@ -54,6 +54,36 @@ public class TestCreateReturningStat extends CuratorTestBase
     }
     
     @Test
+    public void testOrSetDataStoringStatIn() throws Exception {
+        try (CuratorFramework client = createClient())
+        {
+            client.start();
+            client.getZookeeperClient().blockUntilConnectedOrTimedOut();
+
+            final String path = "/test";
+
+            final Stat versionZeroStat = new Stat();
+            client.create().orSetData().storingStatIn(versionZeroStat).forPath(path);
+            Assert.assertEquals(0, versionZeroStat.getVersion());
+
+            final Stat versionOneStat = new Stat();
+            client.create().orSetData().storingStatIn(versionOneStat).forPath(path);
+            
+            Assert.assertEquals(versionZeroStat.getAversion(), versionOneStat.getAversion());
+            Assert.assertEquals(versionZeroStat.getCtime(), versionOneStat.getCtime());
+            Assert.assertEquals(versionZeroStat.getCversion(), versionOneStat.getCversion());
+            Assert.assertEquals(versionZeroStat.getCzxid(), versionOneStat.getCzxid());
+            Assert.assertEquals(versionZeroStat.getDataLength(), versionOneStat.getDataLength());
+            Assert.assertEquals(versionZeroStat.getEphemeralOwner(), versionOneStat.getEphemeralOwner());
+            Assert.assertTrue(versionZeroStat.getMtime() <= versionOneStat.getMtime());
+            Assert.assertNotEquals(versionZeroStat.getMzxid(), versionOneStat.getMzxid());
+            Assert.assertEquals(versionZeroStat.getNumChildren(), versionOneStat.getNumChildren());
+            Assert.assertEquals(versionZeroStat.getPzxid(), versionOneStat.getPzxid());
+            Assert.assertEquals(1, versionOneStat.getVersion());
+        }
+    }
+    
+    @Test
     public void testCreateReturningStat() throws Exception
     {
         CuratorFramework client = createClient();


### PR DESCRIPTION
-The stat object was not being populated if the create failed due to the node already existing.