### PR TITLE
[CURATOR-432] adds import exclusion to curator-framework bundle for org.apache.curator

### DIFF
--- a/curator-framework/pom.xml
+++ b/curator-framework/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <osgi.import.package>
-            *
+            !org.apache.curator,*
         </osgi.import.package>
         <osgi.export.package>
             org.apache.curator.framework*;version="${project.version}";-noimport:=true
@@ -96,27 +96,6 @@
                     <execution>
                         <goals>
                             <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.3.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>!org.apache.curator,*</Import-Package>
-                        <Export-Package>org.apache.curator.framework.*;version=${project.version};-noimport:=true</Export-Package>
-                    </instructions>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/curator-framework/pom.xml
+++ b/curator-framework/pom.xml
@@ -100,6 +100,27 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>!org.apache.curator,*</Import-Package>
+                        <Export-Package>org.apache.curator.framework.*;version=${project.version};-noimport:=true</Export-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
org.apache.curator is not an OSGI bundle so it cannot be imported.  This causes unsatisfied requirements exceptions on deployment.  This PR adds the felix plugin configuration for the exclusion in org.apache.curator.framework.  Note that this exclusion could be applied in the parent pom or to each bundle separately, but the same issue exists for other curator bundles.