### PR TITLE
[CURATOR-436] getSortedChildren() should ignore NoNode exceptions

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java
@@ -149,21 +149,28 @@ public class LockInternals
 
     public static List<String> getSortedChildren(CuratorFramework client, String basePath, final String lockName, final LockInternalsSorter sorter) throws Exception
     {
-        List<String> children = client.getChildren().forPath(basePath);
-        List<String> sortedList = Lists.newArrayList(children);
-        Collections.sort
-        (
-            sortedList,
-            new Comparator<String>()
-            {
-                @Override
-                public int compare(String lhs, String rhs)
+        try
+        {
+            List<String> children = client.getChildren().forPath(basePath);
+            List<String> sortedList = Lists.newArrayList(children);
+            Collections.sort
+            (
+                sortedList,
+                new Comparator<String>()
                 {
-                    return sorter.fixForSorting(lhs, lockName).compareTo(sorter.fixForSorting(rhs, lockName));
+                    @Override
+                    public int compare(String lhs, String rhs)
+                    {
+                        return sorter.fixForSorting(lhs, lockName).compareTo(sorter.fixForSorting(rhs, lockName));
+                    }
                 }
-            }
-        );
-        return sortedList;
+            );
+            return sortedList;
+        }
+        catch ( KeeperException.NoNodeException ignore )
+        {
+            return Collections.emptyList();
+        }
     }
 
     public static List<String> getSortedChildren(final String lockName, final LockInternalsSorter sorter, List<String> children)

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatch.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatch.java
@@ -59,6 +59,17 @@ public class TestLeaderLatch extends BaseClassForTests
     private static final int MAX_LOOPS = 5;
 
     @Test
+    public void testUncreatedPathGetLeader() throws Exception
+    {
+        try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
+        {
+            client.start();
+            LeaderLatch latch = new LeaderLatch(client, "/foo/bar");
+            latch.getLeader();  // CURATOR-436 - was throwing NoNodeException
+        }
+    }
+
+    @Test
     public void testSessionErrorPolicy() throws Exception
     {
         Timing timing = new Timing();


### PR DESCRIPTION
getSortedChildren() should ignore NoNode exceptions and just treat it as if there are no children. This works around issues with container nodes, parents not yet created, etc.