### PR TITLE
CURATOR-438 Replace Deprecated Methods

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/listen/ListenerContainer.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/listen/ListenerContainer.java
@@ -38,7 +38,7 @@ public class ListenerContainer<T> implements Listenable<T>
     @Override
     public void addListener(T listener)
     {
-        addListener(listener, MoreExecutors.sameThreadExecutor());
+        addListener(listener, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMutex.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMutex.java
@@ -173,7 +173,7 @@ public class InterProcessMutex implements InterProcessLock, Revocable<InterProce
     @Override
     public void makeRevocable(RevocationListener<InterProcessMutex> listener)
     {
-        makeRevocable(listener, MoreExecutors.sameThreadExecutor());
+        makeRevocable(listener, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueBuilder.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/QueueBuilder.java
@@ -187,7 +187,7 @@ public class QueueBuilder<T>
     }
 
     /**
-     * Change the executor used. The default is {@link MoreExecutors#sameThreadExecutor()}
+     * Change the executor used. The default is {@link MoreExecutors#directExectutor()}
      *
      * @param executor new executor to use
      * @return this
@@ -269,6 +269,6 @@ public class QueueBuilder<T>
         this.queuePath = PathUtils.validatePath(queuePath);
 
         factory = defaultThreadFactory;
-        executor = MoreExecutors.sameThreadExecutor();
+        executor = MoreExecutors.directExecutor();
     }
 }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedCount.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/shared/SharedCount.java
@@ -119,7 +119,7 @@ public class SharedCount implements Closeable, SharedCountReader, Listenable<Sha
     @Override
     public void     addListener(SharedCountListener listener)
     {
-        addListener(listener, MoreExecutors.sameThreadExecutor());
+        addListener(listener, MoreExecutors.directExecutor());
     }
 
     @Override


### PR DESCRIPTION
This pull request addresses CURATOR-438 which replaces all occurrences of the deprecated MoreExecutors.sameTheadExecutor() with MoreExecutors.directExecutor(). 

This has been an issue before a couple times, but some lingering calls remained so I searched them down and fixed them.