### PR TITLE
[Fix] Curator-444

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -540,6 +540,7 @@ public class LeaderLatch implements Closeable
         }
         else
         {
+            setLeadership(false);
             String watchPath = sortedChildren.get(ourIndex - 1);
             Watcher watcher = new Watcher()
             {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatchIsolatedZookeeper.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatchIsolatedZookeeper.java
@@ -1,15 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.curator.framework.recipes.leader;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
+import java.net.Socket;
+import java.net.SocketException;
 
 import org.apache.curator.framework.recipes.leader.testing.DummyLeaderLatch;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.TestingZooKeeperServer;
-import org.apache.curator.test.Timing;
-import org.apache.zookeeper.server.quorum.QuorumPeer;
+import org.apache.zookeeper.server.quorum.Leader;
+import org.apache.zookeeper.server.quorum.LearnerHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -20,20 +43,28 @@ import org.testng.annotations.Test;
 
 public class TestLeaderLatchIsolatedZookeeper {
 
-	private TestingCluster cluster = new TestingCluster(3);
-	private Timing timing = new Timing();
-	private DummyLeaderLatch firstClient  = new DummyLeaderLatch(cluster.getConnectString(), timing, "First");
-	private DummyLeaderLatch secondClient = new DummyLeaderLatch(cluster.getConnectString(), timing, "Second");
+	private static final Logger logger = LoggerFactory.getLogger(TestLeaderLatchIsolatedZookeeper.class);
+	private static final int CONNECTION_TIMEOUT_MS = 15000;
+	private static final int SESSION_TIMEOUT_MS = 10000;
+
+	private TestingCluster cluster;
+	private DummyLeaderLatch firstClient;
+	private DummyLeaderLatch secondClient;
 
 	@BeforeTest
 	public void beforeTest() throws Exception {
+		cluster = new TestingCluster(3);
 		cluster.start();
+		firstClient  = new DummyLeaderLatch(cluster.getConnectString(), SESSION_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, "First");
+		secondClient = new DummyLeaderLatch(cluster.getConnectString(), SESSION_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, "Second");
 		firstClient.startAndAwaitElection();
 		secondClient.startAndAwaitElection();
+		logger.info("Session: " + SESSION_TIMEOUT_MS + " connection " + CONNECTION_TIMEOUT_MS );
 	}
 
 	@AfterTest
 	public void afterTest() throws IOException {
+		DummyLeaderLatch.resetHistory();
 		firstClient.stop();
 		secondClient.stop();
 		cluster.close();
@@ -53,21 +84,142 @@ public class TestLeaderLatchIsolatedZookeeper {
 	@Test
 	public void testThatResistsNetworkGlitches() throws Exception {
 
-		for(TestingZooKeeperServer server : cluster.getServers()){
+		blockLeaderListeningForSomeTime(SESSION_TIMEOUT_MS);
 
-			// change to real glitch
-			if( server.getQuorumPeer().getPeerState().equals(QuorumPeer.ServerState.LEADING)){
+		Thread.sleep(SESSION_TIMEOUT_MS * 3);
 
-				server.getQuorumPeer().setPeerState(QuorumPeer.ServerState.LOOKING);
+		assertTrue(isHistoryValid());
+		logger.info("History :" + DummyLeaderLatch.getEventHistory());
 
-				System.out.println("CHANGED SERVER" + server);
-				firstClient.awaitElection();
+		assertEquals(   firstClient.isLeaderAccordingToLatch(),  firstClient.isLeaderAccordingToEvents());
+		assertEquals(  secondClient.isLeaderAccordingToLatch(), secondClient.isLeaderAccordingToEvents());
+		assertNotEquals(firstClient.isLeaderAccordingToLatch(), secondClient.isLeaderAccordingToLatch());
+	}
 
-				assertEquals(firstClient.isLeaderAccordingToLatch(),  firstClient.isLeaderAccordingToEvents());
-				assertEquals(secondClient.isLeaderAccordingToLatch(), secondClient.isLeaderAccordingToEvents());
-				assertNotEquals(firstClient.isLeaderAccordingToLatch(), secondClient.isLeaderAccordingToLatch());
+	private void blockLeaderListeningForSomeTime(long milliseconds) throws InterruptedException {
+		for(TestingZooKeeperServer server : cluster.getServers()) {
 
+			if (server.getQuorumPeer().leader != null) {
+				Leader leader = server.getQuorumPeer().leader;
+
+				for (LearnerHandler learnerHandler : leader.getLearners()) {
+
+					logger.info("Locking " + learnerHandler.getName());
+					HandlerLocker locker = new HandlerLocker(learnerHandler, milliseconds);
+					locker.start();
+				}
 			}
 		}
+	}
+
+	private static class HandlerLocker extends Thread{
+
+		private final long milliseconds;
+		private final LearnerHandler learnerHandler;
+
+		public HandlerLocker(LearnerHandler learnerHandler, long milliseconds){
+			this.learnerHandler = learnerHandler;
+			this.milliseconds = milliseconds;
+		}
+
+		@Override
+		public void run() {
+
+			//suspendThread();
+			//closeSocket();
+			lockSocket();
+			forceTimeout();
+		}
+
+		private void forceTimeout(){
+			try{
+				Socket socket = learnerHandler.getSocket();
+				int oldTimeout = learnerHandler.getSocket().getSoTimeout();
+				socket.setSoTimeout(1);
+				Thread.sleep(milliseconds * 3);
+				socket.setSoTimeout(oldTimeout);
+
+			}catch (SocketException ex){
+				logger.error("Error forcing timeout", ex);
+			} catch (InterruptedException ex) {
+				logger.error("Interrupted while forcing timeout", ex);
+			}
+		}
+
+
+		private void lockSocket(){
+			try{
+				logger.info("[" + System.currentTimeMillis() + "] locking socket for learner handler " + learnerHandler.getName() + " for " + milliseconds);
+
+				Socket socket = learnerHandler.getSocket();
+				synchronized (socket){
+					learnerHandler.getSocket().wait(milliseconds);
+				}
+				logger.info("[" + System.currentTimeMillis() + "] freeing socket for learner handler " + learnerHandler.getName() + " after " + milliseconds);
+
+			}catch (InterruptedException ex){
+				String message = "Failed to lock socket for " + milliseconds + " ms";
+				logger.error(message);
+				Thread.currentThread().interrupt();
+				throw new RuntimeException(message, ex);
+			}
+		}
+
+		private void suspendThread(){
+			try{
+				logger.info("[" + System.currentTimeMillis() + "] Suspending learner handler " + learnerHandler.getName() + " for " + milliseconds);
+
+				learnerHandler.suspend();
+				Thread.sleep(milliseconds);
+				learnerHandler.resume();
+
+				logger.info("[" + System.currentTimeMillis() + "] Resume learner handler " + learnerHandler.getName() + " after " + milliseconds);
+
+
+			}catch (InterruptedException ex){
+
+				String message = "Failed to wait " + milliseconds + " ms";
+				logger.error(message);
+				Thread.currentThread().interrupt();
+				throw new RuntimeException(message, ex);
+			}
+
+		}
+
+		private void closeSocket(){
+			try {
+				logger.info("Closing socket for learned handler " + learnerHandler.getName());
+				learnerHandler.getSocket().close();
+				Thread.sleep(milliseconds);
+			}catch (Exception ex){
+				logger.error("Error closing socket", ex);
+			}
+		}
+	}
+
+	private boolean isHistoryValid(){
+
+		boolean hadLeader = false;
+		String lastLeaderId = null;
+		for( DummyLeaderLatch.History history : DummyLeaderLatch.getEventHistory()){
+			if( history.isLeader()){
+				if( hadLeader ){
+					if(lastLeaderId.equals(history.getId())){
+						logger.warn("Redundant ToLeader");
+					}else{
+						return false;
+					}
+				}
+				hadLeader = true;
+				lastLeaderId = history.getId();
+			}else{
+				if(!lastLeaderId.equals(history.getId())) {
+					logger.warn("Redundant NotLeader");
+				}
+				hadLeader = false;
+				lastLeaderId = null;
+			}
+		}
+		return true;
 	}
 }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatchIsolatedZookeeper.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatchIsolatedZookeeper.java
@@ -1,0 +1,73 @@
+package org.apache.curator.framework.recipes.leader;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import java.io.IOException;
+
+import org.apache.curator.framework.recipes.leader.testing.DummyLeaderLatch;
+import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.TestingZooKeeperServer;
+import org.apache.curator.test.Timing;
+import org.apache.zookeeper.server.quorum.QuorumPeer;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+/** Tests issue: CURATOR-444: Zookeeper node is isolated from other zookeepers but not from curator
+ *  temporally */
+
+
+public class TestLeaderLatchIsolatedZookeeper {
+
+	private TestingCluster cluster = new TestingCluster(3);
+	private Timing timing = new Timing();
+	private DummyLeaderLatch firstClient  = new DummyLeaderLatch(cluster.getConnectString(), timing, "First");
+	private DummyLeaderLatch secondClient = new DummyLeaderLatch(cluster.getConnectString(), timing, "Second");
+
+	@BeforeTest
+	public void beforeTest() throws Exception {
+		cluster.start();
+		firstClient.startAndAwaitElection();
+		secondClient.startAndAwaitElection();
+	}
+
+	@AfterTest
+	public void afterTest() throws IOException {
+		firstClient.stop();
+		secondClient.stop();
+		cluster.close();
+	}
+
+	@Test
+	public void testThatStartsWithOnlyOneLeader() throws Exception {
+		assertNotEquals(firstClient.isLeaderAccordingToLatch(), secondClient.isLeaderAccordingToLatch());
+	}
+
+	@Test
+	public void testThatStartCoherent() throws Exception {
+		assertEquals(firstClient.isLeaderAccordingToLatch(),  firstClient.isLeaderAccordingToEvents());
+		assertEquals(secondClient.isLeaderAccordingToLatch(), secondClient.isLeaderAccordingToEvents());
+	}
+
+	@Test
+	public void testThatResistsNetworkGlitches() throws Exception {
+
+		for(TestingZooKeeperServer server : cluster.getServers()){
+
+			// change to real glitch
+			if( server.getQuorumPeer().getPeerState().equals(QuorumPeer.ServerState.LEADING)){
+
+				server.getQuorumPeer().setPeerState(QuorumPeer.ServerState.LOOKING);
+
+				System.out.println("CHANGED SERVER" + server);
+				firstClient.awaitElection();
+
+				assertEquals(firstClient.isLeaderAccordingToLatch(),  firstClient.isLeaderAccordingToEvents());
+				assertEquals(secondClient.isLeaderAccordingToLatch(), secondClient.isLeaderAccordingToEvents());
+				assertNotEquals(firstClient.isLeaderAccordingToLatch(), secondClient.isLeaderAccordingToLatch());
+
+			}
+		}
+	}
+}

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatchIsolatedZookeeper.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatchIsolatedZookeeper.java
@@ -64,10 +64,10 @@ public class TestLeaderLatchIsolatedZookeeper {
 
 	@AfterMethod
 	public void afterMethod() throws IOException {
-		DummyLeaderLatch.resetHistory();
 		firstClient.stop();
 		secondClient.stop();
 		cluster.close();
+		DummyLeaderLatch.resetHistory();
 	}
 
 	@Test

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/testing/DummyLeaderLatch.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/testing/DummyLeaderLatch.java
@@ -1,0 +1,136 @@
+package org.apache.curator.framework.recipes.leader.testing;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
+import org.apache.curator.framework.recipes.leader.Participant;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.Timing;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DummyLeaderLatch implements LeaderLatchListener{
+
+	private static final RetryPolicy 	RETRY_POLICY = new ExponentialBackoffRetry(100, 3);
+	private static final String 	   	LATCH_PATH   = "/leader/dummy/leaderLatch";
+	private static final Logger 	  	LOGGER 		 = LoggerFactory.getLogger(DummyLeaderLatch.class);
+
+	private final LeaderLatch leaderLatch;
+	private final CuratorFramework curatorFramework;
+	private final AtomicBoolean leader = new AtomicBoolean(false);
+	private final LinkedList<Boolean> history = new LinkedList<>();
+
+	public DummyLeaderLatch(final String connectionString, final Timing timing, final String instanceId){
+
+		curatorFramework = CuratorFrameworkFactory.builder()
+				.retryPolicy(RETRY_POLICY)
+				.connectString(connectionString)
+				.sessionTimeoutMs(timing.session())
+				.connectionTimeoutMs(timing.connection())
+				.build();
+		leaderLatch = new LeaderLatch(curatorFramework, LATCH_PATH, instanceId);
+		leaderLatch.addListener(this);
+	}
+
+	public void start() throws Exception {
+		curatorFramework.start();
+		curatorFramework.blockUntilConnected();
+		createPath(LATCH_PATH);
+		leaderLatch.start();
+	}
+
+	/**
+	 * Starts the service and waits until the latch already has a leader that may be a different node.
+	 */
+	public void startAndAwaitElection() throws Exception {
+		start();
+		existsLeader();
+	}
+
+	public void awaitElection() throws Exception {
+		while (!existsLeader()) {
+			Thread.sleep(100L);
+		}
+	}
+
+	public void awaitLeadershipLost() throws Exception {
+		while (existsLeader()) {
+			Thread.sleep(100L);
+		}
+	}
+
+	private boolean existsLeader() throws Exception {
+		for (Participant participant : leaderLatch.getParticipants()) {
+			if (participant.isLeader()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+
+	public void stop() throws IOException {
+		leaderLatch.close();
+		curatorFramework.close();
+	}
+
+	@Override
+	public void isLeader() {
+		synchronized (this){
+			leader.set(true);
+			history.add(true);
+		}
+	}
+
+	@Override
+	public void notLeader() {
+		synchronized (this){
+			leader.set(false);
+			history.add(false);
+		}
+	}
+
+	public boolean isLeaderAccordingToEvents(){
+		return leader.get();
+	}
+
+	public boolean isLeaderAccordingToLatch(){
+		return leaderLatch.hasLeadership();
+	}
+
+	public List<Boolean> getEventHistory(){
+		return history;
+	}
+
+	/**
+	 * Synchronously creates all nodes in a path in ZooKeeper if they don't exist.
+	 * <p>
+	 * All API calls provided by Curator for path creation with parents do async
+	 *
+	 * @param path the path
+	 */
+	private void createPath(final String path) throws Exception {
+		final String[] split = path.split("/");
+		final StringBuilder stringBuilder = new StringBuilder("/");
+		for (final String s : split) {
+			if (!s.isEmpty()) {
+				stringBuilder.append(s);
+				try {
+					final String partial = stringBuilder.toString();
+					curatorFramework.create().forPath(partial);
+				} catch (final KeeperException.NodeExistsException ex) {
+					LOGGER.debug("Node " + stringBuilder.toString() + " already existed " + ex);
+				}
+				stringBuilder.append('/');
+			}
+		}
+	}
+}

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/testing/DummyLeaderLatch.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/testing/DummyLeaderLatch.java
@@ -18,6 +18,8 @@
  */
 package org.apache.curator.framework.recipes.leader.testing;
 
+import static org.apache.curator.framework.recipes.leader.LeaderLatch.CloseMode.NOTIFY_LEADER;
+
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
@@ -83,7 +85,7 @@ public class DummyLeaderLatch implements LeaderLatchListener{
 				.sessionTimeoutMs(sessionTimeoutMs)
 				.connectionTimeoutMs(connectionTimeoutMs)
 				.build();
-		leaderLatch = new LeaderLatch(curatorFramework, LATCH_PATH, instanceId);
+		leaderLatch = new LeaderLatch(curatorFramework, LATCH_PATH, instanceId, NOTIFY_LEADER);
 		leaderLatch.addListener(this);
 	}
 

--- a/curator-test-zk34/pom.xml
+++ b/curator-test-zk34/pom.xml
@@ -132,6 +132,11 @@
             <artifactId>commons-math</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This ensures that not two nodes are simultaneusly as leaders. 

If setLeadership(false) is redundant no event would be reported anyway so it is quite safe.