### PR TITLE
[CURATOR-447] TreeCache: Improve memory usage and concurrent update logic

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
@@ -442,7 +442,7 @@ public class TreeCache implements Closeable
                     {
                         final ChildData oldChildData = childData;
                         // Ignore this event if we've already processed a newer update for this node.
-                        if ( (isLive(oldChildData) && newStat.getMzxid() <= oldChildData.getStat().getMzxid()) )
+                        if ( isLive(oldChildData) && newStat.getMzxid() <= oldChildData.getStat().getMzxid() )
                         {
                             break;
                         }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
@@ -207,7 +207,8 @@ public class TreeCache implements Closeable
 
     private final class TreeNode extends AtomicReference<ChildData> implements Watcher, BackgroundCallback
     {
-
+        private static final long serialVersionUID = 4736888003207088181L;
+        
         final TreeNode parent;
         final String path;
         volatile ConcurrentMap<String, TreeNode> children;
@@ -813,11 +814,6 @@ public class TreeCache implements Closeable
         publishEvent(new TreeCacheEvent(type, null));
     }
 
-    private void publishEvent(TreeCacheEvent.Type type, String path)
-    {
-        publishEvent(new TreeCacheEvent(type, new ChildData(path, null, null)));
-    }
-
     private void publishEvent(TreeCacheEvent.Type type, ChildData data)
     {
         publishEvent(new TreeCacheEvent(type, data));
@@ -833,16 +829,14 @@ public class TreeCache implements Closeable
                 @Override
                 public void run()
                 {
+                    try
                     {
-                        try
-                        {
-                            callListeners(event);
-                        }
-                        catch ( Exception e )
-                        {
-                            ThreadUtils.checkInterrupted(e);
-                            handleException(e);
-                        }
+                        callListeners(event);
+                    }
+                    catch ( Exception e )
+                    {
+                        ThreadUtils.checkInterrupted(e);
+                        handleException(e);
                     }
                 }
             });


### PR DESCRIPTION
Jira https://issues.apache.org/jira/browse/CURATOR-374 reduced per-node memory usage in `TreeCache`. It can be improved further via removal of the `nodeState` field - its `LIVE` state corresponds exactly to the adjacent `childData` field being non-null, and a sentinel `ChildData` value can be used for the `DEAD` state. This simplification also reduces the room for bugs and state inconsistencies.

Other improvements included:
* More robust cache update logic (in get-children and get-data event callbacks)
* ~~A further simplification to have `TreeNode` extend `AtomicReference`, which obviates the need for an explicit `childData` field~~
* ~~Avoid overhead of incrementing/decrementing the `outstandingOps` atomic integer post-initialization~~

See corresponding JIRA: [CURATOR-447](https://issues.apache.org/jira/browse/CURATOR-447)
  