### PR TITLE
[CURATOR-450] Fix dead link in 'Getting Started' documentation

### DIFF
--- a/src/site/confluence/errors.confluence
+++ b/src/site/confluence/errors.confluence
@@ -3,7 +3,7 @@ h1. Error Handling
 h2. Background
 ZooKeeper is a very low level system that requires users to do a lot of housekeeping. See:
 
-* [[http://wiki.apache.org/hadoop/ZooKeeper/FAQ]]
+* [[https://wiki.apache.org/hadoop/ZooKeeper/FAQ]]
 
 The Curator [[Framework|curator-framework/index.html]] is designed to hide as much of the details/tedium of this housekeeping as is possible.
 
@@ -23,7 +23,7 @@ Curator exposes several listenable interfaces for clients to monitor the state o
 appropriate action. These are the possible state changes:
 
 |CONNECTED|Sent for the first successful connection to the server. NOTE: You will only get one of these messages for any CuratorFramework instance.|
-|READ_ONLY|The connection has gone into read\-only mode. This can only happen if you pass true for CuratorFrameworkFactory.Builder.canBeReadOnly(). See the ZooKeeper doc regarding read only connections: [[http://wiki.apache.org/hadoop/ZooKeeper/GSoCReadOnlyMode]]. The connection will remain in read only mode until another state change is sent.|
+|READ_ONLY|The connection has gone into read\-only mode. This can only happen if you pass true for CuratorFrameworkFactory.Builder.canBeReadOnly(). See the ZooKeeper doc regarding read only connections: [[https://wiki.apache.org/hadoop/ZooKeeper/GSoCReadOnlyMode]]. The connection will remain in read only mode until another state change is sent.|
 |SUSPENDED|There has been a loss of connection. Leaders, locks, etc. should suspend until the connection is re\-established.|
 |RECONNECTED|A suspended or lost connection has been re\-established.|
 |LOST|Curator will set the LOST state when it believes that the ZooKeeper session has expired. ZooKeeper connections have a session. When the session expires, clients must take appropriate action. In Curator, this is complicated by the fact that Curator internally manages the ZooKeeper connection. Curator will set the LOST state when any of the following occurs: a) ZooKeeper returns a Watcher.Event.KeeperState.Expired or KeeperException.Code.SESSIONEXPIRED; b) Curator closes the internally managed ZooKeeper instance; c) The session timeout elapses during a network partition. It is possible to get a RECONNECTED state after this but you should still consider any locks, etc. as dirty/unstable. *NOTE*: The meaning of LOST has changed since Curator 3.0.0. Prior to 3.0.0 LOST only meant that the retry policy had expired.|

--- a/src/site/confluence/getting-started.confluence
+++ b/src/site/confluence/getting-started.confluence
@@ -2,7 +2,7 @@ h1. Getting Started
 
 h2. Learn ZooKeeper
 
-Curator users are assumed to know ZooKeeper. A good place to start is here: [[http://zookeeper.apache.org/doc/trunk/zookeeperStarted.html]]
+Curator users are assumed to know ZooKeeper. A good place to start is here: [[https://zookeeper.apache.org/doc/current/zookeeperStarted.html]]
 
 h2. Using Curator
 
@@ -14,7 +14,7 @@ want a wrapper around ZooKeeper that adds connection management and retry polici
 
 h2. Getting a Connection
 
-Curator uses [[Fluent Style|http://en.wikipedia.org/wiki/Fluent%5Finterface]]. If you haven't used this before, it might seem odd
+Curator uses [[Fluent Style|https://en.wikipedia.org/wiki/Fluent%5Finterface]]. If you haven't used this before, it might seem odd
 so it's suggested that you familiarize yourself with the style.
 
 Curator connection instances ({{CuratorFramework}}) are allocated from the {{CuratorFrameworkFactory}}. You only need *one*

--- a/src/site/confluence/logging.confluence
+++ b/src/site/confluence/logging.confluence
@@ -5,7 +5,7 @@ Curator is logging and tracing neutral. The Curator code is instrumented with lo
 but uses a driver mechanism that allows easy integration into your preferred logging and tracing frameworks.
 
 h2. Logging
-Curator uses SLF4J ([[http://www.slf4j.org/]]) for logging. SLF4J is a facade over logging that allows you to
+Curator uses SLF4J ([[https://www.slf4j.org/]]) for logging. SLF4J is a facade over logging that allows you to
 plug in any (or no) logging framework. See the SLF4J website for details.
 
 h2. Tracing


### PR DESCRIPTION
with protocol update for apache.org, slf4j.org and wikipedia.org.