### PR TITLE
changed phase of maven-license-plugin to validate 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -758,6 +758,7 @@
                 <executions>
                     <execution>
                         <id>license</id>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
changed phase of maven-license-plugin to validate in order to avoid compilation and testing of invalid code (fail as early as possible)