### PR TITLE
replace raw Exception thrown by CompressionProvider.compress and decompress with IOException

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/api/CompressionProvider.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/CompressionProvider.java
@@ -18,9 +18,11 @@
  */
 package org.apache.curator.framework.api;
 
+import java.io.IOException;
+
 public interface CompressionProvider
 {
-    public byte[]       compress(String path, byte[] data) throws Exception;
+    public byte[]       compress(String path, byte[] data) throws IOException;
 
-    public byte[]       decompress(String path, byte[] compressedData) throws Exception;
+    public byte[]       decompress(String path, byte[] compressedData) throws IOException;
 }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompression.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompression.java
@@ -30,6 +30,7 @@ import org.apache.curator.framework.api.CompressionProvider;
 import org.apache.curator.retry.RetryOneTime;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestCompression extends BaseClassForTests
@@ -44,7 +45,7 @@ public class TestCompression extends BaseClassForTests
         CompressionProvider     compressionProvider = new CompressionProvider()
         {
             @Override
-            public byte[] compress(String path, byte[] data) throws Exception
+            public byte[] compress(String path, byte[] data) throws IOException
             {
                 compressCounter.incrementAndGet();
 
@@ -55,7 +56,7 @@ public class TestCompression extends BaseClassForTests
             }
 
             @Override
-            public byte[] decompress(String path, byte[] compressedData) throws Exception
+            public byte[] decompress(String path, byte[] compressedData) throws IOException
             {
                 decompressCounter.incrementAndGet();
 


### PR DESCRIPTION
Throwing a raw `Exception` almost always indicates a design error (there's a lot of them in the project). It makes sense to replace `throws Exception` with the real exceptions thrown over time. This is the first stop.

PRs like #78 indicate that strange if not wrong understanding of exceptions and their treatment in `catch` blocks. Except for some example classes with `main` methods you never want to do something like `catch(Exception ex) {ex.printStackTrace()}`. If `Callable.call` is involved throwing `Exception` is a very bad approach as well and the fact that it throws `Exception` is no reason to throw it from the method calling `Callable.call`. In this case the exception needs to be wrapped into a custom type.