### PR TITLE
[CURATOR-452] Fix race condition on cache in ServiceCacheImpl

### DIFF
--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceCacheImpl.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceCacheImpl.java
@@ -93,7 +93,9 @@ public class ServiceCacheImpl<T> implements ServiceCache<T>, PathChildrenCacheLi
         cache.start(true);
         for ( ChildData childData : cache.getCurrentData() )
         {
-            addInstance(childData, true);
+            if ( childData.getData() != null ) {
+                addInstance(childData, true);
+            } // Otherwise, cache data has already been cleared
         }
         discovery.cacheOpened(this);
     }

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceCacheImpl.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceCacheImpl.java
@@ -1,0 +1,104 @@
+package org.apache.curator.x.discovery.details;
+
+import com.google.common.collect.Lists;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by wei.w on 4/2/18.
+ */
+public class TestServiceCacheImpl extends BaseClassForTests {
+
+    public void testInitialLoadRaceCondition(boolean oldApi) throws Exception {
+
+        List<Closeable> closeables = Lists.newArrayList();
+        try {
+            CuratorFramework initClient = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+            closeables.add(initClient);
+            initClient.start();
+
+            ServiceDiscovery<String> initDiscovery = ServiceDiscoveryBuilder.builder(String.class).basePath("/discovery").client(initClient).build();
+            closeables.add(initDiscovery);
+            initDiscovery.start();
+
+            ServiceInstance<String> instance1 = ServiceInstance.<String>builder().payload("test").name("test").port(10064).build();
+            ServiceInstance<String> instance2 = ServiceInstance.<String>builder().payload("test").name("test").port(10065).build();
+            ServiceInstance<String> instance3 = ServiceInstance.<String>builder().payload("test").name("test").port(10066).build();
+            initDiscovery.registerService(instance1);
+            initDiscovery.registerService(instance2);
+            initDiscovery.registerService(instance3);
+
+
+            CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+            closeables.add(client);
+
+            ServiceDiscovery<String> discovery = ServiceDiscoveryBuilder.builder(String.class).basePath("/discovery").client(client).build();
+            closeables.add(discovery);
+            discovery.start();
+
+            ServiceCacheImpl cache = (ServiceCacheImpl) discovery.serviceCacheBuilder().name("test").build();
+            closeables.add(cache);
+
+            final CountDownLatch latch = new CountDownLatch(3);
+
+            ServiceCacheListener listener = new ServiceCacheListener() {
+                @Override
+                public void cacheChanged() {
+                    latch.countDown();
+
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException e) {
+                    }
+                }
+
+                @Override
+                public void stateChanged(CuratorFramework client, ConnectionState newState) {
+                }
+            };
+            cache.addListener(listener);
+            client.start();
+
+            cache.startCache();
+            Assert.assertTrue(latch.await(300, TimeUnit.SECONDS));
+            if (oldApi) {
+                cache.oldLloadCacheData();
+            } else {
+                cache.loadCacheData();
+            }
+        } finally {
+            Collections.reverse(closeables);
+            for (Closeable c : closeables) {
+                CloseableUtils.closeQuietly(c);
+            }
+        }
+    }
+
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testInitialLoadRaceConditionOldApi() throws Exception {
+        testInitialLoadRaceCondition(true);
+
+    }
+
+    @Test
+    public void testInitialLoadRaceConditionNewApi() throws Exception {
+        testInitialLoadRaceCondition(false);
+    }
+
+}


### PR DESCRIPTION
There is a race condition on variable cache, both the main thread(from start) and the "Curator-ServiceProvider" thread(from childEvent-> addInstance->cache.clearDataBytes) try to access the data in cache.
The following case will cause NPE in sonInstanceSerializer:
1. Main thread finishes the cache.start(true);
2. Then an event(CHILD_ADDED or CHILD_UPDATED) comes, it(Curator-ServiceProvider thread) will try to clear the cache data(in addInstance).
3. Main thread continues to call addInstance on cached data, which is null. It will cause NPE on line 193.

I think this is the cause of https://stackoverflow.com/questions/42007102/apache-curator-npe-in-jsoninstanceserializer .
And it causes the druid-0.11.0 indexing tasks fail to start(https://groups.google.com/forum/#!topic/druid-user/3L7MvwNYHnU).
`
2018-03-22T12:44:17,004 ERROR [main] io.druid.cli.CliPeon - Error when starting up.  Failing.
java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_121]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_121]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_121]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_121]
        at io.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler.start(Lifecycle.java:414) ~[java-util-0.11.0.jar:0.11.0]
        at io.druid.java.util.common.lifecycle.Lifecycle.start(Lifecycle.java:311) ~[java-util-0.11.0.jar:0.11.0]
        at io.druid.guice.LifecycleModule$2.start(LifecycleModule.java:156) ~[druid-api-0.11.0.jar:0.11.0]
        at io.druid.cli.GuiceRunnable.initLifecycle(GuiceRunnable.java:101) [druid-services-0.11.0.jar:0.11.0]
        at io.druid.cli.CliPeon.run(CliPeon.java:283) [druid-services-0.11.0.jar:0.11.0]
        at io.druid.cli.Main.main(Main.java:108) [druid-services-0.11.0.jar:0.11.0]
Caused by: java.lang.NullPointerException
        at org.codehaus.jackson.JsonFactory.createJsonParser(JsonFactory.java:604) ~[jackson-core-asl-1.9.13.jar:1.9.13]
        at org.codehaus.jackson.map.ObjectMapper.readValue(ObjectMapper.java:1973) ~[jackson-mapper-asl-1.9.13.jar:1.9.13]
        at org.apache.curator.x.discovery.details.JsonInstanceSerializer.deserialize(JsonInstanceSerializer.java:86) ~[curator-x-discovery-4.0.0.jar:?]
        at org.apache.curator.x.discovery.details.ServiceCacheImpl.addInstance(ServiceCacheImpl.java:200) ~[curator-x-discovery-4.0.0.jar:?]
        at org.apache.curator.x.discovery.details.ServiceCacheImpl.start(ServiceCacheImpl.java:102) ~[curator-x-discovery-4.0.0.jar:?]
        at org.apache.curator.x.discovery.details.ServiceProviderImpl.start(ServiceProviderImpl.java:75) ~[curator-x-discovery-4.0.0.jar:?]
        at io.druid.curator.discovery.ServerDiscoverySelector.start(ServerDiscoverySelector.java:132) ~[druid-server-0.11.0.jar:0.11.0]
        ... 10 more
`
