### PR TITLE
CURATOR-408 Handle graceful close of ZookKeeper client waiting for all resources to be released

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/ConnectionState.java
+++ b/curator-client/src/main/java/org/apache/curator/ConnectionState.java
@@ -112,14 +112,17 @@ class ConnectionState implements Watcher, Closeable
     }
 
     @Override
-    public void close() throws IOException
-    {
+    public void close() throws IOException {
+        close(0);
+    }
+    
+    public void close(int waitForShutdownTimeoutMs) throws IOException {
         log.debug("Closing");
 
         CloseableUtils.closeQuietly(ensembleProvider);
         try
         {
-            zooKeeper.closeAndClear();
+            zooKeeper.closeAndClear(waitForShutdownTimeoutMs);
         }
         catch ( Exception e )
         {

--- a/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
+++ b/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
@@ -52,7 +52,7 @@ public class CuratorZookeeperClient implements Closeable
     private final ConnectionState state;
     private final AtomicReference<RetryPolicy> retryPolicy = new AtomicReference<RetryPolicy>();
     private final int connectionTimeoutMs;
-    private final int defaultWaitForShutdownTimeoutMs;
+    private final int waitForShutdownTimeoutMs;
     private final AtomicBoolean started = new AtomicBoolean(false);
     private final AtomicReference<TracerDriver> tracer = new AtomicReference<TracerDriver>(new DefaultTracerDriver());
     private final ConnectionHandlingPolicy connectionHandlingPolicy;
@@ -146,7 +146,7 @@ public class CuratorZookeeperClient implements Closeable
         ensembleProvider = Preconditions.checkNotNull(ensembleProvider, "ensembleProvider cannot be null");
 
         this.connectionTimeoutMs = connectionTimeoutMs;
-        this.defaultWaitForShutdownTimeoutMs = defaultWaitForShutdownTimeoutMs;
+        this.waitForShutdownTimeoutMs = defaultWaitForShutdownTimeoutMs;
         state = new ConnectionState(zookeeperFactory, ensembleProvider, sessionTimeoutMs, connectionTimeoutMs, watcher, tracer, canBeReadOnly, connectionHandlingPolicy);
         setRetryPolicy(retryPolicy);
     }
@@ -240,13 +240,13 @@ public class CuratorZookeeperClient implements Closeable
     /**
      * Close the client.
      *
-     * Same as {@link #close(int) } using the default timeout set at construction time.
+     * Same as {@link #close(int) } using the timeout set at construction time.
      *
      * @see #close(int)
      */
     @Override
     public void close() {
-        close(defaultWaitForShutdownTimeoutMs);
+        close(waitForShutdownTimeoutMs);
     }
             
     /**

--- a/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
+++ b/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
@@ -122,7 +122,7 @@ public class CuratorZookeeperClient implements Closeable
      * @param ensembleProvider the ensemble provider
      * @param sessionTimeoutMs session timeout
      * @param connectionTimeoutMs connection timeout
-     * @param defaultWaitForShutdownTimeoutMs default timeout fo close operation
+     * @param waitForShutdownTimeoutMs default timeout fo close operation
      * @param watcher default watcher or null
      * @param retryPolicy the retry policy to use
      * @param canBeReadOnly if true, allow ZooKeeper client to enter
@@ -133,7 +133,7 @@ public class CuratorZookeeperClient implements Closeable
      * @since 4.0.2
      */
     public CuratorZookeeperClient(ZookeeperFactory zookeeperFactory, EnsembleProvider ensembleProvider,
-            int sessionTimeoutMs, int connectionTimeoutMs, int defaultWaitForShutdownTimeoutMs, Watcher watcher,
+            int sessionTimeoutMs, int connectionTimeoutMs, int waitForShutdownTimeoutMs, Watcher watcher,
             RetryPolicy retryPolicy, boolean canBeReadOnly, ConnectionHandlingPolicy connectionHandlingPolicy)
     {
         this.connectionHandlingPolicy = connectionHandlingPolicy;
@@ -146,7 +146,7 @@ public class CuratorZookeeperClient implements Closeable
         ensembleProvider = Preconditions.checkNotNull(ensembleProvider, "ensembleProvider cannot be null");
 
         this.connectionTimeoutMs = connectionTimeoutMs;
-        this.waitForShutdownTimeoutMs = defaultWaitForShutdownTimeoutMs;
+        this.waitForShutdownTimeoutMs = waitForShutdownTimeoutMs;
         state = new ConnectionState(zookeeperFactory, ensembleProvider, sessionTimeoutMs, connectionTimeoutMs, watcher, tracer, canBeReadOnly, connectionHandlingPolicy);
         setRetryPolicy(retryPolicy);
     }

--- a/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
+++ b/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
@@ -213,18 +213,29 @@ public class CuratorZookeeperClient implements Closeable
 
         state.start();
     }
-
+    
     /**
      * Close the client
      */
-    public void close()
+    public void close() {
+        close(0);
+    }
+            
+    /**
+     * Close this client object as the {@link #close() } method.
+     * This method will wait for internal resources to be released.
+     * 
+     * @param waitForShutdownTimeoutMs timeout (in milliseconds) to wait for resources to be released.
+     *                  Use zero or a negative value to skip the wait.
+     */
+    public void close(int waitForShutdownTimeoutMs)
     {
-        log.debug("Closing");
+        log.debug("Closing, waitForShutdownTimeoutMs {}", waitForShutdownTimeoutMs);
 
         started.set(false);
         try
         {
-            state.close();
+            state.close(waitForShutdownTimeoutMs);
         }
         catch ( IOException e )
         {

--- a/curator-client/src/main/java/org/apache/curator/HandleHolder.java
+++ b/curator-client/src/main/java/org/apache/curator/HandleHolder.java
@@ -73,9 +73,9 @@ class HandleHolder
         return ((helperConnectionString != null) && !ensembleProvider.getConnectionString().equals(helperConnectionString)) ? helperConnectionString : null;
     }
 
-    void closeAndClear(int timeout) throws Exception
+    void closeAndClear(int waitForShutdownTimeoutMs) throws Exception
     {
-        internalClose(timeout);
+        internalClose(waitForShutdownTimeoutMs);
         helper = null;
     }
 

--- a/curator-client/src/main/java/org/apache/curator/HandleHolder.java
+++ b/curator-client/src/main/java/org/apache/curator/HandleHolder.java
@@ -73,15 +73,15 @@ class HandleHolder
         return ((helperConnectionString != null) && !ensembleProvider.getConnectionString().equals(helperConnectionString)) ? helperConnectionString : null;
     }
 
-    void closeAndClear() throws Exception
+    void closeAndClear(int timeout) throws Exception
     {
-        internalClose();
+        internalClose(timeout);
         helper = null;
     }
 
     void closeAndReset() throws Exception
     {
-        internalClose();
+        internalClose(0);
 
         // first helper is synchronized when getZooKeeper is called. Subsequent calls
         // are not synchronized.
@@ -140,7 +140,7 @@ class HandleHolder
         };
     }
 
-    private void internalClose() throws Exception
+    private void internalClose(int waitForShutdownTimeoutMs) throws Exception
     {
         try
         {
@@ -155,7 +155,7 @@ class HandleHolder
                     }
                 };
                 zooKeeper.register(dummyWatcher);   // clear the default watcher so that no new events get processed by mistake
-                zooKeeper.close();
+                zooKeeper.close(waitForShutdownTimeoutMs);
             }
         }
         catch ( InterruptedException dummy )

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
@@ -407,12 +407,12 @@ public class CuratorFrameworkFactory
          * The default is 0, which means that this feature is disabled.
          *
          * @since 4.0.2
-         * @param defaultWaitForShutdownTimeoutMs default timeout
+         * @param waitForShutdownTimeoutMs default timeout
          * @return this
          */
-        public Builder defaultWaitForShutdownTimeoutMs(int defaultWaitForShutdownTimeoutMs)
+        public Builder waitForShutdownTimeoutMs(int waitForShutdownTimeoutMs)
         {
-            this.waitForShutdownTimeoutMs = defaultWaitForShutdownTimeoutMs;
+            this.waitForShutdownTimeoutMs = waitForShutdownTimeoutMs;
             return this;
         }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import org.apache.curator.CuratorZookeeperClient;
 
 import static org.apache.curator.utils.Compatibility.isZK34;
 
@@ -147,7 +148,7 @@ public class CuratorFrameworkFactory
         private ConnectionHandlingPolicy connectionHandlingPolicy = new StandardConnectionHandlingPolicy();
         private SchemaSet schemaSet = SchemaSet.getDefaultSchemaSet();
         private boolean zk34CompatibilityMode = isZK34();
-
+        private int defaultWaitForShutdownTimeoutMs = 0;
         /**
          * Apply the current values and build a new CuratorFramework
          *
@@ -402,6 +403,20 @@ public class CuratorFrameworkFactory
         }
 
         /**
+         * Set a default timeout for {@link CuratorZookeeperClient#close() }.
+         * The default is 0, which means that this feature is disabled.
+         *
+         * @since 4.0.2
+         * @param defaultWaitForShutdownTimeoutMs default timeout
+         * @return this
+         */
+        public Builder defaultWaitForShutdownTimeoutMs(int defaultWaitForShutdownTimeoutMs)
+        {
+            this.defaultWaitForShutdownTimeoutMs = defaultWaitForShutdownTimeoutMs;
+            return this;
+        }
+
+        /**
          * <p>
          *     Change the connection handling policy. The default policy is {@link StandardConnectionHandlingPolicy}.
          * </p>
@@ -492,6 +507,11 @@ public class CuratorFrameworkFactory
         public int getConnectionTimeoutMs()
         {
             return connectionTimeoutMs;
+        }
+
+        public int getDefaultWaitForShutdownTimeoutMs()
+        {
+            return defaultWaitForShutdownTimeoutMs;
         }
 
         public int getMaxCloseWaitMs()

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
@@ -148,7 +148,7 @@ public class CuratorFrameworkFactory
         private ConnectionHandlingPolicy connectionHandlingPolicy = new StandardConnectionHandlingPolicy();
         private SchemaSet schemaSet = SchemaSet.getDefaultSchemaSet();
         private boolean zk34CompatibilityMode = isZK34();
-        private int defaultWaitForShutdownTimeoutMs = 0;
+        private int waitForShutdownTimeoutMs = 0;
         /**
          * Apply the current values and build a new CuratorFramework
          *
@@ -412,7 +412,7 @@ public class CuratorFrameworkFactory
          */
         public Builder defaultWaitForShutdownTimeoutMs(int defaultWaitForShutdownTimeoutMs)
         {
-            this.defaultWaitForShutdownTimeoutMs = defaultWaitForShutdownTimeoutMs;
+            this.waitForShutdownTimeoutMs = defaultWaitForShutdownTimeoutMs;
             return this;
         }
 
@@ -509,9 +509,9 @@ public class CuratorFrameworkFactory
             return connectionTimeoutMs;
         }
 
-        public int getDefaultWaitForShutdownTimeoutMs()
+        public int getWaitForShutdownTimeoutMs()
         {
-            return defaultWaitForShutdownTimeoutMs;
+            return waitForShutdownTimeoutMs;
         }
 
         public int getMaxCloseWaitMs()

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -122,7 +122,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
                 builder.getEnsembleProvider(),
                 builder.getSessionTimeoutMs(),
                 builder.getConnectionTimeoutMs(),
-                builder.getDefaultWaitForShutdownTimeoutMs(),
+                builder.getWaitForShutdownTimeoutMs(),
                 new Watcher()
                 {
                     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -122,6 +122,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
                 builder.getEnsembleProvider(),
                 builder.getSessionTimeoutMs(),
                 builder.getConnectionTimeoutMs(),
+                builder.getDefaultWaitForShutdownTimeoutMs(),
                 new Watcher()
                 {
                     @Override

--- a/curator-framework/src/test/java/org/apache/curator/framework/state/TestConnectionStateManager.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/state/TestConnectionStateManager.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.curator.framework.state;
 
 import com.google.common.collect.Queues;

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <jdk-version>1.7</jdk-version>
 
         <!-- versions -->
-        <zookeeper-version>3.5.3-beta</zookeeper-version>
+        <zookeeper-version>3.5.4-beta</zookeeper-version>
         <maven-project-info-reports-plugin-version>2.9</maven-project-info-reports-plugin-version>
         <maven-bundle-plugin-version>3.2.0</maven-bundle-plugin-version>
         <maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>


### PR DESCRIPTION
Add a new close(int timeout) API in order to leverage ZooKeeper#close(timeout) API introduced in ZK 4.5.4-BETA.

Summary of changes:
- bump ZK to 4.5.4-BETA
- add the implementation of the feature
- add a missing license header