### PR TITLE
A fix for double barrier timeout behavior, and an accompanying test

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/barriers/DistributedDoubleBarrier.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/barriers/DistributedDoubleBarrier.java
@@ -121,6 +121,10 @@ public class DistributedDoubleBarrier
         client.create().creatingParentContainersIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(ourPath);
 
         boolean         result = (readyPathExists || internalEnter(startMs, hasMaxWait, maxWaitMs));
+        if ( !result )
+        {
+            client.delete().deletingChildrenIfNeeded().forPath(ourPath);
+        }
         if ( connectionLost.get() )
         {
             throw new KeeperException.ConnectionLossException();


### PR DESCRIPTION
Assuming this is the desired behavior (ie once we timeout we are no longer considered to be in the barrier), this fix will work. By the time the method returns false, we will no longer be considered a member waiting at the barrier,