### PR TITLE
Support client timeouts < 1000ms

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
+++ b/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
@@ -428,9 +428,10 @@ public class CuratorZookeeperClient implements Closeable
 
             state.addParentWatcher(tempWatcher);
             long startTimeMs = System.currentTimeMillis();
+            long timeoutMs = Math.min(waitTimeMs, 1000);
             try
             {
-                latch.await(1, TimeUnit.SECONDS);
+                latch.await(timeoutMs, TimeUnit.MILLISECONDS);
             }
             finally
             {


### PR DESCRIPTION
Before, regardless of the value set in `connectionTimeoutMs` the
CuratorZookeeperClient#internalBlockUntilConnectedOrTimedOut method did
the initial wait with value of 1 second, which made settings lower than
this value ineffective. This proved problematic in several use cases
where such minimum for timeout is prohibitively large.