### PR TITLE
[CURATOR-477] add support for configuring Zk Watches

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
@@ -149,6 +149,7 @@ public class CuratorFrameworkFactory
         private SchemaSet schemaSet = SchemaSet.getDefaultSchemaSet();
         private boolean zk34CompatibilityMode = isZK34();
         private int waitForShutdownTimeoutMs = 0;
+        private boolean createZkWatches = true;
         /**
          * Apply the current values and build a new CuratorFramework
          *
@@ -364,6 +365,17 @@ public class CuratorFrameworkFactory
         }
 
         /**
+         * @param createZkWatches if true, creates watchers in {@link ZooKeeper} so that they are tracked.
+         * @return this
+         */
+        public Builder createZookeeperWatches(boolean createZkWatches)
+        {
+            this.createZkWatches = createZkWatches;
+            return this;
+        }
+
+
+        /**
          * By default, Curator uses {@link CreateBuilder#creatingParentContainersIfNeeded()}
          * if the ZK JAR supports {@link CreateMode#CONTAINER}. Call this method to turn off this behavior.
          *
@@ -552,6 +564,10 @@ public class CuratorFrameworkFactory
         public boolean isZk34CompatibilityMode()
         {
             return zk34CompatibilityMode;
+        }
+
+        public boolean shouldCreateZkWatches() {
+            return createZkWatches;
         }
 
         @Deprecated

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -100,6 +100,8 @@ public class CuratorFrameworkImpl implements CuratorFramework
     private volatile ExecutorService executorService;
     private final AtomicBoolean logAsErrorConnectionErrors = new AtomicBoolean(false);
 
+    private final boolean createZkWatches;
+
     private static final boolean LOG_ALL_CONNECTION_ISSUES_AS_ERROR_LEVEL = !Boolean.getBoolean(DebugUtils.PROPERTY_LOG_ONLY_FIRST_CONNECTION_ISSUE_AS_ERROR_LEVEL);
 
     interface DebugBackgroundListener
@@ -163,6 +165,9 @@ public class CuratorFrameworkImpl implements CuratorFramework
         namespaceFacadeCache = new NamespaceFacadeCache(this);
 
         ensembleTracker = zk34CompatibilityMode ? null : new EnsembleTracker(this, builder.getEnsembleProvider());
+
+        createZkWatches = builder.shouldCreateZkWatches();
+
     }
 
     private List<AuthInfo> buildAuths(CuratorFrameworkFactory.Builder builder)
@@ -240,6 +245,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
         schemaSet = parent.schemaSet;
         zk34CompatibilityMode = parent.zk34CompatibilityMode;
         ensembleTracker = null;
+        createZkWatches = parent.createZkWatches;
     }
 
     @Override
@@ -434,14 +440,14 @@ public class CuratorFrameworkImpl implements CuratorFramework
     public ExistsBuilder checkExists()
     {
         checkState();
-        return new ExistsBuilderImpl(this);
+        return new ExistsBuilderImpl(this, createZkWatches);
     }
 
     @Override
     public GetDataBuilder getData()
     {
         checkState();
-        return new GetDataBuilderImpl(this);
+        return new GetDataBuilderImpl(this, createZkWatches);
     }
 
     @Override
@@ -455,7 +461,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
     public GetChildrenBuilder getChildren()
     {
         checkState();
-        return new GetChildrenBuilderImpl(this);
+        return new GetChildrenBuilderImpl(this, createZkWatches);
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
@@ -101,7 +101,9 @@ public class ExistsBuilderImpl implements ExistsBuilder, BackgroundOperation<Str
     @Override
     public BackgroundPathable<Stat> usingWatcher(Watcher watcher)
     {
-        watching = new Watching(client, watcher);
+        if (createZkWatches) {
+            watching = new Watching(client, watcher);
+        }
         return this;
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
@@ -40,13 +40,24 @@ public class ExistsBuilderImpl implements ExistsBuilder, BackgroundOperation<Str
     private boolean createParentsIfNeeded;
     private boolean createParentContainersIfNeeded;
     private ACLing acling;
+    private boolean createZkWatches;
 
     ExistsBuilderImpl(CuratorFrameworkImpl client)
     {
         this(client, new Backgrounding(), null, false, false);
     }
 
+    ExistsBuilderImpl(CuratorFrameworkImpl client, boolean createZkWatches)
+    {
+        this(client, new Backgrounding(), null, false, false);
+    }
+
     public ExistsBuilderImpl(CuratorFrameworkImpl client, Backgrounding backgrounding, Watcher watcher, boolean createParentsIfNeeded, boolean createParentContainersIfNeeded)
+    {
+        this(client, backgrounding, watcher, createParentsIfNeeded, createParentContainersIfNeeded, true);
+    }
+
+    ExistsBuilderImpl(CuratorFrameworkImpl client, Backgrounding backgrounding, Watcher watcher, boolean createParentsIfNeeded, boolean createParentContainersIfNeeded, boolean createZkWatches)
     {
         this.client = client;
         this.backgrounding = backgrounding;
@@ -54,6 +65,7 @@ public class ExistsBuilderImpl implements ExistsBuilder, BackgroundOperation<Str
         this.createParentsIfNeeded = createParentsIfNeeded;
         this.createParentContainersIfNeeded = createParentContainersIfNeeded;
         this.acling = new ACLing(client.getAclProvider());
+        this.createZkWatches = createZkWatches;
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
@@ -44,6 +44,7 @@ public class GetChildrenBuilderImpl implements GetChildrenBuilder, BackgroundOpe
     private Watching watching;
     private Backgrounding backgrounding;
     private Stat                                    responseStat;
+    private boolean createZkWatches;
 
     GetChildrenBuilderImpl(CuratorFrameworkImpl client)
     {
@@ -51,6 +52,16 @@ public class GetChildrenBuilderImpl implements GetChildrenBuilder, BackgroundOpe
         watching = new Watching(client);
         backgrounding = new Backgrounding();
         responseStat = null;
+        createZkWatches = true;
+    }
+
+    GetChildrenBuilderImpl(CuratorFrameworkImpl client, boolean createZkWatches)
+    {
+        this.client = client;
+        watching = new Watching(client);
+        backgrounding = new Backgrounding();
+        responseStat = null;
+        this.createZkWatches = createZkWatches;
     }
 
     public GetChildrenBuilderImpl(CuratorFrameworkImpl client, Watcher watcher, Backgrounding backgrounding, Stat responseStat)
@@ -59,6 +70,7 @@ public class GetChildrenBuilderImpl implements GetChildrenBuilder, BackgroundOpe
         this.watching = new Watching(client, watcher);
         this.backgrounding = backgrounding;
         this.responseStat = responseStat;
+        this.createZkWatches = true;
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
@@ -167,8 +167,10 @@ public class GetChildrenBuilderImpl implements GetChildrenBuilder, BackgroundOpe
     @Override
     public BackgroundPathable<List<String>> usingWatcher(Watcher watcher)
     {
-        watching = new Watching(client, watcher);
-        return this;
+       if (createZkWatches) {
+           watching = new Watching(client, watcher);
+       }
+       return this;
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
@@ -40,6 +40,7 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
     private Watching                    watching;
     private Backgrounding               backgrounding;
     private boolean                     decompress;
+    private boolean                     createZkWatches;
 
     GetDataBuilderImpl(CuratorFrameworkImpl client)
     {
@@ -48,6 +49,17 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
         watching = new Watching(client);
         backgrounding = new Backgrounding();
         decompress = false;
+        createZkWatches = true;
+    }
+
+    GetDataBuilderImpl(CuratorFrameworkImpl client, boolean createZkWatches)
+    {
+        this.client = client;
+        responseStat = null;
+        watching = new Watching(client);
+        backgrounding = new Backgrounding();
+        decompress = false;
+        this.createZkWatches = createZkWatches;
     }
 
     public GetDataBuilderImpl(CuratorFrameworkImpl client, Stat responseStat, Watcher watcher, Backgrounding backgrounding, boolean decompress)
@@ -57,6 +69,8 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
         this.watching = new Watching(client, watcher);
         this.backgrounding = backgrounding;
         this.decompress = decompress;
+        this.createZkWatches = true;
+
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
@@ -241,8 +241,10 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
     @Override
     public BackgroundPathable<byte[]> usingWatcher(Watcher watcher)
     {
-        watching = new Watching(client, watcher);
-        return this;
+       if (createZkWatches) {
+           watching = new Watching(client, watcher);
+       }
+       return this;
     }
 
     @Override


### PR DESCRIPTION
In our use case, we use `TreeCache` to get Zk Data periodically. We start `TreeCache` read data and close it. In this use case, The `ZkWatchManager` of `ZooKeeper` class keeps growing for every TreeCache operation because new `TreeNode` objects are created and added there leading to a memory leak. Also since we do not want the Watcher to periodically watch, this creates  unnecessary background operations.

In this PR, Made the createZkWatches configurable in the Builder, so that use cases like ours can set it to false. The default is true, retaining the current behaviour.