### PR TITLE
[CURATOR-477] added support for turning off zk watches

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
@@ -347,7 +347,11 @@ public class TreeCache implements Closeable
             if ( parent == null )
             {
                 // Root node; use an exist query to watch for existence.
-                client.checkExists().usingWatcher(this).inBackground(this).forPath(path);
+                if (disableZkWatches) {
+                    client.checkExists().forPath(path);
+                } else {
+                    client.checkExists().usingWatcher(this).inBackground(this).forPath(path);
+                }
             }
             else
             {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
@@ -347,11 +347,7 @@ public class TreeCache implements Closeable
             if ( parent == null )
             {
                 // Root node; use an exist query to watch for existence.
-                if (disableZkWatches) {
-                    client.checkExists().forPath(path);
-                } else {
-                    client.checkExists().usingWatcher(this).inBackground(this).forPath(path);
-                }
+                maybeWatch(client.checkExists()).forPath(path);
             }
             else
             {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
@@ -19,28 +19,11 @@
 
 package org.apache.curator.framework.recipes.cache;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.apache.curator.utils.PathUtils.validatePath;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.WatcherRemoveCuratorFramework;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -62,6 +45,23 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.curator.utils.PathUtils.validatePath;
 
 /**
  * <p>A utility that attempts to keep all data from all children of a ZK path locally cached. This class

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/TreeCache.java
@@ -173,7 +173,7 @@ public class TreeCache implements Closeable
         /**
          * By default, TreeCache creates {@link org.apache.zookeeper.ZooKeeper} watches for every created path.
          * Change this behavior with this method.
-         * @param disableZkWatches false to create watches
+         * @param disableZkWatches true to disable zk watches
          * @return this for chaining
          */
         public Builder disableZkWatches(boolean disableZkWatches)
@@ -572,7 +572,7 @@ public class TreeCache implements Closeable
      */
     public TreeCache(CuratorFramework client, String path)
     {
-        this(client, path, true, false, Integer.MAX_VALUE, Executors.newSingleThreadExecutor(defaultThreadFactory), false, true, new DefaultTreeCacheSelector());
+        this(client, path, true, false, Integer.MAX_VALUE, Executors.newSingleThreadExecutor(defaultThreadFactory), false, false, new DefaultTreeCacheSelector());
     }
 
     /**
@@ -582,7 +582,7 @@ public class TreeCache implements Closeable
      * @param dataIsCompressed if true, data in the path is compressed
      * @param executorService  Closeable ExecutorService to use for the TreeCache's background thread
      * @param createParentNodes true to create parent nodes as containers
-     * @param disableZkWatches false to create Zookeeper watches
+     * @param disableZkWatches true to disable Zookeeper watches
      * @param selector         the selector to use
      */
     TreeCache(CuratorFramework client, String path, boolean cacheData, boolean dataIsCompressed, int maxDepth, final ExecutorService executorService, boolean createParentNodes, boolean disableZkWatches, TreeCacheSelector selector)

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCache.java
@@ -468,6 +468,31 @@ public class TestTreeCache extends BaseTestTreeCache
     }
 
     @Test
+    public void testBasicsWithNoZkWatches() throws Exception
+    {
+        client.create().forPath("/test");
+        client.create().forPath("/test/one", "hey there".getBytes());
+
+
+        cache = buildWithListeners(TreeCache.newBuilder(client, "/test").setCreateZkWatches(false));
+
+        cache.start();
+        assertEvent(TreeCacheEvent.Type.NODE_ADDED, "/test");
+        assertEvent(TreeCacheEvent.Type.NODE_ADDED, "/test/one");
+
+        assertEvent(TreeCacheEvent.Type.INITIALIZED);
+        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
+        Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
+        Assert.assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
+        Assert.assertNull(cache.getCurrentChildren("/test/o"));
+        Assert.assertNull(cache.getCurrentChildren("/test/onely"));
+        Assert.assertNull(cache.getCurrentChildren("/t"));
+        Assert.assertNull(cache.getCurrentChildren("/testing"));
+
+        assertNoMoreEvents();
+    }
+
+    @Test
     public void testBasicsOnTwoCaches() throws Exception
     {
         TreeCache cache2 = newTreeCacheWithListeners(client, "/test");

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCache.java
@@ -474,7 +474,7 @@ public class TestTreeCache extends BaseTestTreeCache
         client.create().forPath("/test/one", "hey there".getBytes());
 
 
-        cache = buildWithListeners(TreeCache.newBuilder(client, "/test").setCreateZkWatches(false));
+        cache = buildWithListeners(TreeCache.newBuilder(client, "/test").disableZkWatches(true));
 
         cache.start();
         assertEvent(TreeCacheEvent.Type.NODE_ADDED, "/test");


### PR DESCRIPTION
In our use case, we use `TreeCache` to get Zk Data periodically. We start `TreeCache` read data and close it. In this use case, The `ZkWatchManager` of `ZooKeeper` class keeps growing for every TreeCache operation because new `TreeNode` objects are created and added there leading to a memory leak. Also since we do not want the Watcher to periodically watch, this creates  unnecessary background operations.

In this PR, Made the createZkWatches configurable in the Builder, so that use cases like ours can set it to false. The default is true, retaining the current behaviour.
Fixes the jira issue https://issues.apache.org/jira/browse/CURATOR-477