### PR TITLE
[CURATOR-483] Fix path used when re-creating sequential PersistentNode with protection

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNode.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/nodes/PersistentNode.java
@@ -445,7 +445,8 @@ public class PersistentNode implements Closeable
         try
         {
             String existingPath = nodePath.get();
-            String createPath = (existingPath != null && !useProtection) ? existingPath : basePath;
+            String createPath = existingPath == null || (useProtection && !isSequential(mode)) ? basePath
+                    : (useProtection ? basePath + existingPath.substring(existingPath.length()-10) : existingPath);
 
             CreateModable<ACLBackgroundPathAndBytesable<String>> localCreateMethod = createMethod.get();
             if ( localCreateMethod == null )
@@ -462,6 +463,10 @@ public class PersistentNode implements Closeable
             ThreadUtils.checkInterrupted(e);
             throw new RuntimeException("Creating node. BasePath: " + basePath, e);  // should never happen unless there's a programming error - so throw RuntimeException
         }
+    }
+    
+    private static boolean isSequential(CreateMode mode) {
+        return mode == CreateMode.EPHEMERAL_SEQUENTIAL || mode == CreateMode.PERSISTENT_SEQUENTIAL;
     }
 
     private CreateMode getCreateMode(boolean pathIsSet)


### PR DESCRIPTION
Would previously result in creation of a second non-sequential znode.

See https://issues.apache.org/jira/browse/CURATOR-483.