### PR TITLE
CURATOR-472 - fix deadlocks during tests as well as TTL test issues

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/HandleHolder.java
+++ b/curator-client/src/main/java/org/apache/curator/HandleHolder.java
@@ -157,7 +157,7 @@ class HandleHolder
                 zooKeeper.register(dummyWatcher);   // clear the default watcher so that no new events get processed by mistake
                 if ( waitForShutdownTimeoutMs == 0 )
                 {
-                    zooKeeper.close();
+                    zooKeeper.close();  // coming from closeAndReset() which is executed in ZK's event thread. Cannot use zooKeeper.close(n) otherwise we'd get a dead lock
                 }
                 else
                 {

--- a/curator-client/src/main/java/org/apache/curator/HandleHolder.java
+++ b/curator-client/src/main/java/org/apache/curator/HandleHolder.java
@@ -37,7 +37,7 @@ class HandleHolder
     private interface Helper
     {
         ZooKeeper getZooKeeper() throws Exception;
-        
+
         String getConnectionString();
 
         int getNegotiatedSessionTimeoutMs();
@@ -155,7 +155,14 @@ class HandleHolder
                     }
                 };
                 zooKeeper.register(dummyWatcher);   // clear the default watcher so that no new events get processed by mistake
-                zooKeeper.close(waitForShutdownTimeoutMs);
+                if ( waitForShutdownTimeoutMs == 0 )
+                {
+                    zooKeeper.close();
+                }
+                else
+                {
+                    zooKeeper.close(waitForShutdownTimeoutMs);
+                }
             }
         }
         catch ( InterruptedException dummy )

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkEdges.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkEdges.java
@@ -46,6 +46,7 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -59,6 +60,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class TestFrameworkEdges extends BaseClassForTests
 {
     private final Timing2 timing = new Timing2();
+
+    @BeforeClass
+    public static void setUpClass() {
+        System.setProperty("zookeeper.extendedTypesEnabled", "true");
+    }
 
     @Test
     public void testBackgroundLatencyUnSleep() throws Exception

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTtlNodes.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTtlNodes.java
@@ -29,6 +29,7 @@ import org.apache.curator.test.compatibility.Zk35MethodInterceptor;
 import org.apache.zookeeper.CreateMode;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import java.util.concurrent.CountDownLatch;
@@ -36,6 +37,11 @@ import java.util.concurrent.CountDownLatch;
 @Test(groups = Zk35MethodInterceptor.zk35Group)
 public class TestTtlNodes extends CuratorTestBase
 {
+    @BeforeClass
+    public static void setUpClass() {
+        System.setProperty("zookeeper.extendedTypesEnabled", "true");
+    }
+    
     @BeforeMethod
     @Override
     public void setup() throws Exception

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentTtlNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentTtlNode.java
@@ -30,6 +30,7 @@ import org.apache.curator.test.compatibility.Zk35MethodInterceptor;
 import org.apache.curator.utils.ZKPaths;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import java.util.concurrent.Semaphore;
@@ -42,6 +43,11 @@ public class TestPersistentTtlNode extends CuratorTestBase
 {
     private final Timing timing = new Timing();
     private final long ttlMs = timing.multiple(.10).milliseconds(); // a small number
+
+    @BeforeClass
+    public static void setUpClass() {
+        System.setProperty("zookeeper.extendedTypesEnabled", "true");
+    }
 
     @BeforeMethod
     @Override


### PR DESCRIPTION
Fixed 2 problems: 1) internalClose can be called from a ZooKeeper background thread (as part of a Watcher callback). Calling ZooKeeper.close with a waitForShutdownTimeoutMs in this case will cause a deadlock as no other events can be processed until the current thread exits. 2) All TTL tests must set the system property "zookeeper.extendedTypesEnabled"

Note: all tests pass for me now