### PR TITLE
CURATOR-489: CreateBuilderImpl assigns protectedId if doProtected is …

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -91,13 +91,15 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
         this.backgrounding = backgrounding;
         this.createParentsIfNeeded = createParentsIfNeeded;
         this.createParentsAsContainers = createParentsAsContainers;
-        this.doProtected = doProtected;
         this.compress = compress;
         this.setDataIfExists = setDataIfExists;
-        protectedId = null;
         this.acling = new ACLing(client.getAclProvider(), aclList);
         this.storingStat = storingStat;
         this.ttl = ttl;
+        if ( doProtected )
+        {
+            setProtected();
+        }
     }
 
     public void setSetDataIfExistsVersion(int version)

--- a/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFramework.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -408,6 +409,15 @@ public class TestFramework extends BaseClassForTests
             String path = async.create().withOptions(Collections.singleton(CreateOption.doProtected)).forPath("/yo").toCompletableFuture().get();
             String node = ZKPaths.getNodeFromPath(path);
             Assert.assertTrue(node.startsWith(CreateBuilderImpl.PROTECTED_PREFIX), node);
+
+            // CURATOR-489: confirm that the node contains a valid UUID, eg '_c_53345f98-9423-4e0c-a7b5-9f819e3ec2e1-yo'
+            int expectedProtectedIdLength = 36; // '53345f98-9423-4e0c-a7b5-9f819e3ec2e1'
+            int delimeterLength = 1; // '-'
+            int expectedNodeLength = CreateBuilderImpl.PROTECTED_PREFIX.length() + expectedProtectedIdLength + delimeterLength + "yo".length();
+            Assert.assertEquals(node.length(), expectedNodeLength);
+            int uuidStart = CreateBuilderImpl.PROTECTED_PREFIX.length();
+            String protectedId = node.substring(uuidStart, uuidStart + expectedProtectedIdLength);
+            UUID.fromString(protectedId); // will throw if token is not a UUID
         }
         finally
         {


### PR DESCRIPTION
This is a light change to correct a bug when `doProtected` is true: the existing code sets `CreateBuilderImpl.doProtected = true`, but assigns `protectedId = null`, resulting in a non-unique protection-token (`_c_null-`) being applied to the name created in zookeeper. Given that all replicas coordinating via zookeeper would use the identical token, this could conceivably lead to incorrect behavior when the protection logic is needed.

While I believe this PR fixes the bug, I'd really suggest a more comprehensive change to eliminate the `CreateBuilderImpl.doProtected` field entirely, instead relying upon `protectedId != null` to convey this intention. However, being unfamiliar with the nuances of the existing implementation, I didn't want to perform that surgery today. If you think that change seems preferable, I'd be happy to do that instead.