### PR TITLE
[CURATOR-480] fixed ModeledFrameworkImpl.delete version handling

### DIFF
--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
@@ -229,7 +229,7 @@ public class ModeledFrameworkImpl<T> implements ModeledFramework<T>
     @Override
     public AsyncStage<Void> delete(int version)
     {
-        return dslClient.delete().withVersion(-1).forPath(modelSpec.path().fullPath());
+        return dslClient.delete().withVersion(version).forPath(modelSpec.path().fullPath());
     }
 
     @Override


### PR DESCRIPTION
using the passed in version in ModeledFrameworkImpl.delete