### PR TITLE
[CURATOR-479] fixed CachedModeledFrameworkImpl children queries

### DIFF
--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
@@ -248,7 +248,7 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T>
         List<ZPath> paths = cache.currentChildren(client.modelSpec().path())
             .keySet()
             .stream()
-            .filter(path -> path.equals(cache.basePath()))
+            .filter(path -> path.startsWith(client.modelSpec().path()) && !path.equals(client.modelSpec().path()))
             .collect(Collectors.toList());
         return completed(paths);
     }
@@ -259,7 +259,7 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T>
         List<ZNode<T>> nodes = cache.currentChildren(client.modelSpec().path())
             .entrySet()
             .stream()
-            .filter(e -> e.getKey().equals(cache.basePath()))
+            .filter(e -> e.getKey().startsWith(client.modelSpec().path()) && !e.getKey().equals(client.modelSpec().path()))
             .map(Map.Entry::getValue)
             .collect(Collectors.toList());
         return completed(nodes);


### PR DESCRIPTION
fixed the children filtering from the cache and added test cases