### PR TITLE
[CURATOR-491] PathChildrenCache can process background jobs after being closed

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/PathChildrenCache.java
@@ -617,7 +617,7 @@ public class PathChildrenCache implements Closeable
     {
         if ( state.get().equals(State.CLOSED))
         {
-        //    client.removeWatchers();
+            client.removeWatchers();
             return true;
         }
         return false;


### PR DESCRIPTION
CURATOR-332 fixed part of this, but there's another background handler that has the same problem.
The background handler in refresh() correctly checks if the instance has been closed before processing as well as clearing watchers that might have been set in the interim. This same treatment needs to be added to the background handler in getDataAndStat().
