### PR TITLE
[CURATOR-405] reset startOfSuspendedEpoch when session expiration is injected

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/state/ConnectionStateManager.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/state/ConnectionStateManager.java
@@ -301,6 +301,7 @@ public class ConnectionStateManager implements Closeable
             int useSessionTimeoutMs = getUseSessionTimeoutMs();
             if ( elapsedMs >= useSessionTimeoutMs )
             {
+                startOfSuspendedEpoch = System.currentTimeMillis(); // reset startOfSuspendedEpoch to avoid spinning on this session expiration injection CURATOR-405
                 log.warn(String.format("Session timeout has elapsed while SUSPENDED. Injecting a session expiration. Elapsed ms: %d. Adjusted session timeout ms: %d", elapsedMs, useSessionTimeoutMs));
                 try
                 {


### PR DESCRIPTION
Once the session expiration is injected, reset startOfSuspendedEpoch so that we don't do this copious times while things are being reset.