### PR TITLE
[CURATOR-479] fixed CachedModeledFrameworkImpl children 

### DIFF
--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/ZPath.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/ZPath.java
@@ -249,12 +249,26 @@ public interface ZPath extends Resolvable
 
     /**
      * Return true if this path starts with the given path. i.e.
-     * <code>ZPath.from("/one/two/three").startsWith(ZPath.from("/one/two"))</code> returns true
+     * <code>ZPath.parse("/one/two/three").startsWith(ZPath.parse("/one/two"))</code> returns true
      *
      * @param path base path
      * @return true/false
      */
     boolean startsWith(ZPath path);
+
+    /**
+     * Return true if this path is a parent, grandparent, etc. of the given path i.e.
+     * <code>ZPath.parse("/one").isParentOf(ZPath.parse("/one/two/three"))</code> returns true.
+     * However, <code>ZPath.from("/one/two/three").isParentOf(ZPath.from("/one/two/three"))</code>
+     * returns false.
+     *
+     * @param path base path
+     * @return true/false
+     */
+    default boolean isParentOf(ZPath path)
+    {
+        return path.startsWith(this) && !path.fullPath().equals(fullPath());
+    }
 
     /**
      * The string full path that this ZPath represents

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
@@ -248,7 +248,7 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T>
         List<ZPath> paths = cache.currentChildren(client.modelSpec().path())
             .keySet()
             .stream()
-            .filter(path -> path.startsWith(client.modelSpec().path()) && !path.equals(client.modelSpec().path()))
+            .filter(path -> client.modelSpec().path().isParentOf(path))
             .collect(Collectors.toList());
         return completed(paths);
     }
@@ -259,7 +259,7 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T>
         List<ZNode<T>> nodes = cache.currentChildren(client.modelSpec().path())
             .entrySet()
             .stream()
-            .filter(e -> e.getKey().startsWith(client.modelSpec().path()) && !e.getKey().equals(client.modelSpec().path()))
+            .filter(e -> client.modelSpec().path().isParentOf(e.getKey()))
             .map(Map.Entry::getValue)
             .collect(Collectors.toList());
         return completed(nodes);

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ZPathImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ZPathImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.x.async.modeled.details;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import org.apache.curator.x.async.modeled.NodeName;
@@ -142,6 +143,27 @@ public class ZPathImpl implements ZPath
             rhs = parseInternal(path.fullPath(), s -> s);
         }
         return (nodes.size() >= rhs.nodes.size()) && nodes.subList(0, rhs.nodes.size()).equals(rhs.nodes);
+    }
+
+    @VisibleForTesting
+    public boolean defaultIsParentOf(ZPath path)
+    {
+        return ZPath.super.isParentOf(path);
+    }
+
+    @Override
+    public boolean isParentOf(ZPath path)
+    {
+        ZPathImpl rhs;
+        if ( path instanceof ZPathImpl )
+        {
+            rhs = (ZPathImpl)path;
+        }
+        else
+        {
+            rhs = parseInternal(path.fullPath(), s -> s);
+        }
+        return (rhs.nodes.size() > nodes.size()) && rhs.nodes.subList(0, nodes.size()).equals(nodes);
     }
 
     @Override

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestZPath.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestZPath.java
@@ -59,6 +59,16 @@ public class TestZPath
         Assert.assertTrue(checkIdLike.isResolved());
         checkIdLike = ZPath.parse("/one/" + ZPath.parameter("others") + "/three");
         Assert.assertTrue(checkIdLike.isResolved());
+
+        Assert.assertTrue(ZPath.parse("/one").isParentOf(ZPath.parse("/one/two/three")));
+        Assert.assertTrue(path.isParentOf(path.child("one")));
+        Assert.assertFalse(path.isParentOf(path));
+        Assert.assertFalse(path.isParentOf(path.parent()));
+
+        // check default implementation
+        Assert.assertTrue(((ZPathImpl)path).defaultIsParentOf(path.child("one")));
+        Assert.assertFalse(((ZPathImpl)path).defaultIsParentOf(path));
+        Assert.assertFalse(((ZPathImpl)path).defaultIsParentOf(path.parent()));
     }
 
     @Test


### PR DESCRIPTION
Added new method to ZPath, isParentOf(). The, use it in CachedModeledFrameworkImpl.children() and CachedModeledFrameworkImpl.childrenAsZNodes() which were not implemented correctly.
