### PR TITLE
CURATOR-494 Make ZKPaths.makePath() methods to allocate less garbage

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/DistributedDelayQueue.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/queue/DistributedDelayQueue.java
@@ -42,7 +42,7 @@ public class DistributedDelayQueue<T> implements Closeable, QueueBase<T>
 {
     private final DistributedQueue<T>      queue;
 
-    private static final String            SEPARATOR = "|";
+    private static final char              SEPARATOR = '|';
 
     DistributedDelayQueue
         (


### PR DESCRIPTION
Currently ZKPaths.makePath() methods call substring() unnecessarily. I've seen those methods responsible for 15% of total heap allocation in some application.

