### PR TITLE
[CURATOR-498] - Fix protection mode race with ephemeral nodes

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
@@ -81,7 +81,7 @@ class FindAndDeleteProtectedNodeInBackground implements BackgroundOperation<Void
 
                 if ( rc == KeeperException.Code.OK.intValue() )
                 {
-                    final String node = CreateBuilderImpl.findNode(strings, "/", protectedId);  // due to namespacing, don't let CreateBuilderImpl.findNode adjust the path
+                    final String node = CreateBuilderImpl.findNode(strings, "/", protectedId, 0);  // due to namespacing, don't let CreateBuilderImpl.findNode adjust the path
                     if ( node != null )
                     {
                         try

--- a/curator-framework/src/main/java/org/apache/curator/framework/state/ConnectionStateManager.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/state/ConnectionStateManager.java
@@ -25,6 +25,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.listen.ListenerContainer;
 import org.apache.curator.utils.Compatibility;
 import org.apache.curator.utils.ThreadUtils;
+import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.Closeable;
@@ -302,10 +303,11 @@ public class ConnectionStateManager implements Closeable
             if ( elapsedMs >= useSessionTimeoutMs )
             {
                 startOfSuspendedEpoch = System.currentTimeMillis(); // reset startOfSuspendedEpoch to avoid spinning on this session expiration injection CURATOR-405
-                log.warn(String.format("Session timeout has elapsed while SUSPENDED. Injecting a session expiration. Elapsed ms: %d. Adjusted session timeout ms: %d", elapsedMs, useSessionTimeoutMs));
                 try
                 {
-                    Compatibility.injectSessionExpiration(client.getZookeeperClient().getZooKeeper());
+                    ZooKeeper zooKeeper = client.getZookeeperClient().getZooKeeper();
+                    log.warn(String.format("Session timeout has elapsed while SUSPENDED. Injecting a session expiration. Elapsed ms: %d. Adjusted session timeout ms: %d. SessionId: 0x%s", elapsedMs, useSessionTimeoutMs, Long.toHexString(zooKeeper.getSessionId())));
+                    Compatibility.injectSessionExpiration(zooKeeper);
                 }
                 catch ( Exception e )
                 {


### PR DESCRIPTION
"Protection" has a potential bug. If the connection is lost for long enough, Curator will want to kill the session. Session deletions must be handled by the Leader ZK instance. At the same time that the session kill is being processed, Curator's protection mode handling could be calling the follower that it's connected to get the current list of children - this can be handled directly by the follower instance without needing to call the leader. So, in this scenario, the client will get a list of children that includes the ZNode that will get deleted as part of killing the session.
    
This bug has been in Curator since we added the protection feature to it more than 6 years ago. The fix is to include the session ID in the protection ID that is generated for the node name when the create mode is an ephemeral type. Then, if findProtectedNodeInForeground() finds the node in the use-case we've been discussing, it can compare the session ID to the current ZooKeeper handle's session ID and disregard the found node if they don't match.
