### PR TITLE
CURATOR-499 Allow creating sequential nodes with an empty name

### DIFF
--- a/curator-client/src/test/java/org/apache/curator/utils/TestZKPaths.java
+++ b/curator-client/src/test/java/org/apache/curator/utils/TestZKPaths.java
@@ -26,6 +26,18 @@ import java.util.Collections;
 
 public class TestZKPaths
 {
+    @Test
+    public void testFixForNamespaceWithEmptyNodeName()
+    {
+        Assert.assertEquals(ZKPaths.fixForNamespace("foo", "/bar/", true, false), "/foo/bar");
+    }
+
+    @Test
+    public void testFixForNamespaceWithEmptyNodeNameAllowed()
+    {
+        Assert.assertEquals(ZKPaths.fixForNamespace("foo", "/bar/", true, true), "/foo/bar/");
+    }
+
     @SuppressWarnings("NullArgumentToVariableArgMethod")
     @Test
     public void testMakePath()

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/CreateModable.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/CreateModable.java
@@ -28,5 +28,18 @@ public interface CreateModable<T>
      * @param mode new create mode
      * @return this
      */
-    public T withMode(CreateMode mode);
+    public default T withMode(CreateMode mode)
+    {
+        return withMode(mode, PathEncodingType.DEFAULT);
+    }
+
+    /**
+     * Set a create mode with a path encoding option - the default is {@link CreateMode#PERSISTENT} and
+     * {@link PathEncodingType#DEFAULT}.
+     *
+     * @param mode new create mode
+     * @param pathEncodingType path encoding type
+     * @return this
+     */
+    public T withMode(CreateMode mode, PathEncodingType pathEncodingType);
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -56,6 +56,7 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
     private boolean doProtected;
     private boolean compress;
     private boolean setDataIfExists;
+    private boolean allowEmptyNodeName;
     private int setDataIfExistsVersion = -1;
     private String protectedId;
     private ACLing acling;
@@ -154,9 +155,9 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
             }
 
             @Override
-            public ACLPathAndBytesable<T> withMode(CreateMode mode)
+            public ACLPathAndBytesable<T> withMode(CreateMode mode, PathEncodingType pathEncodingType)
             {
-                CreateBuilderImpl.this.withMode(mode);
+                CreateBuilderImpl.this.withMode(mode, pathEncodingType);
                 return this;
             }
 
@@ -277,9 +278,9 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
             }
 
             @Override
-            public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode)
+            public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode, PathEncodingType pathEncodingType)
             {
-                return CreateBuilderImpl.this.withMode(mode);
+                return CreateBuilderImpl.this.withMode(mode, pathEncodingType);
             }
 
             @Override
@@ -446,9 +447,9 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
             }
 
             @Override
-            public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode)
+            public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode, PathEncodingType pathEncodingType)
             {
-                return CreateBuilderImpl.this.withMode(mode);
+                return CreateBuilderImpl.this.withMode(mode, pathEncodingType);
             }
 
             @Override
@@ -514,9 +515,10 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
     }
 
     @Override
-    public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode)
+    public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode, PathEncodingType pathEncodingType)
     {
         createMode = mode;
+        this.allowEmptyNodeName = pathEncodingType == PathEncodingType.ALLOW_EMPTY;
         return this;
     }
 
@@ -583,7 +585,7 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
             data = client.getCompressionProvider().compress(givenPath, data);
         }
 
-        final String adjustedPath = adjustPath(client.fixForNamespace(givenPath, createMode.isSequential()));
+        final String adjustedPath = adjustPath(client.fixForNamespace(givenPath, createMode.isSequential(), allowEmptyNodeName));
         List<ACL> aclList = acling.getAclList(adjustedPath);
         client.getSchemaSet().getSchema(givenPath).validateCreate(createMode, givenPath, data, aclList);
 
@@ -763,8 +765,8 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
             }
 
             @Override
-            public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode) {
-                return CreateBuilderImpl.this.withMode(mode);
+            public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode, PathEncodingType pathEncodingType) {
+                return CreateBuilderImpl.this.withMode(mode, pathEncodingType);
             }
 
             @Override
@@ -883,9 +885,10 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
             }
 
             @Override
-            public ACLPathAndBytesable<String> withMode(CreateMode mode)
-            {
+            public ACLPathAndBytesable<String> withMode(CreateMode mode, PathEncodingType pathEncodingType) {
                 createMode = mode;
+                allowEmptyNodeName = pathEncodingType == PathEncodingType.ALLOW_EMPTY;
+
                 return new ACLPathAndBytesable<String>()
                 {
                     @Override
@@ -944,8 +947,8 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
             }
 
             @Override
-            public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode) {
-                return CreateBuilderImpl.this.withMode(mode);
+            public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode, PathEncodingType pathEncodingType) {
+                return CreateBuilderImpl.this.withMode(mode, pathEncodingType);
             }
 
             @Override
@@ -1064,8 +1067,8 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
             }
 
             @Override
-            public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode) {
-                return CreateBuilderImpl.this.withMode(mode);
+            public ACLBackgroundPathAndBytesable<String> withMode(CreateMode mode, PathEncodingType pathEncodingType) {
+                return CreateBuilderImpl.this.withMode(mode, pathEncodingType);
             }
 
             @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -722,12 +722,17 @@ public class CuratorFrameworkImpl implements CuratorFramework
 
     String fixForNamespace(String path)
     {
-        return namespace.fixForNamespace(path, false);
+        return namespace.fixForNamespace(path, false, false);
     }
 
     String fixForNamespace(String path, boolean isSequential)
     {
-        return namespace.fixForNamespace(path, isSequential);
+        return namespace.fixForNamespace(path, isSequential, false);
+    }
+
+    String fixForNamespace(String path, boolean isSequential, boolean allowEmptyNodeName)
+    {
+        return namespace.fixForNamespace(path, isSequential, allowEmptyNodeName);
     }
 
     byte[] getDefaultData()

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceFacade.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceFacade.java
@@ -135,13 +135,19 @@ class NamespaceFacade extends CuratorFrameworkImpl
     @Override
     String fixForNamespace(String path)
     {
-        return namespace.fixForNamespace(path, false);
+        return namespace.fixForNamespace(path, false, false);
     }
 
     @Override
     String fixForNamespace(String path, boolean isSequential)
     {
-        return namespace.fixForNamespace(path, isSequential);
+        return namespace.fixForNamespace(path, isSequential, false);
+    }
+
+    @Override
+    String fixForNamespace(String path, boolean isSequential, boolean allowEmptyNodeName)
+    {
+        return namespace.fixForNamespace(path, isSequential, allowEmptyNodeName);
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceImpl.java
@@ -72,7 +72,7 @@ class NamespaceImpl
         return path;
     }
 
-    String    fixForNamespace(String path, boolean isSequential)
+    String    fixForNamespace(String path, boolean isSequential, boolean allowEmptyNodeName)
     {
         if ( ensurePathNeeded.get() )
         {
@@ -101,11 +101,11 @@ class NamespaceImpl
             }
         }
 
-        return ZKPaths.fixForNamespace(namespace, path, isSequential);
+        return ZKPaths.fixForNamespace(namespace, path, isSequential, allowEmptyNodeName);
     }
 
     EnsurePath newNamespaceAwareEnsurePath(String path)
     {
-        return new EnsurePath(fixForNamespace(path, false), client.getAclProvider());
+        return new EnsurePath(fixForNamespace(path, false, false), client.getAclProvider());
     }
 }


### PR DESCRIPTION
Add CreateModable#withMode(CreateMode, PathEncodingType) where
PathEncodingType is an enum with values DEFAULT and ALLOW_EMPTY.

When a node is created with ALLOW_EMPTY, trailing /s will not be
removed from the path.

This should not be used except with sequential CreateModes, as it will
fail with:
java.lang.IllegalArgumentException: Path must not end with / character

Calling the following:

curatorFramework.create()
    .withMode(CreateMode.PERSISTENT_SEQUENTIAL, PathEncodingType.ALLOW_EMPTY)
    .forPath("/foo/bar/, data);

Will create a node "/foo/bar/000000000X", whereas calling:

curatorFramework.create()
    .withMode(CreateMode.PERSISTENT_SEQUENTIAL)
    .forPath("/foo/bar/, data);

Will create a node "/foo/bar000000000X".