### PR TITLE
[CURATOR-503] Update dependencies in January 2019

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/schema/SchemaViolation.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/schema/SchemaViolation.java
@@ -18,7 +18,6 @@
  */
 package org.apache.curator.framework.schema;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import org.apache.zookeeper.data.ACL;
 import java.util.Arrays;
@@ -148,6 +147,6 @@ public class SchemaViolation extends RuntimeException
 
     private static String toString(Schema schema, String violation, ViolatorData violatorData)
     {
-        return Objects.firstNonNull(violation, "") + " " + schema + " " + violatorData;
+        return (violation != null ? violation : "") + " " + schema + " " + violatorData;
     }
 }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedQueue.java
@@ -705,7 +705,7 @@ public class TestDistributedQueue extends BaseClassForTests
         try
         {
             final AtomicBoolean     firstTime = new AtomicBoolean(true);
-            queue = new DistributedQueue<TestQueueItem>(client, null, serializer, "/test", new ThreadFactoryBuilder().build(), MoreExecutors.sameThreadExecutor(), 10, true, null, QueueBuilder.NOT_SET, true, 0)
+            queue = new DistributedQueue<TestQueueItem>(client, null, serializer, "/test", new ThreadFactoryBuilder().build(), MoreExecutors.directExecutor(), 10, true, null, QueueBuilder.NOT_SET, true, 0)
             {
                 @Override
                 void internalCreateNode(final String path, final byte[] bytes, final BackgroundCallback callback) throws Exception

--- a/curator-x-discovery-server/pom.xml
+++ b/curator-x-discovery-server/pom.xml
@@ -135,8 +135,8 @@
                 <jdk>[1.9,)</jdk>
             </activation>
             <dependencies>
-                <!-- The following dependencies are added to make tests work with JDK 9, as per this
-                     answer: https://stackoverflow.com/questions/43574426#43574427 -->
+                <!-- The following dependencies are added to make tests work with JDK 9 or later,
+                      as per this answer: https://stackoverflow.com/questions/43574426#43574427 -->
 
                 <dependency>
                     <groupId>javax.xml.bind</groupId>

--- a/curator-x-discovery-server/pom.xml
+++ b/curator-x-discovery-server/pom.xml
@@ -127,4 +127,41 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk-9-plus</id>
+            <activation>
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies are added to make tests work with JDK 9, as per this
+                     answer: https://stackoverflow.com/questions/43574426#43574427 -->
+
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-core</artifactId>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,26 +60,31 @@
 
         <!-- versions -->
         <zookeeper-version>3.5.4-beta</zookeeper-version>
-        <maven-project-info-reports-plugin-version>2.9</maven-project-info-reports-plugin-version>
-        <maven-bundle-plugin-version>3.2.0</maven-bundle-plugin-version>
-        <maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>
+        <maven-bundle-plugin-version>4.1.0</maven-bundle-plugin-version>
+        <maven-javadoc-plugin-version>3.0.1</maven-javadoc-plugin-version>
         <doxia-module-confluence-version>1.8</doxia-module-confluence-version>
         <maven-license-plugin-version>1.9.0</maven-license-plugin-version>
-        <javassist-version>3.20.0-GA</javassist-version>
+        <javassist-version>3.24.1-GA</javassist-version>
         <commons-math-version>2.2</commons-math-version>
         <jackson-mapper-asl-version>1.9.13</jackson-mapper-asl-version>
-        <jackson-version>2.7.3</jackson-version>
-        <jersey-version>1.18.1</jersey-version>
+        <jackson-version>2.9.8</jackson-version>
+        <jersey-version>1.19.4</jersey-version>
+        <!-- Upgrading to Jersey 2.x is difficult and of unclear benefits, see
+             https://stackoverflow.com/questions/17098341#22033825 -->
         <jsr311-api-version>1.1.1</jsr311-api-version>
+        <!-- See https://stackoverflow.com/questions/43574426#comment93992044_43574427 -->
+        <jaxb-version>2.2.11</jaxb-version>
+        <javax-activation-version>1.1.1</javax-activation-version>
         <jetty-version>6.1.26</jetty-version>
         <scannotation-version>1.0.2</scannotation-version>
-        <resteasy-jaxrs-version>2.3.0.GA</resteasy-jaxrs-version>
-        <guava-version>20.0</guava-version>
-        <testng-version>6.10</testng-version>
-        <swift-version>0.18.0</swift-version>
-        <dropwizard-version>0.7.0</dropwizard-version>
-        <maven-shade-plugin-version>2.4.3</maven-shade-plugin-version>
-        <slf4j-version>1.7.6</slf4j-version>
+        <!-- resteasy-jaxrs dependency cannot be higher than 2.x for compatibility with Jersey 1.x -->
+        <resteasy-jaxrs-version>2.3.5.Final</resteasy-jaxrs-version>
+        <guava-version>27.0.1-jre</guava-version>
+        <testng-version>6.14.3</testng-version>
+        <swift-version>0.23.1</swift-version>
+        <dropwizard-version>1.3.7</dropwizard-version>
+        <maven-shade-plugin-version>3.2.1</maven-shade-plugin-version>
+        <slf4j-version>1.7.25</slf4j-version>
         <clirr-maven-plugin-version>2.8</clirr-maven-plugin-version>
 
         <!-- OSGi Properties -->
@@ -432,6 +437,30 @@
             </dependency>
 
             <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>${jaxb-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>${javax-activation-version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>jetty</artifactId>
                 <version>${jetty-version}</version>
@@ -526,7 +555,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${maven-project-info-reports-plugin-version}</version>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
The main motivation for this update is updating Guava from 20.0 to 27.0.1-jre. Between these versions, the implementation of `Maps.newConcurrentMap()` (this method is used in many places in Curator code) was changed and now it returns `ConcurrentHashMap` instead of Guava's own implementation, that was less efficient.

This PR also updates Jackson version, as well as #280, from 2.7 to 2.9. Answering questions raised in the comments to that PR: I believe upgrading Jackson from 2.7 to 2.9 is safe. The compatibility standards in Jackson are much higher than in an average Java project. Most incompatibilities in [2.8](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8#changes-compatibility) and [2.9](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#changes-compatibility) are minor tweaks in Jackson's programmatic API (shouldn't be a concern as long as Curator is built and passes tests with the updated dependencies). Also support for some old Java and Android versions is dropped, shouldn't be a concern in Curator either. Finally, seems that there are the only two changes that affect serialization format: [of `java.nio.Path`](https://github.com/FasterXML/jackson-databind/issues/1235) and [of `java.sql.Date`](https://github.com/FasterXML/jackson-databind/issues/219). It also doesn't seem to be relevant to Curator.

Testing: `mvn test` in a private CI server passed.