### PR TITLE
[CURATOR-429] Make Curator 4.x compatible with Zookeeper 3.4.x in OSGi too

### DIFF
--- a/curator-client/pom.xml
+++ b/curator-client/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <osgi.import.package>
-            *
+            org.apache.zookeeper.*;version="[3.4,4.0)", *
         </osgi.import.package>
         <osgi.export.package>
             org.apache.curator*;version="${project.version}";-noimport:=true

--- a/curator-framework/pom.xml
+++ b/curator-framework/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <osgi.import.package>
-            *
+            org.apache.zookeeper.*;version="[3.4,4.0)", *
         </osgi.import.package>
         <osgi.export.package>
             org.apache.curator.framework*;version="${project.version}";-noimport:=true

--- a/curator-recipes/pom.xml
+++ b/curator-recipes/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <osgi.import.package>
-            *
+            org.apache.zookeeper.*;version="[3.4,4.0)", *
         </osgi.import.package>
         <osgi.export.package>
             org.apache.curator.framework.recipes*;version="${project.version}";-noimport:=true

--- a/curator-x-discovery-server/pom.xml
+++ b/curator-x-discovery-server/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <osgi.import.package>
-            *
+            org.apache.zookeeper.*;version="[3.4,4.0)", *
         </osgi.import.package>
         <osgi.export.package>
             org.apache.curator.x.discovery.server*;version="${project.version}";-noimport:=true

--- a/curator-x-discovery/pom.xml
+++ b/curator-x-discovery/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <osgi.import.package>
-            *
+            org.apache.zookeeper.*;version="[3.4,4.0)", *
         </osgi.import.package>
         <osgi.export.package>
             org.apache.curator.x.discovery*;version="${project.version}";-noimport:=true


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CURATOR-429

Curator 4.0 supports ZooKeeper 3.4.x (https://curator.apache.org/zk-compatibility.html)
This change allows this dependency also in OSGi. (where it required 3.5)