### PR TITLE
Compilation on jdk11 for release 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <jdk-version>1.8</jdk-version>
+        <jdk-release-version>8</jdk-release-version>
 
         <!-- versions -->
         <zookeeper-version>3.5.4-beta</zookeeper-version>
@@ -668,6 +669,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <release>${jdk-release-version}</release>
                     <source>${jdk-version}</source>
                     <target>${jdk-version}</target>
                 </configuration>


### PR DESCRIPTION
Hi, we're migrating to JDK11 and came across this potential issue.

I see from the manifest that 4.2.0 is built on jdk11:
```
Build-Jdk: 11.0.2
Built-By: jordanzimmerman
```

Changes to covariant return types for `ByteBuffer` in JDK11 may cause a `java.lang.NoSuchMethodError` when running on JDK 8. Which may impact these calls:

https://github.com/apache/curator/blob/master/curator-framework/src/main/java/org/apache/curator/framework/imps/GzipCompressionProvider.java#L307-L319

This can be mitigated by setting the `--release` to 8. Although I see that .travis.yml is still using `oraclejdk8`