### PR TITLE
[CURATOR-539] Remove link to obsolete Stack Overflow tag

### DIFF
--- a/src/site/confluence/index.confluence
+++ b/src/site/confluence/index.confluence
@@ -17,7 +17,6 @@ h2. Stack Overflow
 There's lots of great help on Stack Overflow:
 
 * [[Main "Apache Curator" tag|https://stackoverflow.com/questions/tagged/apache-curator]]
-* [[Old "Curator" tag|https://stackoverflow.com/questions/tagged/curator]]
 
 h2. Nav Bar
 


### PR DESCRIPTION
The Stack Overflow "curator" tag got merged with "apache-curator" and both Stack Overflow links now redirect to the same page. The obsolete link doesn't add anything useful.