### PR TITLE
CURATOR-543 - ZOOKEEPER-1392 broke TestLockACLs

### DIFF
--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestLockACLs.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestLockACLs.java
@@ -38,7 +38,7 @@ import java.util.List;
 public class TestLockACLs extends BaseClassForTests
 {
     private static final List<ACL> ACLS1 = Collections.singletonList(new ACL(ZooDefs.Perms.ALL, new Id("ip", "127.0.0.1")));
-    private static final List<ACL> ACLS2 = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE, new Id("ip", "127.0.0.1")));
+    private static final List<ACL> ACLS2 = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, new Id("ip", "127.0.0.1")));
 
     private CuratorFramework createClient(ACLProvider provider) throws Exception
     {
@@ -86,7 +86,7 @@ public class TestLockACLs extends BaseClassForTests
         try
         {
             client.create().creatingParentsIfNeeded().forPath("/parent/foo");
-            Assert.assertEquals(ZooDefs.Perms.CREATE, client.getACL().forPath("/parent").get(0).getPerms());
+            Assert.assertEquals(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, client.getACL().forPath("/parent").get(0).getPerms());
             Assert.assertEquals(ZooDefs.Perms.ALL, client.getACL().forPath("/parent/foo").get(0).getPerms());
         }
         finally


### PR DESCRIPTION
ZOOKEEPER-1392 broke TestLockACLs. In order to read ACLS you now need READ perm. TestLockACLs.testLockACLs() needs to be updated to reflect this.