### PR TITLE
CURATOR-547 change JAX-RS reader/writer to reuse Jackson ObjectMapper

### DIFF
--- a/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceInstanceMarshaller.java
+++ b/curator-x-discovery-server/src/main/java/org/apache/curator/x/discovery/server/entity/JsonServiceInstanceMarshaller.java
@@ -48,6 +48,8 @@ import java.lang.reflect.Type;
 @Produces(MediaType.APPLICATION_JSON)
 public class JsonServiceInstanceMarshaller<T> implements MessageBodyReader<ServiceInstance<T>>, MessageBodyWriter<ServiceInstance<T>>
 {
+    private final static ObjectMapper MAPPER = new ObjectMapper();
+
     private final DiscoveryContext<T> context;
 
     public JsonServiceInstanceMarshaller(DiscoveryContext<T> context)
@@ -140,8 +142,7 @@ public class JsonServiceInstanceMarshaller<T> implements MessageBodyReader<Servi
     {
         try
         {
-            ObjectMapper                mapper = new ObjectMapper();
-            JsonNode                    node = mapper.reader().readTree(entityStream);
+            JsonNode                    node = MAPPER.readTree(entityStream);
             return readInstance(node, context);
         }
         catch ( Exception e )
@@ -154,8 +155,7 @@ public class JsonServiceInstanceMarshaller<T> implements MessageBodyReader<Servi
     @Override
     public void writeTo(ServiceInstance<T> serviceInstance, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException
     {
-        ObjectMapper    mapper = new ObjectMapper();
-        ObjectNode      node = writeInstance(mapper, serviceInstance, context);
-        mapper.writer().writeValue(entityStream, node);
+        ObjectNode      node = writeInstance(MAPPER, serviceInstance, context);
+        MAPPER.writeValue(entityStream, node);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <javassist-version>3.24.1-GA</javassist-version>
         <commons-math-version>2.2</commons-math-version>
         <jackson-mapper-asl-version>1.9.13</jackson-mapper-asl-version>
-        <jackson-version>2.9.8</jackson-version>
+        <jackson-version>2.9.10</jackson-version>
         <!-- Upgrading to Jersey 2.x is difficult and of unclear benefits, see
              https://stackoverflow.com/questions/17098341#22033825 -->
         <jersey-version>1.19.4</jersey-version>


### PR DESCRIPTION
also upgrade Jackson version from 2.9.8 to 2.9.10 (latest 2.9.x patch).
