### PR TITLE
[CURATOR-546] - ModeledCacheImpl.currentData() was removing from entries instead of calling get()

### DIFF
--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledCacheImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledCacheImpl.java
@@ -100,7 +100,7 @@ class ModeledCacheImpl<T> implements TreeCacheListener, ModeledCache<T>
     @Override
     public Optional<ZNode<T>> currentData(ZPath path)
     {
-        Entry<T> entry = entries.remove(path);
+        Entry<T> entry = entries.get(path);
         if ( entry != null )
         {
             return Optional.of(new ZNodeImpl<>(path, entry.stat, entry.model));


### PR DESCRIPTION
Bad copy/paste bug. ModeledCacheImpl.currentData() was removing from entries instead of calling get()