### PR TITLE
[CURATOR-557] ServiceCacheImpl does not close ExecutorService

### DIFF
--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceCacheBuilder.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceCacheBuilder.java
@@ -45,7 +45,9 @@ public interface ServiceCacheBuilder<T>
      *
      * @param threadFactory factory
      * @return this
+     * @deprecated use {@link #executorService(ExecutorService)} instead
      */
+    @Deprecated
     public ServiceCacheBuilder<T> threadFactory(ThreadFactory threadFactory);
 
     /**

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceProviderBuilder.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceProviderBuilder.java
@@ -18,7 +18,9 @@
  */
 package org.apache.curator.x.discovery;
 
+import org.apache.curator.utils.CloseableExecutorService;
 import org.apache.curator.x.discovery.strategies.RoundRobinStrategy;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 
 public interface ServiceProviderBuilder<T>
@@ -47,11 +49,14 @@ public interface ServiceProviderBuilder<T>
     public ServiceProviderBuilder<T> providerStrategy(ProviderStrategy<T> providerStrategy);
 
     /**
-     * optional - the thread factory to use for creating internal threads
+     * optional - the thread factory to use for creating internal threads. The specified ThreadFactory overrides
+     * any prior ThreadFactory or ClosableExecutorService set on the ServiceProviderBuilder
      *
      * @param threadFactory factory to use
      * @return this
+     * @deprecated use {@link #executorService(ExecutorService)} instead
      */
+    @Deprecated
     public ServiceProviderBuilder<T> threadFactory(ThreadFactory threadFactory);
 
     /**
@@ -71,4 +76,23 @@ public interface ServiceProviderBuilder<T>
      * @return this
      */
     public ServiceProviderBuilder<T> additionalFilter(InstanceFilter<T> filter);
+
+    /**
+     * Optional ExecutorService to use for the cache's background thread. The specified ExecutorService
+     * will be wrapped in a CloseableExecutorService and overrides any prior ThreadFactory or CloseableExecutorService
+     * set on the ServiceProviderBuilder.
+     *
+     * @param executorService executor service
+     * @return this
+     */
+    public ServiceProviderBuilder<T> executorService(ExecutorService executorService);
+
+    /**
+     * Optional CloseableExecutorService to use for the cache's background thread. The specified CloseableExecutorService
+     * overrides any prior ThreadFactory or CloseableExecutorService set on the ServiceProviderBuilder.
+     *
+     * @param executorService an instance of CloseableExecutorService
+     * @return this
+     */
+    public ServiceProviderBuilder<T> executorService(CloseableExecutorService executorService);
 }

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceCacheBuilderImpl.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceCacheBuilderImpl.java
@@ -77,6 +77,7 @@ class ServiceCacheBuilderImpl<T> implements ServiceCacheBuilder<T>
      * @return this
      */
     @Override
+    @Deprecated
     public ServiceCacheBuilder<T> threadFactory(ThreadFactory threadFactory)
     {
         this.threadFactory = threadFactory;
@@ -92,9 +93,7 @@ class ServiceCacheBuilderImpl<T> implements ServiceCacheBuilder<T>
      */
     @Override
     public ServiceCacheBuilder<T> executorService(ExecutorService executorService) {
-        this.executorService = new CloseableExecutorService(executorService);
-        this.threadFactory = null;
-        return this;
+        return executorService(new CloseableExecutorService(executorService, false));
     }
 
     /**

--- a/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceCacheImpl.java
+++ b/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceCacheImpl.java
@@ -61,7 +61,7 @@ public class ServiceCacheImpl<T> implements ServiceCache<T>, PathChildrenCacheLi
     private static CloseableExecutorService convertThreadFactory(ThreadFactory threadFactory)
     {
         Preconditions.checkNotNull(threadFactory, "threadFactory cannot be null");
-        return new CloseableExecutorService(Executors.newSingleThreadExecutor(threadFactory));
+        return new CloseableExecutorService(Executors.newSingleThreadExecutor(threadFactory), true);
     }
 
     ServiceCacheImpl(ServiceDiscoveryImpl<T> discovery, String name, ThreadFactory threadFactory)


### PR DESCRIPTION
- ServiceCacheImpl should allow the self-created executor service to be closed
- Allow an optional executor service for ServiceProvider

fix #CURATOR-557