### PR TITLE
[CURATOR-559] Fix nested retry loops

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
+++ b/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
@@ -171,7 +171,7 @@ public class CuratorZookeeperClient implements Closeable
      */
     public RetryLoop newRetryLoop()
     {
-        return new RetryLoop(retryPolicy.get(), tracer);
+        return new RetryLoopImpl(retryPolicy.get(), tracer);
     }
 
     /**

--- a/curator-client/src/main/java/org/apache/curator/RetryLoopImpl.java
+++ b/curator-client/src/main/java/org/apache/curator/RetryLoopImpl.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.curator;
+
+import org.apache.curator.drivers.EventTrace;
+import org.apache.curator.drivers.TracerDriver;
+import org.apache.curator.utils.DebugUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.concurrent.atomic.AtomicReference;
+
+class RetryLoopImpl extends RetryLoop
+{
+    private boolean isDone = false;
+    private int retryCount = 0;
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final long startTimeMs = System.currentTimeMillis();
+    private final RetryPolicy retryPolicy;
+    private final AtomicReference<TracerDriver> tracer;
+
+    private static final RetrySleeper sleeper = (time, unit) -> unit.sleep(time);
+
+    RetryLoopImpl(RetryPolicy retryPolicy, AtomicReference<TracerDriver> tracer)
+    {
+        this.retryPolicy = retryPolicy;
+        this.tracer = tracer;
+    }
+
+    static RetrySleeper getRetrySleeper()
+    {
+        return sleeper;
+    }
+
+
+    @Override
+    public boolean shouldContinue()
+    {
+        return !isDone;
+    }
+
+    @Override
+    public void markComplete()
+    {
+        isDone = true;
+    }
+
+    @Override
+    public void takeException(Exception exception) throws Exception
+    {
+        boolean rethrow = true;
+        if ( RetryLoop.isRetryException(exception) )
+        {
+            if ( !Boolean.getBoolean(DebugUtils.PROPERTY_DONT_LOG_CONNECTION_ISSUES) )
+            {
+                log.debug("Retry-able exception received", exception);
+            }
+
+            if ( retryPolicy.allowRetry(retryCount++, System.currentTimeMillis() - startTimeMs, sleeper) )
+            {
+                new EventTrace("retries-allowed", tracer.get()).commit();
+                if ( !Boolean.getBoolean(DebugUtils.PROPERTY_DONT_LOG_CONNECTION_ISSUES) )
+                {
+                    log.debug("Retrying operation");
+                }
+                rethrow = false;
+            }
+            else
+            {
+                new EventTrace("retries-disallowed", tracer.get()).commit();
+                if ( !Boolean.getBoolean(DebugUtils.PROPERTY_DONT_LOG_CONNECTION_ISSUES) )
+                {
+                    log.debug("Retry policy not allowing retry");
+                }
+            }
+        }
+
+        if ( rethrow )
+        {
+            throw exception;
+        }
+    }
+}

--- a/curator-client/src/main/java/org/apache/curator/connection/ThreadLocalRetryLoop.java
+++ b/curator-client/src/main/java/org/apache/curator/connection/ThreadLocalRetryLoop.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.connection;
+
+import org.apache.curator.RetryLoop;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * <p>
+ *     Retry loops can easily end up getting nested which can cause exponential calls of the retry policy
+ *     (see https://issues.apache.org/jira/browse/CURATOR-559). This utility works around that by using
+ *     an internal ThreadLocal to hold a retry loop. E.g. if the retry loop fails anywhere in the chain
+ *     of nested calls it will fail for the rest of the nested calls instead.
+ * </p>
+ *
+ * <p>
+ *     Example usage:
+ *
+ * <code><pre>
+ * ThreadLocalRetryLoop threadLocalRetryLoop = new ThreadLocalRetryLoop();
+ * RetryLoop retryLoop = threadLocalRetryLoop.getRetryLoop(client::newRetryLoop);
+ * try
+ * {
+ *     while ( retryLoop.shouldContinue() )
+ *     {
+ *         try
+ *         {
+ *             // do work
+ *             retryLoop.markComplete();
+ *         }
+ *         catch ( Exception e )
+ *         {
+ *             ThreadUtils.checkInterrupted(e);
+ *             retryLoop.takeException(e);
+ *         }
+ *     }
+ * }
+ * finally
+ * {
+ *     threadLocalRetryLoop.release();
+ * }
+ * </pre></code>
+ * </p>
+ */
+public class ThreadLocalRetryLoop
+{
+    private static final Logger log = LoggerFactory.getLogger(ThreadLocalRetryLoop.class);
+    private static final ThreadLocal<Entry> threadLocal = new ThreadLocal<>();
+
+    private static class Entry
+    {
+        private final RetryLoop retryLoop;
+        private int counter;
+
+        Entry(RetryLoop retryLoop)
+        {
+            this.retryLoop = retryLoop;
+        }
+    }
+
+    private static class WrappedRetryLoop extends RetryLoop
+    {
+        private final RetryLoop retryLoop;
+        private Exception takenException;
+
+        public WrappedRetryLoop(RetryLoop retryLoop)
+        {
+            this.retryLoop = retryLoop;
+        }
+
+        @Override
+        public boolean shouldContinue()
+        {
+            return retryLoop.shouldContinue() && (takenException == null);
+        }
+
+        @Override
+        public void markComplete()
+        {
+            retryLoop.markComplete();
+        }
+
+        @Override
+        public void takeException(Exception exception) throws Exception
+        {
+            if ( takenException != null )
+            {
+                if ( exception.getClass() != takenException.getClass() )
+                {
+                    log.error("Multiple exceptions in retry loop", exception);
+                }
+                throw takenException;
+            }
+            try
+            {
+                retryLoop.takeException(exception);
+            }
+            catch ( Exception e )
+            {
+                takenException = e;
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Call to get the current retry loop. If there isn't one, one is allocated
+     * via {@code newRetryLoopSupplier}.
+     *
+     * @param newRetryLoopSupplier supply a new retry loop when needed. Normally you should use {@link org.apache.curator.CuratorZookeeperClient#newRetryLoop()}
+     * @return retry loop to use
+     */
+    public RetryLoop getRetryLoop(Supplier<RetryLoop> newRetryLoopSupplier)
+    {
+        Entry entry = threadLocal.get();
+        if ( entry == null )
+        {
+            entry = new Entry(new WrappedRetryLoop(newRetryLoopSupplier.get()));
+            threadLocal.set(entry);
+        }
+        ++entry.counter;
+        return entry.retryLoop;
+    }
+
+    /**
+     * Must be called to release the retry loop. See {@link org.apache.curator.connection.StandardConnectionHandlingPolicy#callWithRetry(org.apache.curator.CuratorZookeeperClient, java.util.concurrent.Callable)}
+     * for an example usage.
+     */
+    public void release()
+    {
+        Entry entry = Objects.requireNonNull(threadLocal.get(), "No retry loop was set - unbalanced call to release()");
+        if ( --entry.counter <= 0 )
+        {
+            threadLocal.remove();
+        }
+    }
+}

--- a/curator-client/src/test/java/org/apache/curator/TestEnsurePath.java
+++ b/curator-client/src/test/java/org/apache/curator/TestEnsurePath.java
@@ -51,7 +51,7 @@ public class TestEnsurePath
         ZooKeeper               client = mock(ZooKeeper.class, Mockito.RETURNS_MOCKS);
         CuratorZookeeperClient  curator = mock(CuratorZookeeperClient.class);
         RetryPolicy             retryPolicy = new RetryOneTime(1);
-        RetryLoop               retryLoop = new RetryLoop(retryPolicy, null);
+        RetryLoop               retryLoop = new RetryLoopImpl(retryPolicy, null);
         when(curator.getConnectionHandlingPolicy()).thenReturn(new StandardConnectionHandlingPolicy());
         when(curator.getZooKeeper()).thenReturn(client);
         when(curator.getRetryPolicy()).thenReturn(retryPolicy);
@@ -76,7 +76,7 @@ public class TestEnsurePath
     {
         ZooKeeper               client = mock(ZooKeeper.class, Mockito.RETURNS_MOCKS);
         RetryPolicy             retryPolicy = new RetryOneTime(1);
-        RetryLoop               retryLoop = new RetryLoop(retryPolicy, null);
+        RetryLoop               retryLoop = new RetryLoopImpl(retryPolicy, null);
         final CuratorZookeeperClient  curator = mock(CuratorZookeeperClient.class);
         when(curator.getConnectionHandlingPolicy()).thenReturn(new StandardConnectionHandlingPolicy());
         when(curator.getZooKeeper()).thenReturn(client);

--- a/curator-recipes/src/test/java/org/apache/curator/connection/TestThreadLocalRetryLoop.java
+++ b/curator-recipes/src/test/java/org/apache/curator/connection/TestThreadLocalRetryLoop.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.connection;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.RetrySleeper;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.locks.InterProcessReadWriteLock;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.apache.zookeeper.KeeperException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestThreadLocalRetryLoop extends CuratorTestBase
+{
+    private static final int retryCount = 4;
+
+    @Test(description = "Check for fix for CURATOR-559")
+    public void testRecursingRetry() throws Exception
+    {
+        AtomicInteger count = new AtomicInteger();
+        try (CuratorFramework client = newClient(count))
+        {
+            prep(client);
+            doLock(client);
+            Assert.assertEquals(count.get(), retryCount + 1);    // Curator's retry policy has been off by 1 since inception - we might consider fixing it someday
+        }
+    }
+
+    @Test(description = "Check for fix for CURATOR-559 with multiple threads")
+    public void testThreadedRecursingRetry() throws Exception
+    {
+        final int threadQty = 4;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadQty);
+        AtomicInteger count = new AtomicInteger();
+        try (CuratorFramework client = newClient(count))
+        {
+            prep(client);
+            for ( int i = 0; i < threadQty; ++i )
+            {
+                executorService.submit(() -> doLock(client));
+            }
+            executorService.shutdown();
+            executorService.awaitTermination(timing.milliseconds(), TimeUnit.MILLISECONDS);
+            Assert.assertEquals(count.get(), threadQty * (retryCount + 1));    // Curator's retry policy has been off by 1 since inception - we might consider fixing it someday
+        }
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testBadReleaseWithNoGet()
+    {
+        ThreadLocalRetryLoop retryLoopStack = new ThreadLocalRetryLoop();
+        retryLoopStack.release();
+    }
+
+    private CuratorFramework newClient(AtomicInteger count)
+    {
+        RetryPolicy retryPolicy = makeRetryPolicy(count);
+        return CuratorFrameworkFactory.newClient(server.getConnectString(), 100, 100, retryPolicy);
+    }
+
+    private void prep(CuratorFramework client) throws Exception
+    {
+        client.start();
+        client.create().forPath("/test");
+        server.stop();
+    }
+
+    private Void doLock(CuratorFramework client) throws Exception
+    {
+        InterProcessReadWriteLock lock = new InterProcessReadWriteLock(client, "/test/lock");
+        try
+        {
+            lock.readLock().acquire();
+            Assert.fail("Should have thrown an exception");
+        }
+        catch ( KeeperException ignore )
+        {
+            // correct
+        }
+        return null;
+    }
+
+    private RetryPolicy makeRetryPolicy(AtomicInteger count)
+    {
+        return new RetryNTimes(retryCount, 1)
+        {
+            @Override
+            public boolean allowRetry(int retryCount, long elapsedTimeMs, RetrySleeper sleeper)
+            {
+                count.incrementAndGet();
+                return super.allowRetry(retryCount, elapsedTimeMs, sleeper);
+            }
+        };
+    }
+}


### PR DESCRIPTION
The retry loop mechanism ended up getting nested multiple times causing exponential calls to the retry policy and violating a given policy's limits. Use a thread local to mitigate this so that a retry loop is reused for nested API calls, etc.