### PR TITLE
[CURATOR-560] set tickTime and minSessionTimeout

### DIFF
--- a/curator-test/src/main/java/org/apache/curator/test/InstanceSpec.java
+++ b/curator-test/src/main/java/org/apache/curator/test/InstanceSpec.java
@@ -89,6 +89,7 @@ public class InstanceSpec
         try
         {
             server = new ServerSocket(0);
+            server.setReuseAddress(true);
             return server.getLocalPort();
         }
         catch ( IOException e )

--- a/curator-test/src/main/java/org/apache/curator/test/QuorumConfigBuilder.java
+++ b/curator-test/src/main/java/org/apache/curator/test/QuorumConfigBuilder.java
@@ -22,6 +22,7 @@ package org.apache.curator.test;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
+import org.apache.curator.test.compatibility.Timing2;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import java.io.Closeable;
 import java.io.File;
@@ -40,7 +41,7 @@ public class QuorumConfigBuilder implements Closeable
 
     public QuorumConfigBuilder(Collection<InstanceSpec> specs)
     {
-        this(specs.toArray(new InstanceSpec[specs.size()]));
+        this(specs.toArray(new InstanceSpec[0]));
     }
 
     public QuorumConfigBuilder(InstanceSpec... specs)
@@ -109,11 +110,9 @@ public class QuorumConfigBuilder implements Closeable
         properties.setProperty("syncLimit", "5");
         properties.setProperty("dataDir", spec.getDataDirectory().getCanonicalPath());
         properties.setProperty("clientPort", Integer.toString(spec.getPort()));
-        int tickTime = spec.getTickTime();
-        if ( tickTime >= 0 )
-        {
-            properties.setProperty("tickTime", Integer.toString(tickTime));
-        }
+        String tickTime = Integer.toString((spec.getTickTime() >= 0) ? spec.getTickTime() : new Timing2().tickTime());
+        properties.setProperty("tickTime", tickTime);
+        properties.setProperty("minSessionTimeout", tickTime);
         int maxClientCnxns = spec.getMaxClientCnxns();
         if ( maxClientCnxns >= 0 )
         {

--- a/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java
+++ b/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java
@@ -143,7 +143,9 @@ public class TestingZooKeeperMain implements ZooKeeperMainFace
     public void blockUntilStarted() throws Exception
     {
         if(!timing.awaitLatch(latch))
-            throw new IllegalStateException("Timed out waiting for watch removal");
+        {
+            throw new IllegalStateException("Timed out waiting for server startup");
+        }
 
         if ( zkServer != null )
         {

--- a/curator-test/src/main/java/org/apache/curator/test/compatibility/Timing2.java
+++ b/curator-test/src/main/java/org/apache/curator/test/compatibility/Timing2.java
@@ -36,6 +36,7 @@ public class Timing2
     private final TimeUnit unit;
     private final int waitingMultiple;
 
+    private static final double TICK_TIME_MULTIPLE = .10;
     private static final int DEFAULT_SECONDS = 10;
     private static final int DEFAULT_WAITING_MULTIPLE = 5;
     private static final double SESSION_MULTIPLE = 1.5;
@@ -290,6 +291,16 @@ public class Timing2
     public int connection()
     {
         return milliseconds();
+    }
+
+    /**
+     * Value to use for server "tickTime"
+     *
+     * @return tick time
+     */
+    public int tickTime()
+    {
+        return (int)Math.max(1, milliseconds() * TICK_TIME_MULTIPLE);
     }
 
     private static Integer getWaitingMultiple()


### PR DESCRIPTION
a) make sure setReuseAddress is set for server when getting a random port
b) always set "tickTime" and "minSessionTimeout" to make our tests run a bit faster
c) fixed incorrect exception message in blockUntilStarted()