### PR TITLE
[CURATOR-464] attach orignal artifacts with classifier original

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <clirr-maven-plugin-version>2.8</clirr-maven-plugin-version>
         <dropwizard-version>3.2.5</dropwizard-version>
         <snappy-version>1.1.7</snappy-version>
+        <build-helper-maven-plugin-version>3.1.0</build-helper-maven-plugin-version>
 
         <!-- OSGi Properties -->
         <osgi.export.package/>
@@ -658,6 +659,12 @@
                     <artifactId>clirr-maven-plugin</artifactId>
                     <version>${clirr-maven-plugin-version}</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${build-helper-maven-plugin-version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -919,6 +926,55 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <condition property="skip-attaching-original-artifact" else="false">
+                                    <not>
+                                        <or>
+                                            <equals arg1="${project.packaging}" arg2="jar"/>
+                                            <equals arg1="${project.packaging}" arg2="bundle"/>
+                                        </or>
+                                    </not>
+                                </condition>
+                            </target>
+                            <exportAntProperties>true</exportAntProperties>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/original-${project.build.finalName}.jar</file>
+                                    <type>jar</type>
+                                    <classifier>original</classifier>
+                                </artifact>
+                            </artifacts>
+                            <skipAttach>${skip-attaching-original-artifact}</skipAttach>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Would like to revisit the following issue.

https://issues.apache.org/jira/browse/CURATOR-464

The current approach would be preventing shaded artifacts from replacing original artifacts. Instead, shaded artifacts are now also attached with classifier uber, next to original artifacts, so clients could integrate either based on their need.

This approach is my preference while it'll be a little expensive in adoption, as new classifier must be added during upgrade. If this really bothers, here are 2 alternatives we may go:

1. **Removing the reloaction in shading.** Packages like `org.apache.curator.shaded.com.google` could be found nowhere but in curator-client, which doesn't export these relocated packages in its manifest. Without relocation, these packages could be fulfilled by some other bundle, following the import instruction inside the manifest. However, if shaded classes take priority, problems would be expected in OSGi runtime because same classes are loaded by different bundles and they become different classses. This decision belongs to the implementation of OSGi runtime.

2. **Attaching original artifact with some classifier like 'slim'.** This is essentially the reverse way of the proposed approach, which costs little in adoption as no new classifier is required during upgrade. Personally, I don't like this way as we don't usually put classifier on original artifacts. However, if compared with this issue not being fixed, this alternative would be better.

Please review the change and any comment is welcome.