### PR TITLE
[CURATOR-525] Fix for Zombie LOST Curator

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/state/ConnectionStateManager.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/state/ConnectionStateManager.java
@@ -291,16 +291,9 @@ public class ConnectionStateManager implements Closeable
                     if ( (currentConnectionState == ConnectionState.LOST) && client.getZookeeperClient().isConnected() )
                     {
                         // CURATOR-525 - there is a race whereby LOST is sometimes set after the connection has been repaired
-                        // this "hack" fixes it by resetting the connection
-                        log.warn("ConnectionState is LOST but isConnected() is true. Resetting connection.");
-                        try
-                        {
-                            client.getZookeeperClient().reset();
-                        }
-                        catch ( Exception e )
-                        {
-                            log.error("Could not reset connection after LOST/isConnected mismatch");
-                        }
+                        // this "hack" fixes it by forcing the state to RECONNECTED
+                        log.warn("ConnectionState is LOST but isConnected() is true. Forcing RECONNECTED.");
+                        addStateChange(ConnectionState.RECONNECTED);
                     }
                 }
             }


### PR DESCRIPTION
There is a race whereby the ZooKeeper connection can be healed before Curator is finished processing the new connection state. When this happens the Curator instance becomes a Zombie stuck in the LOST state. This fix is a "hack". ConnectionStateManager will notice that the connection state is LOST but that the Curator instance reports that it is connected. When this happens, it is logged and the connection is reset.