### PR TITLE
CURATOR-544: SessionFailedRetryPolicy

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/RetryLoop.java
+++ b/curator-client/src/main/java/org/apache/curator/RetryLoop.java
@@ -20,7 +20,6 @@ package org.apache.curator;
 
 import org.apache.curator.connection.ThreadLocalRetryLoop;
 import org.apache.curator.utils.ThreadUtils;
-import org.apache.zookeeper.KeeperException;
 import java.util.concurrent.Callable;
 
 /**
@@ -120,37 +119,6 @@ public abstract class RetryLoop
      * Call this when your operation has successfully completed
      */
     public abstract void markComplete();
-
-    /**
-     * Utility - return true if the given Zookeeper result code is retry-able
-     *
-     * @param rc result code
-     * @return true/false
-     */
-    public static boolean shouldRetry(int rc)
-    {
-        return (rc == KeeperException.Code.CONNECTIONLOSS.intValue()) ||
-            (rc == KeeperException.Code.OPERATIONTIMEOUT.intValue()) ||
-            (rc == KeeperException.Code.SESSIONMOVED.intValue()) ||
-            (rc == KeeperException.Code.SESSIONEXPIRED.intValue()) ||
-            (rc == -13); // KeeperException.Code.NEWCONFIGNOQUORUM.intValue()) - using hard coded value for ZK 3.4.x compatibility
-    }
-
-    /**
-     * Utility - return true if the given exception is retry-able
-     *
-     * @param exception exception to check
-     * @return true/false
-     */
-    public static boolean isRetryException(Throwable exception)
-    {
-        if ( exception instanceof KeeperException )
-        {
-            KeeperException keeperException = (KeeperException)exception;
-            return shouldRetry(keeperException.code().intValue());
-        }
-        return false;
-    }
 
     /**
      * Pass any caught exceptions here

--- a/curator-client/src/main/java/org/apache/curator/RetryLoopImpl.java
+++ b/curator-client/src/main/java/org/apache/curator/RetryLoopImpl.java
@@ -66,7 +66,7 @@ class RetryLoopImpl extends RetryLoop
     public void takeException(Exception exception) throws Exception
     {
         boolean rethrow = true;
-        if ( RetryLoop.isRetryException(exception) )
+        if ( retryPolicy.allowRetry(exception) )
         {
             if ( !Boolean.getBoolean(DebugUtils.PROPERTY_DONT_LOG_CONNECTION_ISSUES) )
             {

--- a/curator-client/src/main/java/org/apache/curator/RetryPolicy.java
+++ b/curator-client/src/main/java/org/apache/curator/RetryPolicy.java
@@ -52,8 +52,7 @@ public interface RetryPolicy
             return (rc == KeeperException.Code.CONNECTIONLOSS.intValue()) ||
                     (rc == KeeperException.Code.OPERATIONTIMEOUT.intValue()) ||
                     (rc == KeeperException.Code.SESSIONMOVED.intValue()) ||
-                    (rc == KeeperException.Code.SESSIONEXPIRED.intValue()) ||
-                    (rc == -13); // KeeperException.Code.NEWCONFIGNOQUORUM.intValue()) - using hard coded value for ZK 3.4.x compatibility
+                    (rc == KeeperException.Code.SESSIONEXPIRED.intValue());
         }
         return false;
     }

--- a/curator-client/src/main/java/org/apache/curator/RetryPolicy.java
+++ b/curator-client/src/main/java/org/apache/curator/RetryPolicy.java
@@ -18,6 +18,8 @@
  */
 package org.apache.curator;
 
+import org.apache.zookeeper.KeeperException;
+
 /**
  * Abstracts the policy to use when retrying connections
  */
@@ -33,5 +35,26 @@ public interface RetryPolicy
      * @param sleeper use this to sleep - DO NOT call Thread.sleep
      * @return true/false
      */
-    public boolean      allowRetry(int retryCount, long elapsedTimeMs, RetrySleeper sleeper);
+    boolean allowRetry(int retryCount, long elapsedTimeMs, RetrySleeper sleeper);
+
+    /**
+     * Called when an operation has failed with a specific exception. This method
+     * should return true to make another attempt.
+     *
+     * @param exception the cause that this operation failed
+     * @return true/false
+     */
+    default boolean allowRetry(Throwable exception)
+    {
+        if ( exception instanceof KeeperException)
+        {
+            final int rc = ((KeeperException) exception).code().intValue();
+            return (rc == KeeperException.Code.CONNECTIONLOSS.intValue()) ||
+                    (rc == KeeperException.Code.OPERATIONTIMEOUT.intValue()) ||
+                    (rc == KeeperException.Code.SESSIONMOVED.intValue()) ||
+                    (rc == KeeperException.Code.SESSIONEXPIRED.intValue()) ||
+                    (rc == -13); // KeeperException.Code.NEWCONFIGNOQUORUM.intValue()) - using hard coded value for ZK 3.4.x compatibility
+        }
+        return false;
+    }
 }

--- a/curator-client/src/main/java/org/apache/curator/SessionFailedRetryPolicy.java
+++ b/curator-client/src/main/java/org/apache/curator/SessionFailedRetryPolicy.java
@@ -1,0 +1,36 @@
+package org.apache.curator;
+
+import org.apache.zookeeper.KeeperException;
+
+/**
+ * {@link RetryPolicy} implementation that failed on session expired.
+ */
+public class SessionFailedRetryPolicy implements RetryPolicy
+{
+
+    private final RetryPolicy delegatePolicy;
+
+    public SessionFailedRetryPolicy(RetryPolicy delegatePolicy)
+    {
+        this.delegatePolicy = delegatePolicy;
+    }
+
+    @Override
+    public boolean allowRetry(int retryCount, long elapsedTimeMs, RetrySleeper sleeper)
+    {
+        return delegatePolicy.allowRetry(retryCount, elapsedTimeMs, sleeper);
+    }
+
+    @Override
+    public boolean allowRetry(Throwable exception)
+    {
+        if ( exception instanceof KeeperException.SessionExpiredException )
+        {
+            return false;
+        }
+        else
+        {
+            return delegatePolicy.allowRetry(exception);
+        }
+    }
+}

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -20,7 +20,6 @@
 package org.apache.curator.framework.imps;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import org.apache.curator.RetryLoop;
@@ -36,14 +35,12 @@ import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
-import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.DataTree;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -770,7 +767,7 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
                 }
                 catch ( KeeperException e )
                 {
-                    if ( !RetryLoop.isRetryException(e) )
+                    if ( !client.getZookeeperClient().getRetryPolicy().allowRetry(e) )
                     {
                         throw e;
                     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -637,7 +637,8 @@ public class CuratorFrameworkImpl implements CuratorFramework
         boolean doQueueOperation = false;
         do
         {
-            if ( RetryLoop.shouldRetry(event.getResultCode()) )
+            final KeeperException ke = KeeperException.create(event.getResultCode());
+            if ( getZookeeperClient().getRetryPolicy().allowRetry(ke) )
             {
                 doQueueOperation = checkBackgroundRetry(operationAndData, event);
                 break;
@@ -901,7 +902,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
     {
         do
         {
-            if ( (operationAndData != null) && RetryLoop.isRetryException(e) )
+            if ( (operationAndData != null) && getZookeeperClient().getRetryPolicy().allowRetry(e) )
             {
                 if ( !Boolean.getBoolean(DebugUtils.PROPERTY_DONT_LOG_CONNECTION_ISSUES) )
                 {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -637,8 +637,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
         boolean doQueueOperation = false;
         do
         {
-            final KeeperException ke = KeeperException.create(event.getResultCode());
-            if ( getZookeeperClient().getRetryPolicy().allowRetry(ke) )
+            if ( getZookeeperClient().getRetryPolicy().allowRetry(KeeperException.create(event.getResultCode())) )
             {
                 doQueueOperation = checkBackgroundRetry(operationAndData, event);
                 break;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
@@ -300,7 +300,7 @@ public class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<Str
         {
             ThreadUtils.checkInterrupted(e);
             //Only retry a guaranteed delete if it's a retryable error
-            if( (RetryLoop.isRetryException(e) || (e instanceof InterruptedException)) && guaranteed )
+            if ( (client.getZookeeperClient().getRetryPolicy().allowRetry(e) || (e instanceof InterruptedException)) && guaranteed )
             {
                 client.getFailedDeleteManager().addFailedOperation(unfixedPath);
             }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/RemoveWatchesBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/RemoveWatchesBuilderImpl.java
@@ -270,13 +270,13 @@ public class RemoveWatchesBuilderImpl implements RemoveWatchesBuilder, RemoveWat
                             }
                             catch(Exception e)
                             {
-                                if( RetryLoop.isRetryException(e) && guaranteed )
+                                if ( client.getZookeeperClient().getRetryPolicy().allowRetry(e) && guaranteed )
                                 {
                                     //Setup the guaranteed handler
                                     client.getFailedRemoveWatcherManager().addFailedOperation(new FailedRemoveWatchManager.FailedRemoveWatchDetails(path, finalNamespaceWatcher));
                                     throw e;
                                 }
-                                else if(e instanceof KeeperException.NoWatcherException && quietly)
+                                else if (e instanceof KeeperException.NoWatcherException && quietly)
                                 {
                                     // ignore
                                 }

--- a/src/site/confluence/breaking-changes.confluence
+++ b/src/site/confluence/breaking-changes.confluence
@@ -11,3 +11,5 @@ need to use Curator with ZooKeeper 3.4.x you will need to use a previous version
 * {{newPersistentEphemeralNode(}} and {{newPathChildrenCache}} were removed from {{GroupMember}}
 * {{ServiceCacheBuilder<T> executorService(CloseableExecutorService executorService)} was removed from {{ServiceCacheBuilder}}
 * {{ServiceProviderBuilder<T> executorService(CloseableExecutorService executorService);)} was removed from {{ServiceProviderBuilder}}
+* {{static boolean shouldRetry(int rc);} was removed from {{RetryLoop}}.
+* {{static boolean isRetryException(Throwable exception);} was removed from {{RetryLoop}}.


### PR DESCRIPTION
More details on [JIRA](https://issues.apache.org/jira/browse/CURATOR-544#).

The breaking parts are we remove `RetryLoop.shouldRetry` & `RetryLoop. isRetryException` but it is no harm to add them back if we want to keep public APIs.

cc @Randgalt @shayshim 