### PR TITLE
CURATOR-577 - Add a dedicated downloads page to the website

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,8 @@
     </organization>
 
     <properties>
+        <currentStableVersion>5.1.0</currentStableVersion>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -800,6 +802,7 @@
                     <header>src/etc/header.txt</header>
                     <excludes>
                         <exclude>**/*.confluence</exclude>
+                        <exclude>**/*.confluence.vm</exclude>
                         <exclude>**/help.txt</exclude>
                         <exclude>**/*.rdf</exclude>
                         <exclude>**/.gitignore</exclude>

--- a/src/site/confluence/index.confluence
+++ b/src/site/confluence/index.confluence
@@ -8,6 +8,10 @@ Apache Curator is a Java/JVM client library for [[Apache ZooKeeper|https://zooke
 
 !images/ph-quote.png!
 
+h2. Download
+
+[[Download Apache Curator|releases.html]] from the release page.
+
 h2. Important Compatibility Updates
 
 Note: version 5.0 of Curator has a few breaking changes. Please read the details here:

--- a/src/site/confluence/releases.confluence.vm
+++ b/src/site/confluence/releases.confluence.vm
@@ -1,0 +1,22 @@
+h1. Apache Curator Releases
+
+h2. Download
+The current release can be [[downloaded using these links|#Current_Release]].
+
+Older releases are available from the [[archive|https://archive.apache.org/dist/curator/]].
+
+You can verify the integrity of a downloaded release using the PGP signatures and hashes hosted at the main Apache distribution site.
+For additional information, refer to the Apache documentation for [[verifying the integrity of Apache project releases|https://www.apache.org/info/verification.html]].
+The binary artifacts for Curator are available from [[Maven Central|http://search.maven.org/#search%7Cga%7C1%7Corg.apache.curator]] and its mirrors.
+
+h2. Current Release
+
+* Current Release: [[apache\-curator\-${currentStableVersion}\-source\-release.zip|https://downloads.apache.org/curator/${currentStableVersion}/apache-curator-${currentStableVersion}-source-release.zip]]
+* PGP: [[apache\-curator\-${currentStableVersion}\-source\-release.zip.asc|https://downloads.apache.org/curator/${currentStableVersion}/apache-curator-${currentStableVersion}-source-release.zip.asc]]
+* SHA\-512: [[apache\-curator\-${currentStableVersion}\-source\-release.zip.sha512|https://downloads.apache.org/curator/${currentStableVersion}/apache-curator-${currentStableVersion}-source-release.zip.sha512]]
+* Keys: [[KEYS|https://downloads.apache.org/curator/KEYS]]
+
+h2. All Releases / History
+
+See [[Curator's Release Wiki|https://cwiki.apache.org/confluence/display/CURATOR/Releases]] for a detailed historical
+list of releases.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -71,7 +71,7 @@
 
         <menu name="Apache Curator" inherit="top">
             <item name="About" href="index.html"/>
-            <item name="Download" href="https://cwiki.apache.org/confluence/display/CURATOR/Releases"/>
+            <item name="Download" href="releases.html"/>
             <item name="Getting Started" href="getting-started.html"/>
             <item name="Examples" href="curator-examples/index.html"/>
             <item name="Recipes" href="curator-recipes/index.html"/>
@@ -97,7 +97,6 @@
             <item name="API Compatibility" href="compatibility.html"/>
             <item name="Javadoc" href="apidocs/index.html"/>
             <item name="Wiki" href="https://cwiki.apache.org/confluence/display/CURATOR"/>
-            <item name="Releases/Compatibility" href="https://cwiki.apache.org/confluence/display/CURATOR/Releases"/>
             <item name="ZooKeeper 3.4.x" href="zk-compatibility-34.html"/>
             <item name="v5.x Breaking Changes" href="breaking-changes.html"/>
         </menu>


### PR DESCRIPTION
Add a dedicated downloads page to the website.

The new version of the website can be seen here: http://curator.apache.org/staging/

I tried using the Build Helper plugin to get the current release version but it picked an old version on my machine and left me not trusting it. So, we now have a property specifically for the download page in the root POM: `currentStableVersion`. Once this new website is released I'll update the instructions on the wiki page for building the website.