### PR TITLE
CURATOR-582: Migrate to jUnit 5.6

### DIFF
--- a/curator-client/pom.xml
+++ b/curator-client/pom.xml
@@ -72,8 +72,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.artsok</groupId>
+            <artifactId>rerunner-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -119,4 +125,3 @@
         </plugins>
     </build>
 </project>
-

--- a/curator-client/pom.xml
+++ b/curator-client/pom.xml
@@ -78,12 +78,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.artsok</groupId>
-            <artifactId>rerunner-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>

--- a/curator-client/src/test/java/org/apache/curator/BasicTests.java
+++ b/curator-client/src/test/java/org/apache/curator/BasicTests.java
@@ -18,6 +18,13 @@
  */
 package org.apache.curator;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
@@ -30,15 +37,13 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.mockito.Mockito;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BasicTests extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testFactory() throws Exception
     {
         final ZooKeeper         mockZookeeper = Mockito.mock(ZooKeeper.class);
@@ -52,10 +57,10 @@ public class BasicTests extends BaseClassForTests
         };
         CuratorZookeeperClient  client = new CuratorZookeeperClient(zookeeperFactory, new FixedEnsembleProvider(server.getConnectString()), 10000, 10000, null, new RetryOneTime(1), false);
         client.start();
-        Assert.assertEquals(client.getZooKeeper(), mockZookeeper);
+        assertEquals(client.getZooKeeper(), mockZookeeper);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testExpiredSession() throws Exception
     {
         // see http://wiki.apache.org/hadoop/ZooKeeper/FAQ#A4
@@ -101,11 +106,11 @@ public class BasicTests extends BaseClassForTests
 
                             client.getZooKeeper().getTestable().injectSessionExpiration();
 
-                            Assert.assertTrue(timing.awaitLatch(latch));
+                            assertTrue(timing.awaitLatch(latch));
                         }
                         ZooKeeper zooKeeper = client.getZooKeeper();
                         client.blockUntilConnectedOrTimedOut();
-                        Assert.assertNotNull(zooKeeper.exists("/foo", false));
+                        assertNotNull(zooKeeper.exists("/foo", false));
                         return null;
                     }
                 }
@@ -117,7 +122,7 @@ public class BasicTests extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testReconnect() throws Exception
     {
         CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000, 10000, null, new RetryOneTime(1));
@@ -133,9 +138,9 @@ public class BasicTests extends BaseClassForTests
             Thread.sleep(1000);
 
             server.restart();
-            Assert.assertTrue(client.blockUntilConnectedOrTimedOut());
+            assertTrue(client.blockUntilConnectedOrTimedOut());
             byte[]      readData = client.getZooKeeper().getData("/test", false, null);
-            Assert.assertEquals(readData, writtenData);
+            assertArrayEquals(readData, writtenData);
         }
         finally
         {
@@ -143,7 +148,7 @@ public class BasicTests extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSimple() throws Exception
     {
         CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000, 10000, null, new RetryOneTime(1));
@@ -152,7 +157,7 @@ public class BasicTests extends BaseClassForTests
         {
             client.blockUntilConnectedOrTimedOut();
             String              path = client.getZooKeeper().create("/test", new byte[]{1,2,3}, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-            Assert.assertEquals(path, "/test");
+            assertEquals(path, "/test");
         }
         finally
         {
@@ -160,7 +165,7 @@ public class BasicTests extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBackgroundConnect() throws Exception
     {
         final int CONNECTION_TIMEOUT_MS = 4000;
@@ -168,7 +173,7 @@ public class BasicTests extends BaseClassForTests
         CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000, CONNECTION_TIMEOUT_MS, null, new RetryOneTime(1));
         try
         {
-            Assert.assertFalse(client.isConnected());
+            assertFalse(client.isConnected());
             client.start();
 
             outer: do
@@ -183,7 +188,7 @@ public class BasicTests extends BaseClassForTests
                     Thread.sleep(CONNECTION_TIMEOUT_MS);
                 }
 
-                Assert.fail();
+                fail();
             } while ( false );
         }
         finally

--- a/curator-client/src/test/java/org/apache/curator/BasicTests.java
+++ b/curator-client/src/test/java/org/apache/curator/BasicTests.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
@@ -36,6 +35,7 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BasicTests extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testFactory() throws Exception
     {
         final ZooKeeper         mockZookeeper = Mockito.mock(ZooKeeper.class);
@@ -60,7 +60,7 @@ public class BasicTests extends BaseClassForTests
         assertEquals(client.getZooKeeper(), mockZookeeper);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testExpiredSession() throws Exception
     {
         // see http://wiki.apache.org/hadoop/ZooKeeper/FAQ#A4
@@ -122,7 +122,7 @@ public class BasicTests extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testReconnect() throws Exception
     {
         CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000, 10000, null, new RetryOneTime(1));
@@ -148,7 +148,7 @@ public class BasicTests extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSimple() throws Exception
     {
         CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000, 10000, null, new RetryOneTime(1));
@@ -165,7 +165,7 @@ public class BasicTests extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBackgroundConnect() throws Exception
     {
         final int CONNECTION_TIMEOUT_MS = 4000;

--- a/curator-client/src/test/java/org/apache/curator/TestEnsurePath.java
+++ b/curator-client/src/test/java/org/apache/curator/TestEnsurePath.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -36,11 +37,10 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.utils.EnsurePath;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 public class TestEnsurePath
 {
@@ -117,9 +117,9 @@ public class TestEnsurePath
             );
         }
 
-        Assert.assertTrue(startedLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(startedLatch.await(10, TimeUnit.SECONDS));
         semaphore.release(3);
-        Assert.assertTrue(finishedLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(finishedLatch.await(10, TimeUnit.SECONDS));
         verify(client, times(3)).exists(Mockito.<String>any(), anyBoolean());
 
         ensurePath.ensure(curator);

--- a/curator-client/src/test/java/org/apache/curator/TestIs36.java
+++ b/curator-client/src/test/java/org/apache/curator/TestIs36.java
@@ -20,15 +20,14 @@ package org.apache.curator;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.Compatibility;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 public class TestIs36 extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Tag(zk36Group)
     public void testIsZk36()
     {

--- a/curator-client/src/test/java/org/apache/curator/TestIs36.java
+++ b/curator-client/src/test/java/org/apache/curator/TestIs36.java
@@ -18,19 +18,23 @@
  */
 package org.apache.curator;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.Compatibility;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 
 public class TestIs36 extends CuratorTestBase
 {
-    @Test(groups = zk36Group)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Tag(zk36Group)
     public void testIsZk36()
     {
-        Assert.assertTrue(Compatibility.hasGetReachableOrOneMethod());
-        Assert.assertTrue(Compatibility.hasAddrField());
-        Assert.assertTrue(Compatibility.hasPersistentWatchers());
+        assertTrue(Compatibility.hasGetReachableOrOneMethod());
+        assertTrue(Compatibility.hasAddrField());
+        assertTrue(Compatibility.hasPersistentWatchers());
     }
 
     @Override

--- a/curator-client/src/test/java/org/apache/curator/TestRetryLoop.java
+++ b/curator-client/src/test/java/org/apache/curator/TestRetryLoop.java
@@ -21,7 +21,6 @@ package org.apache.curator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.retry.RetryForever;
 import org.apache.curator.retry.RetryOneTime;
@@ -30,6 +29,7 @@ import org.apache.curator.test.Timing;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.concurrent.TimeUnit;
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.times;
 
 public class TestRetryLoop extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testExponentialBackoffRetryLimit()
     {
         RetrySleeper                    sleeper = new RetrySleeper()
@@ -56,7 +56,7 @@ public class TestRetryLoop extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testRetryLoopWithFailure() throws Exception
     {
         CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 5000, 5000, null, new RetryOneTime(1));
@@ -116,7 +116,7 @@ public class TestRetryLoop extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testRetryLoop() throws Exception
     {
         CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000, 10000, null, new RetryOneTime(1));
@@ -152,7 +152,7 @@ public class TestRetryLoop extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testRetryForever() throws Exception
     {
         int retryIntervalMs = 1;
@@ -167,7 +167,7 @@ public class TestRetryLoop extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRetryForeverWithSessionFailed() throws Exception
     {
         final Timing timing = new Timing();

--- a/curator-client/src/test/java/org/apache/curator/TestRetryLoop.java
+++ b/curator-client/src/test/java/org/apache/curator/TestRetryLoop.java
@@ -18,6 +18,10 @@
  */
 package org.apache.curator;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.retry.RetryForever;
 import org.apache.curator.retry.RetryOneTime;
@@ -27,8 +31,6 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.mockito.Mockito;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
@@ -36,7 +38,7 @@ import static org.mockito.Mockito.times;
 
 public class TestRetryLoop extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testExponentialBackoffRetryLimit()
     {
         RetrySleeper                    sleeper = new RetrySleeper()
@@ -44,7 +46,7 @@ public class TestRetryLoop extends BaseClassForTests
             @Override
             public void sleepFor(long time, TimeUnit unit) throws InterruptedException
             {
-                Assert.assertTrue(unit.toMillis(time) <= 100);
+                assertTrue(unit.toMillis(time) <= 100);
             }
         };
         ExponentialBackoffRetry         retry = new ExponentialBackoffRetry(1, Integer.MAX_VALUE, 100);
@@ -54,7 +56,7 @@ public class TestRetryLoop extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testRetryLoopWithFailure() throws Exception
     {
         CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 5000, 5000, null, new RetryOneTime(1));
@@ -89,7 +91,7 @@ public class TestRetryLoop extends BaseClassForTests
 
                     default:
                     {
-                        Assert.fail();
+                        fail();
                         break outer;
                     }
                 }
@@ -106,7 +108,7 @@ public class TestRetryLoop extends BaseClassForTests
                 }
             }
 
-            Assert.assertTrue(loopCount >= 2);
+            assertTrue(loopCount >= 2);
         }
         finally
         {
@@ -114,7 +116,7 @@ public class TestRetryLoop extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testRetryLoop() throws Exception
     {
         CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000, 10000, null, new RetryOneTime(1));
@@ -127,7 +129,7 @@ public class TestRetryLoop extends BaseClassForTests
             {
                 if ( ++loopCount > 2 )
                 {
-                    Assert.fail();
+                    fail();
                     break;
                 }
 
@@ -142,7 +144,7 @@ public class TestRetryLoop extends BaseClassForTests
                 }
             }
 
-            Assert.assertTrue(loopCount > 0);
+            assertTrue(loopCount > 0);
         }
         finally
         {
@@ -150,7 +152,7 @@ public class TestRetryLoop extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testRetryForever() throws Exception
     {
         int retryIntervalMs = 1;
@@ -160,12 +162,12 @@ public class TestRetryLoop extends BaseClassForTests
         for (int i = 0; i < 10; i++)
         {
             boolean allowed = retryForever.allowRetry(i, 0, sleeper);
-            Assert.assertTrue(allowed);
+            assertTrue(allowed);
             Mockito.verify(sleeper, times(i + 1)).sleepFor(retryIntervalMs, TimeUnit.MILLISECONDS);
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRetryForeverWithSessionFailed() throws Exception
     {
         final Timing timing = new Timing();
@@ -196,14 +198,14 @@ public class TestRetryLoop extends BaseClassForTests
                 }
             }
 
-            Assert.fail("Should failed with SessionExpiredException.");
+            fail("Should failed with SessionExpiredException.");
         }
         catch ( Exception e )
         {
             if ( e instanceof KeeperException )
             {
                 int rc = ((KeeperException) e).code().intValue();
-                Assert.assertEquals(rc, KeeperException.Code.SESSIONEXPIRED.intValue());
+                assertEquals(rc, KeeperException.Code.SESSIONEXPIRED.intValue());
             }
             else
             {

--- a/curator-client/src/test/java/org/apache/curator/TestSessionFailRetryLoop.java
+++ b/curator-client/src/test/java/org/apache/curator/TestSessionFailRetryLoop.java
@@ -18,18 +18,21 @@
  */
 package org.apache.curator;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.test.Timing;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TestSessionFailRetryLoop extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testRetry() throws Exception
     {
         Timing                          timing = new Timing();
@@ -55,13 +58,13 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
                             {
                                 if ( firstTime.compareAndSet(true, false) )
                                 {
-                                    Assert.assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                    assertNull(client.getZooKeeper().exists("/foo/bar", false));
                                     client.getZooKeeper().getTestable().injectSessionExpiration();
                                     client.getZooKeeper();
                                     client.blockUntilConnectedOrTimedOut();
                                 }
 
-                                Assert.assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                assertNull(client.getZooKeeper().exists("/foo/bar", false));
                                 return null;
                             }
                         }
@@ -75,8 +78,8 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
                             @Override
                             public Void call() throws Exception
                             {
-                                Assert.assertFalse(firstTime.get());
-                                Assert.assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                assertFalse(firstTime.get());
+                                assertNull(client.getZooKeeper().exists("/foo/bar", false));
                                 secondWasDone.set(true);
                                 return null;
                             }
@@ -89,7 +92,7 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
                 }
             }
 
-            Assert.assertTrue(secondWasDone.get());
+            assertTrue(secondWasDone.get());
         }
         finally
         {
@@ -98,7 +101,7 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testRetryStatic() throws Exception
     {
         Timing                          timing = new Timing();
@@ -129,13 +132,13 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
                                 {
                                     if ( firstTime.compareAndSet(true, false) )
                                     {
-                                        Assert.assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                        assertNull(client.getZooKeeper().exists("/foo/bar", false));
                                         client.getZooKeeper().getTestable().injectSessionExpiration();
                                         client.getZooKeeper();
                                         client.blockUntilConnectedOrTimedOut();
                                     }
 
-                                    Assert.assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                    assertNull(client.getZooKeeper().exists("/foo/bar", false));
                                     return null;
                                 }
                             }
@@ -149,8 +152,8 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
                                 @Override
                                 public Void call() throws Exception
                                 {
-                                    Assert.assertFalse(firstTime.get());
-                                    Assert.assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                    assertFalse(firstTime.get());
+                                    assertNull(client.getZooKeeper().exists("/foo/bar", false));
                                     secondWasDone.set(true);
                                     return null;
                                 }
@@ -161,7 +164,7 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
                 }
             );
 
-            Assert.assertTrue(secondWasDone.get());
+            assertTrue(secondWasDone.get());
         }
         finally
         {
@@ -170,7 +173,7 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasic() throws Exception
     {
         final Timing                          timing = new Timing();
@@ -194,14 +197,14 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
                                 @Override
                                 public Void call() throws Exception
                                 {
-                                    Assert.assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                    assertNull(client.getZooKeeper().exists("/foo/bar", false));
                                     client.getZooKeeper().getTestable().injectSessionExpiration();
 
                                     timing.sleepABit();
 
                                     client.getZooKeeper();
                                     client.blockUntilConnectedOrTimedOut();
-                                    Assert.assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                    assertNull(client.getZooKeeper().exists("/foo/bar", false));
                                     return null;
                                 }
                             }
@@ -213,7 +216,7 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
                     }
                 }
 
-                Assert.fail();
+                fail();
             }
             catch ( SessionFailRetryLoop.SessionFailedException dummy )
             {
@@ -227,7 +230,7 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasicStatic() throws Exception
     {
         Timing                          timing = new Timing();
@@ -256,12 +259,12 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
                                     @Override
                                     public Void call() throws Exception
                                     {
-                                        Assert.assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                        assertNull(client.getZooKeeper().exists("/foo/bar", false));
                                         client.getZooKeeper().getTestable().injectSessionExpiration();
 
                                         client.getZooKeeper();
                                         client.blockUntilConnectedOrTimedOut();
-                                        Assert.assertNull(client.getZooKeeper().exists("/foo/bar", false));
+                                        assertNull(client.getZooKeeper().exists("/foo/bar", false));
                                         return null;
                                     }
                                 }

--- a/curator-client/src/test/java/org/apache/curator/TestSessionFailRetryLoop.java
+++ b/curator-client/src/test/java/org/apache/curator/TestSessionFailRetryLoop.java
@@ -22,17 +22,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.test.Timing;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TestSessionFailRetryLoop extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testRetry() throws Exception
     {
         Timing                          timing = new Timing();
@@ -101,7 +102,7 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testRetryStatic() throws Exception
     {
         Timing                          timing = new Timing();
@@ -173,7 +174,7 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasic() throws Exception
     {
         final Timing                          timing = new Timing();
@@ -230,7 +231,7 @@ public class TestSessionFailRetryLoop extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasicStatic() throws Exception
     {
         Timing                          timing = new Timing();

--- a/curator-client/src/test/java/org/apache/curator/utils/TestCloseableExecutorService.java
+++ b/curator-client/src/test/java/org/apache/curator/utils/TestCloseableExecutorService.java
@@ -19,11 +19,13 @@
 
 package org.apache.curator.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -38,13 +40,13 @@ public class TestCloseableExecutorService
 
     private volatile ExecutorService executorService;
 
-    @BeforeMethod
+    @BeforeEach
     public void setup()
     {
         executorService = Executors.newFixedThreadPool(QTY * 2);
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDown()
     {
         executorService.shutdownNow();
@@ -63,9 +65,9 @@ public class TestCloseableExecutorService
                 submitRunnable(service, startLatch, latch);
             }
 
-            Assert.assertTrue(startLatch.await(3, TimeUnit.SECONDS));
+            assertTrue(startLatch.await(3, TimeUnit.SECONDS));
             service.close();
-            Assert.assertTrue(latch.await(3, TimeUnit.SECONDS));
+            assertTrue(latch.await(3, TimeUnit.SECONDS));
         }
         catch ( AssertionError e )
         {
@@ -111,9 +113,9 @@ public class TestCloseableExecutorService
             );
         }
 
-        Assert.assertTrue(startLatch.await(3, TimeUnit.SECONDS));
+        assertTrue(startLatch.await(3, TimeUnit.SECONDS));
         service.close();
-        Assert.assertTrue(latch.await(3, TimeUnit.SECONDS));
+        assertTrue(latch.await(3, TimeUnit.SECONDS));
     }
 
     @Test
@@ -146,14 +148,14 @@ public class TestCloseableExecutorService
             futures.add(future);
         }
 
-        Assert.assertTrue(startLatch.await(3, TimeUnit.SECONDS));
+        assertTrue(startLatch.await(3, TimeUnit.SECONDS));
 
         for ( Future<?> future : futures )
         {
             future.cancel(true);
         }
 
-        Assert.assertEquals(service.size(), 0);
+        assertEquals(service.size(), 0);
     }
 
     @Test
@@ -187,13 +189,13 @@ public class TestCloseableExecutorService
             futures.add(future);
         }
 
-        Assert.assertTrue(startLatch.await(3, TimeUnit.SECONDS));
+        assertTrue(startLatch.await(3, TimeUnit.SECONDS));
         for ( Future<?> future : futures )
         {
             future.cancel(true);
         }
 
-        Assert.assertEquals(service.size(), 0);
+        assertEquals(service.size(), 0);
     }
 
     @Test
@@ -236,10 +238,10 @@ public class TestCloseableExecutorService
             Thread.sleep(100);
         }
 
-        Assert.assertTrue(startLatch.await(3, TimeUnit.SECONDS));
+        assertTrue(startLatch.await(3, TimeUnit.SECONDS));
         service.close();
-        Assert.assertTrue(latch.await(3, TimeUnit.SECONDS));
-        Assert.assertEquals(outsideLatch.getCount(), 1);
+        assertTrue(latch.await(3, TimeUnit.SECONDS));
+        assertEquals(outsideLatch.getCount(), 1);
     }
 
     private void submitRunnable(CloseableExecutorService service, final CountDownLatch startLatch, final CountDownLatch latch)

--- a/curator-client/src/test/java/org/apache/curator/utils/TestCloseableScheduledExecutorService.java
+++ b/curator-client/src/test/java/org/apache/curator/utils/TestCloseableScheduledExecutorService.java
@@ -18,16 +18,17 @@
  */
 package org.apache.curator.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 public class TestCloseableScheduledExecutorService
 {
@@ -36,13 +37,13 @@ public class TestCloseableScheduledExecutorService
 
     private volatile ScheduledExecutorService executorService;
 
-    @BeforeMethod
+    @BeforeEach
     public void setup()
     {
         executorService = Executors.newScheduledThreadPool(QTY * 2);
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDown()
     {
         executorService.shutdownNow();
@@ -68,7 +69,7 @@ public class TestCloseableScheduledExecutorService
                 TimeUnit.MILLISECONDS
         );
 
-        Assert.assertTrue(latch.await((QTY * 2) * DELAY_MS, TimeUnit.MILLISECONDS));
+        assertTrue(latch.await((QTY * 2) * DELAY_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -103,18 +104,18 @@ public class TestCloseableScheduledExecutorService
         Thread.sleep(DELAY_MS * 2);
 
         int innerValue = innerCounter.get();
-        Assert.assertTrue(innerValue > 0);
+        assertTrue(innerValue > 0);
 
         int value = outerCounter.get();
         Thread.sleep(DELAY_MS * 2);
         int newValue = outerCounter.get();
-        Assert.assertTrue(newValue > value);
-        Assert.assertEquals(innerValue, innerCounter.get());
+        assertTrue(newValue > value);
+        assertEquals(innerValue, innerCounter.get());
 
         value = newValue;
         Thread.sleep(DELAY_MS * 2);
         newValue = outerCounter.get();
-        Assert.assertTrue(newValue > value);
-        Assert.assertEquals(innerValue, innerCounter.get());
+        assertTrue(newValue > value);
+        assertEquals(innerValue, innerCounter.get());
     }
 }

--- a/curator-client/src/test/java/org/apache/curator/utils/TestZKPaths.java
+++ b/curator-client/src/test/java/org/apache/curator/utils/TestZKPaths.java
@@ -19,8 +19,8 @@
 
 package org.apache.curator.utils;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -30,58 +30,58 @@ public class TestZKPaths
     @Test
     public void testMakePath()
     {
-        Assert.assertEquals(ZKPaths.makePath(null, "/"), "/");
-        Assert.assertEquals(ZKPaths.makePath("", null), "/");
-        Assert.assertEquals(ZKPaths.makePath("/", null), "/");
-        Assert.assertEquals(ZKPaths.makePath(null, null), "/");
+        assertEquals(ZKPaths.makePath(null, "/"), "/");
+        assertEquals(ZKPaths.makePath("", null), "/");
+        assertEquals(ZKPaths.makePath("/", null), "/");
+        assertEquals(ZKPaths.makePath(null, null), "/");
 
-        Assert.assertEquals(ZKPaths.makePath("/", "/"), "/");
-        Assert.assertEquals(ZKPaths.makePath("", "/"), "/");
-        Assert.assertEquals(ZKPaths.makePath("/", ""), "/");
-        Assert.assertEquals(ZKPaths.makePath("", ""), "/");
+        assertEquals(ZKPaths.makePath("/", "/"), "/");
+        assertEquals(ZKPaths.makePath("", "/"), "/");
+        assertEquals(ZKPaths.makePath("/", ""), "/");
+        assertEquals(ZKPaths.makePath("", ""), "/");
 
-        Assert.assertEquals(ZKPaths.makePath("foo", ""), "/foo");
-        Assert.assertEquals(ZKPaths.makePath("foo", "/"), "/foo");
-        Assert.assertEquals(ZKPaths.makePath("/foo", ""), "/foo");
-        Assert.assertEquals(ZKPaths.makePath("/foo", "/"), "/foo");
+        assertEquals(ZKPaths.makePath("foo", ""), "/foo");
+        assertEquals(ZKPaths.makePath("foo", "/"), "/foo");
+        assertEquals(ZKPaths.makePath("/foo", ""), "/foo");
+        assertEquals(ZKPaths.makePath("/foo", "/"), "/foo");
 
-        Assert.assertEquals(ZKPaths.makePath("foo", null), "/foo");
-        Assert.assertEquals(ZKPaths.makePath("foo", null), "/foo");
-        Assert.assertEquals(ZKPaths.makePath("/foo", null), "/foo");
-        Assert.assertEquals(ZKPaths.makePath("/foo", null), "/foo");
+        assertEquals(ZKPaths.makePath("foo", null), "/foo");
+        assertEquals(ZKPaths.makePath("foo", null), "/foo");
+        assertEquals(ZKPaths.makePath("/foo", null), "/foo");
+        assertEquals(ZKPaths.makePath("/foo", null), "/foo");
 
-        Assert.assertEquals(ZKPaths.makePath("", "bar"), "/bar");
-        Assert.assertEquals(ZKPaths.makePath("/", "bar"), "/bar");
-        Assert.assertEquals(ZKPaths.makePath("", "/bar"), "/bar");
-        Assert.assertEquals(ZKPaths.makePath("/", "/bar"), "/bar");
+        assertEquals(ZKPaths.makePath("", "bar"), "/bar");
+        assertEquals(ZKPaths.makePath("/", "bar"), "/bar");
+        assertEquals(ZKPaths.makePath("", "/bar"), "/bar");
+        assertEquals(ZKPaths.makePath("/", "/bar"), "/bar");
 
-        Assert.assertEquals(ZKPaths.makePath(null, "bar"), "/bar");
-        Assert.assertEquals(ZKPaths.makePath(null, "bar"), "/bar");
-        Assert.assertEquals(ZKPaths.makePath(null, "/bar"), "/bar");
-        Assert.assertEquals(ZKPaths.makePath(null, "/bar"), "/bar");
+        assertEquals(ZKPaths.makePath(null, "bar"), "/bar");
+        assertEquals(ZKPaths.makePath(null, "bar"), "/bar");
+        assertEquals(ZKPaths.makePath(null, "/bar"), "/bar");
+        assertEquals(ZKPaths.makePath(null, "/bar"), "/bar");
 
-        Assert.assertEquals(ZKPaths.makePath("foo", "bar"), "/foo/bar");
-        Assert.assertEquals(ZKPaths.makePath("/foo", "bar"), "/foo/bar");
-        Assert.assertEquals(ZKPaths.makePath("foo", "/bar"), "/foo/bar");
-        Assert.assertEquals(ZKPaths.makePath("/foo", "/bar"), "/foo/bar");
-        Assert.assertEquals(ZKPaths.makePath("/foo", "bar/"), "/foo/bar");
-        Assert.assertEquals(ZKPaths.makePath("/foo/", "/bar/"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("foo", "bar"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("/foo", "bar"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("foo", "/bar"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("/foo", "/bar"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("/foo", "bar/"), "/foo/bar");
+        assertEquals(ZKPaths.makePath("/foo/", "/bar/"), "/foo/bar");
 
-        Assert.assertEquals(ZKPaths.makePath("foo", "bar", "baz"), "/foo/bar/baz");
-        Assert.assertEquals(ZKPaths.makePath("foo", "bar", "baz", "qux"), "/foo/bar/baz/qux");
-        Assert.assertEquals(ZKPaths.makePath("/foo", "/bar", "/baz"), "/foo/bar/baz");
-        Assert.assertEquals(ZKPaths.makePath("/foo/", "/bar/", "/baz/"), "/foo/bar/baz");
-        Assert.assertEquals(ZKPaths.makePath("foo", null, null), "/foo");
-        Assert.assertEquals(ZKPaths.makePath("foo", "bar", null), "/foo/bar");
-        Assert.assertEquals(ZKPaths.makePath("foo", null, "baz"), "/foo/baz");
+        assertEquals(ZKPaths.makePath("foo", "bar", "baz"), "/foo/bar/baz");
+        assertEquals(ZKPaths.makePath("foo", "bar", "baz", "qux"), "/foo/bar/baz/qux");
+        assertEquals(ZKPaths.makePath("/foo", "/bar", "/baz"), "/foo/bar/baz");
+        assertEquals(ZKPaths.makePath("/foo/", "/bar/", "/baz/"), "/foo/bar/baz");
+        assertEquals(ZKPaths.makePath("foo", null, null), "/foo");
+        assertEquals(ZKPaths.makePath("foo", "bar", null), "/foo/bar");
+        assertEquals(ZKPaths.makePath("foo", null, "baz"), "/foo/baz");
     }
 
     @Test
     public void testSplit()
     {
-        Assert.assertEquals(ZKPaths.split("/"), Collections.emptyList());
-        Assert.assertEquals(ZKPaths.split("/test"), Collections.singletonList("test"));
-        Assert.assertEquals(ZKPaths.split("/test/one"), Arrays.asList("test", "one"));
-        Assert.assertEquals(ZKPaths.split("/test/one/two"), Arrays.asList("test", "one", "two"));
+        assertEquals(ZKPaths.split("/"), Collections.emptyList());
+        assertEquals(ZKPaths.split("/test"), Collections.singletonList("test"));
+        assertEquals(ZKPaths.split("/test/one"), Arrays.asList("test", "one"));
+        assertEquals(ZKPaths.split("/test/one/two"), Arrays.asList("test", "one", "two"));
     }
 }

--- a/curator-framework/pom.xml
+++ b/curator-framework/pom.xml
@@ -82,12 +82,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.artsok</groupId>
-            <artifactId>rerunner-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>

--- a/curator-framework/pom.xml
+++ b/curator-framework/pom.xml
@@ -76,8 +76,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.artsok</groupId>
+            <artifactId>rerunner-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/curator-framework/src/test/java/org/apache/curator/framework/ensemble/TestEnsembleProvider.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/ensemble/TestEnsembleProvider.java
@@ -18,6 +18,9 @@
  */
 package org.apache.curator.framework.ensemble;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -28,17 +31,14 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 public class TestEnsembleProvider extends BaseClassForTests
 {
     private final Timing timing = new Timing();
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic()
     {
         Semaphore counter = new Semaphore(0);
@@ -46,7 +46,7 @@ public class TestEnsembleProvider extends BaseClassForTests
         try
         {
             client.start();
-            Assert.assertTrue(timing.acquireSemaphore(counter));
+            assertTrue(timing.acquireSemaphore(counter));
         }
         finally
         {
@@ -54,7 +54,7 @@ public class TestEnsembleProvider extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testAfterSessionExpiration() throws Exception
     {
         TestingServer oldServer = server;
@@ -87,20 +87,20 @@ public class TestEnsembleProvider extends BaseClassForTests
             client.getConnectionStateListenable().addListener(listener);
             client.start();
 
-            Assert.assertTrue(timing.awaitLatch(connectedLatch));
+            assertTrue(timing.awaitLatch(connectedLatch));
 
             server.stop();
 
-            Assert.assertTrue(timing.awaitLatch(lostLatch));
+            assertTrue(timing.awaitLatch(lostLatch));
             counter.drainPermits();
             for ( int i = 0; i < 5; ++i )
             {
                 // the ensemble provider should still be called periodically when the connection is lost
-                Assert.assertTrue(timing.acquireSemaphore(counter), "Failed when i is: " + i);
+                assertTrue(timing.acquireSemaphore(counter), "Failed when i is: " + i);
             }
 
             server = new TestingServer();   // this changes the CountingEnsembleProvider's value for getConnectionString() - connection should notice this and recover
-            Assert.assertTrue(timing.awaitLatch(reconnectedLatch));
+            assertTrue(timing.awaitLatch(reconnectedLatch));
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/ensemble/TestEnsembleProvider.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/ensemble/TestEnsembleProvider.java
@@ -20,7 +20,6 @@ package org.apache.curator.framework.ensemble;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -31,6 +30,8 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 
@@ -38,7 +39,7 @@ public class TestEnsembleProvider extends BaseClassForTests
 {
     private final Timing timing = new Timing();
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic()
     {
         Semaphore counter = new Semaphore(0);
@@ -54,7 +55,7 @@ public class TestEnsembleProvider extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAfterSessionExpiration() throws Exception
     {
         TestingServer oldServer = server;

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestBlockUntilConnected.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestBlockUntilConnected.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -33,6 +32,8 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
@@ -43,7 +44,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
     /**
      * Test the case where we're already connected
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBlockUntilConnectedCurrentlyConnected() throws Exception
     {
         Timing timing = new Timing();
@@ -85,7 +86,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
     /**
      * Test the case where we are not currently connected and never have been
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBlockUntilConnectedCurrentlyNeverConnected()
     {
         CuratorFramework client = CuratorFrameworkFactory.builder().
@@ -111,7 +112,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
     /**
      * Test the case where we are not currently connected, but have been previously
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBlockUntilConnectedCurrentlyAwaitingReconnect()
     {
         Timing timing = new Timing();
@@ -166,7 +167,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
      * Test the case where we are not currently connected and time out before a
      * connection becomes available.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBlockUntilConnectedConnectTimeout()
     {
         //Kill the server
@@ -196,7 +197,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
      * Test the case where we are not currently connected and the thread gets interrupted
      * prior to a connection becoming available
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBlockUntilConnectedInterrupt()
     {
         //Kill the server
@@ -240,7 +241,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
     /**
      * Test that we are actually connected every time that we block until connection is established in a tight loop.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBlockUntilConnectedTightLoop() throws InterruptedException
     {
         CuratorFramework client;

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestBlockUntilConnected.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestBlockUntilConnected.java
@@ -19,6 +19,11 @@
 
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -28,8 +33,6 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
@@ -40,7 +43,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
     /**
      * Test the case where we're already connected
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBlockUntilConnectedCurrentlyConnected() throws Exception
     {
         Timing timing = new Timing();
@@ -66,12 +69,12 @@ public class TestBlockUntilConnected extends BaseClassForTests
 
             client.start();
 
-            Assert.assertTrue(timing.awaitLatch(connectedLatch), "Timed out awaiting latch");
-            Assert.assertTrue(client.blockUntilConnected(1, TimeUnit.SECONDS), "Not connected");
+            assertTrue(timing.awaitLatch(connectedLatch), "Timed out awaiting latch");
+            assertTrue(client.blockUntilConnected(1, TimeUnit.SECONDS), "Not connected");
         }
         catch ( InterruptedException e )
         {
-            Assert.fail("Unexpected interruption");
+            fail("Unexpected interruption");
         }
         finally
         {
@@ -82,7 +85,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
     /**
      * Test the case where we are not currently connected and never have been
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBlockUntilConnectedCurrentlyNeverConnected()
     {
         CuratorFramework client = CuratorFrameworkFactory.builder().
@@ -93,11 +96,11 @@ public class TestBlockUntilConnected extends BaseClassForTests
         try
         {
             client.start();
-            Assert.assertTrue(client.blockUntilConnected(5, TimeUnit.SECONDS), "Not connected");
+            assertTrue(client.blockUntilConnected(5, TimeUnit.SECONDS), "Not connected");
         }
         catch ( InterruptedException e )
         {
-            Assert.fail("Unexpected interruption");
+            fail("Unexpected interruption");
         }
         finally
         {
@@ -108,7 +111,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
     /**
      * Test the case where we are not currently connected, but have been previously
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBlockUntilConnectedCurrentlyAwaitingReconnect()
     {
         Timing timing = new Timing();
@@ -137,21 +140,21 @@ public class TestBlockUntilConnected extends BaseClassForTests
             client.start();
 
             //Block until we're connected
-            Assert.assertTrue(client.blockUntilConnected(5, TimeUnit.SECONDS), "Failed to connect");
+            assertTrue(client.blockUntilConnected(5, TimeUnit.SECONDS), "Failed to connect");
 
             //Kill the server
             CloseableUtils.closeQuietly(server);
 
             //Wait until we hit the lost state
-            Assert.assertTrue(timing.awaitLatch(lostLatch), "Failed to reach LOST state");
+            assertTrue(timing.awaitLatch(lostLatch), "Failed to reach LOST state");
 
             server = new TestingServer(server.getPort(), server.getTempDirectory());
 
-            Assert.assertTrue(client.blockUntilConnected(5, TimeUnit.SECONDS), "Not connected");
+            assertTrue(client.blockUntilConnected(5, TimeUnit.SECONDS), "Not connected");
         }
         catch ( Exception e )
         {
-            Assert.fail("Unexpected exception " + e);
+            fail("Unexpected exception " + e);
         }
         finally
         {
@@ -163,7 +166,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
      * Test the case where we are not currently connected and time out before a
      * connection becomes available.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBlockUntilConnectedConnectTimeout()
     {
         //Kill the server
@@ -177,11 +180,11 @@ public class TestBlockUntilConnected extends BaseClassForTests
         try
         {
             client.start();
-            Assert.assertFalse(client.blockUntilConnected(5, TimeUnit.SECONDS), "Connected");
+            assertFalse(client.blockUntilConnected(5, TimeUnit.SECONDS), "Connected");
         }
         catch ( InterruptedException e )
         {
-            Assert.fail("Unexpected interruption");
+            fail("Unexpected interruption");
         }
         finally
         {
@@ -193,7 +196,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
      * Test the case where we are not currently connected and the thread gets interrupted
      * prior to a connection becoming available
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBlockUntilConnectedInterrupt()
     {
         //Kill the server
@@ -222,7 +225,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
             }, 3000);
 
             client.blockUntilConnected(5, TimeUnit.SECONDS);
-            Assert.fail("Expected interruption did not occur");
+            fail("Expected interruption did not occur");
         }
         catch ( InterruptedException e )
         {
@@ -237,7 +240,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
     /**
      * Test that we are actually connected every time that we block until connection is established in a tight loop.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBlockUntilConnectedTightLoop() throws InterruptedException
     {
         CuratorFramework client;
@@ -249,7 +252,7 @@ public class TestBlockUntilConnected extends BaseClassForTests
                 client.start();
                 client.blockUntilConnected();
 
-                Assert.assertTrue(client.getZookeeperClient().isConnected(), "Not connected after blocking for connection #" + i);
+                assertTrue(client.getZookeeperClient().isConnected(), "Not connected after blocking for connection #" + i);
             }
             finally
             {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompression.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompression.java
@@ -18,19 +18,22 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.CompressionProvider;
 import org.apache.curator.retry.RetryOneTime;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestCompression extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCompressionProvider() throws Exception
     {
         final byte[]            data = "here's a string".getBytes();
@@ -72,19 +75,19 @@ public class TestCompression extends BaseClassForTests
 
             client.create().compressed().creatingParentsIfNeeded().forPath("/a/b/c", data);
 
-            Assert.assertNotEquals(data, client.getData().forPath("/a/b/c"));
-            Assert.assertEquals(data.length, client.getData().decompressed().forPath("/a/b/c").length);
+            assertNotEquals(data, client.getData().forPath("/a/b/c"));
+            assertEquals(data.length, client.getData().decompressed().forPath("/a/b/c").length);
         }
         finally
         {
             CloseableUtils.closeQuietly(client);
         }
 
-        Assert.assertEquals(compressCounter.get(), 1);
-        Assert.assertEquals(decompressCounter.get(), 1);
+        assertEquals(compressCounter.get(), 1);
+        assertEquals(decompressCounter.get(), 1);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSetData() throws Exception
     {
         final byte[]            data = "here's a string".getBytes();
@@ -95,10 +98,10 @@ public class TestCompression extends BaseClassForTests
             client.start();
 
             client.create().creatingParentsIfNeeded().forPath("/a/b/c", data);
-            Assert.assertEquals(data, client.getData().forPath("/a/b/c"));
+            assertArrayEquals(data, client.getData().forPath("/a/b/c"));
 
             client.setData().compressed().forPath("/a/b/c", data);
-            Assert.assertEquals(data.length, client.getData().decompressed().forPath("/a/b/c").length);
+            assertEquals(data.length, client.getData().decompressed().forPath("/a/b/c").length);
         }
         finally
         {
@@ -106,7 +109,7 @@ public class TestCompression extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSimple() throws Exception
     {
         final byte[]            data = "here's a string".getBytes();
@@ -118,8 +121,8 @@ public class TestCompression extends BaseClassForTests
 
             client.create().compressed().creatingParentsIfNeeded().forPath("/a/b/c", data);
 
-            Assert.assertNotEquals(data, client.getData().forPath("/a/b/c"));
-            Assert.assertEquals(data.length, client.getData().decompressed().forPath("/a/b/c").length);
+            assertNotEquals(data, client.getData().forPath("/a/b/c"));
+            assertEquals(data.length, client.getData().decompressed().forPath("/a/b/c").length);
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompression.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompression.java
@@ -22,18 +22,19 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.CompressionProvider;
 import org.apache.curator.retry.RetryOneTime;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestCompression extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCompressionProvider() throws Exception
     {
         final byte[]            data = "here's a string".getBytes();
@@ -87,7 +88,7 @@ public class TestCompression extends BaseClassForTests
         assertEquals(decompressCounter.get(), 1);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetData() throws Exception
     {
         final byte[]            data = "here's a string".getBytes();
@@ -109,7 +110,7 @@ public class TestCompression extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSimple() throws Exception
     {
         final byte[]            data = "here's a string".getBytes();

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionNew.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionNew.java
@@ -18,18 +18,20 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 public class TestCompressionInTransactionNew extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSetData() throws Exception
     {
         final String path = "/a";
@@ -43,12 +45,12 @@ public class TestCompressionInTransactionNew extends BaseClassForTests
             //Create uncompressed data in a transaction
             CuratorOp op = client.transactionOp().create().forPath(path, data);
             client.transaction().forOperations(op);
-            Assert.assertEquals(data, client.getData().forPath(path));
+            assertArrayEquals(data, client.getData().forPath(path));
 
             //Create compressed data in transaction
             op = client.transactionOp().setData().compressed().forPath(path, data);
             client.transaction().forOperations(op);
-            Assert.assertEquals(data, client.getData().decompressed().forPath(path));
+            assertArrayEquals(data, client.getData().decompressed().forPath(path));
         }
         finally
         {
@@ -56,7 +58,7 @@ public class TestCompressionInTransactionNew extends BaseClassForTests
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSetCompressedAndUncompressed() throws Exception
     {
         final String path1 = "/a";
@@ -76,18 +78,18 @@ public class TestCompressionInTransactionNew extends BaseClassForTests
             client.transaction().forOperations(op1, op2);
 
             //Check they exist
-            Assert.assertNotNull(client.checkExists().forPath(path1));
-            Assert.assertNotNull(client.checkExists().forPath(path2));
+            assertNotNull(client.checkExists().forPath(path1));
+            assertNotNull(client.checkExists().forPath(path2));
             
             //Set the nodes, path1 compressed, path2 uncompressed.
             op1 = client.transactionOp().setData().compressed().forPath(path1, data1);
             op2 = client.transactionOp().setData().forPath(path2, data2);
             client.transaction().forOperations(op1, op2);
             
-            Assert.assertNotEquals(data1, client.getData().forPath(path1));
-            Assert.assertEquals(data1, client.getData().decompressed().forPath(path1));
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
       
-            Assert.assertEquals(data2, client.getData().forPath(path2));            
+            assertArrayEquals(data2, client.getData().forPath(path2));
         }
         finally
         {
@@ -95,7 +97,7 @@ public class TestCompressionInTransactionNew extends BaseClassForTests
         }
     }    
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSimple() throws Exception
     {
         final String path1 = "/a";
@@ -114,11 +116,11 @@ public class TestCompressionInTransactionNew extends BaseClassForTests
 
             client.transaction().forOperations(op1, op2);
 
-            Assert.assertNotEquals(data1, client.getData().forPath(path1));
-            Assert.assertEquals(data1, client.getData().decompressed().forPath(path1));
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
             
-            Assert.assertNotEquals(data2, client.getData().forPath(path2));
-            Assert.assertEquals(data2, client.getData().decompressed().forPath(path2));            
+            assertNotEquals(data2, client.getData().forPath(path2));
+            assertArrayEquals(data2, client.getData().decompressed().forPath(path2));
         }
         finally
         {
@@ -131,7 +133,7 @@ public class TestCompressionInTransactionNew extends BaseClassForTests
      * the same transaction
      * @throws Exception
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateCompressedAndUncompressed() throws Exception
     {
         final String path1 = "/a";
@@ -149,10 +151,10 @@ public class TestCompressionInTransactionNew extends BaseClassForTests
             CuratorOp op2 = client.transactionOp().create().forPath(path2, data2);
             client.transaction().forOperations(op1, op2);
 
-            Assert.assertNotEquals(data1, client.getData().forPath(path1));
-            Assert.assertEquals(data1, client.getData().decompressed().forPath(path1));
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
       
-            Assert.assertEquals(data2, client.getData().forPath(path2));            
+            assertArrayEquals(data2, client.getData().forPath(path2));
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionNew.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionNew.java
@@ -21,17 +21,17 @@ package org.apache.curator.framework.imps;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
 
 public class TestCompressionInTransactionNew extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetData() throws Exception
     {
         final String path = "/a";
@@ -58,7 +58,7 @@ public class TestCompressionInTransactionNew extends BaseClassForTests
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetCompressedAndUncompressed() throws Exception
     {
         final String path1 = "/a";
@@ -97,7 +97,7 @@ public class TestCompressionInTransactionNew extends BaseClassForTests
         }
     }    
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSimple() throws Exception
     {
         final String path1 = "/a";
@@ -133,7 +133,7 @@ public class TestCompressionInTransactionNew extends BaseClassForTests
      * the same transaction
      * @throws Exception
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateCompressedAndUncompressed() throws Exception
     {
         final String path1 = "/a";

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionOld.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionOld.java
@@ -22,17 +22,17 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation")
 public class TestCompressionInTransactionOld extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetData() throws Exception
     {
         final String path = "/a";
@@ -57,7 +57,7 @@ public class TestCompressionInTransactionOld extends BaseClassForTests
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetCompressedAndUncompressed() throws Exception
     {
         final String path1 = "/a";
@@ -94,7 +94,7 @@ public class TestCompressionInTransactionOld extends BaseClassForTests
         }
     }    
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSimple() throws Exception
     {
         final String path1 = "/a";
@@ -128,7 +128,7 @@ public class TestCompressionInTransactionOld extends BaseClassForTests
      * the same transaction
      * @throws Exception
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateCompressedAndUncompressed() throws Exception
     {
         final String path1 = "/a";

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionOld.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionOld.java
@@ -18,21 +18,21 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.api.CompressionProvider;
 import org.apache.curator.retry.RetryOneTime;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 @SuppressWarnings("deprecation")
 public class TestCompressionInTransactionOld extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSetData() throws Exception
     {
         final String path = "/a";
@@ -45,11 +45,11 @@ public class TestCompressionInTransactionOld extends BaseClassForTests
 
             //Create uncompressed data in a transaction
             client.inTransaction().create().forPath(path, data).and().commit();
-            Assert.assertEquals(data, client.getData().forPath(path));
+            assertArrayEquals(data, client.getData().forPath(path));
 
             //Create compressed data in transaction
             client.inTransaction().setData().compressed().forPath(path, data).and().commit();
-            Assert.assertEquals(data, client.getData().decompressed().forPath(path));
+            assertArrayEquals(data, client.getData().decompressed().forPath(path));
         }
         finally
         {
@@ -57,7 +57,7 @@ public class TestCompressionInTransactionOld extends BaseClassForTests
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSetCompressedAndUncompressed() throws Exception
     {
         final String path1 = "/a";
@@ -76,17 +76,17 @@ public class TestCompressionInTransactionOld extends BaseClassForTests
             create().forPath(path2).and().commit();
 
             //Check they exist
-            Assert.assertNotNull(client.checkExists().forPath(path1));
-            Assert.assertNotNull(client.checkExists().forPath(path2));
+            assertNotNull(client.checkExists().forPath(path1));
+            assertNotNull(client.checkExists().forPath(path2));
             
             //Set the nodes, path1 compressed, path2 uncompressed.
             client.inTransaction().setData().compressed().forPath(path1, data1).and().
             setData().forPath(path2, data2).and().commit();
             
-            Assert.assertNotEquals(data1, client.getData().forPath(path1));
-            Assert.assertEquals(data1, client.getData().decompressed().forPath(path1));
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
       
-            Assert.assertEquals(data2, client.getData().forPath(path2));            
+            assertArrayEquals(data2, client.getData().forPath(path2));
         }
         finally
         {
@@ -94,7 +94,7 @@ public class TestCompressionInTransactionOld extends BaseClassForTests
         }
     }    
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSimple() throws Exception
     {
         final String path1 = "/a";
@@ -111,11 +111,11 @@ public class TestCompressionInTransactionOld extends BaseClassForTests
             client.inTransaction().create().compressed().forPath(path1, data1).and().
             create().compressed().forPath(path2, data2).and().commit();
 
-            Assert.assertNotEquals(data1, client.getData().forPath(path1));
-            Assert.assertEquals(data1, client.getData().decompressed().forPath(path1));
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
             
-            Assert.assertNotEquals(data2, client.getData().forPath(path2));
-            Assert.assertEquals(data2, client.getData().decompressed().forPath(path2));            
+            assertNotEquals(data2, client.getData().forPath(path2));
+            assertArrayEquals(data2, client.getData().decompressed().forPath(path2));
         }
         finally
         {
@@ -128,7 +128,7 @@ public class TestCompressionInTransactionOld extends BaseClassForTests
      * the same transaction
      * @throws Exception
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateCompressedAndUncompressed() throws Exception
     {
         final String path1 = "/a";
@@ -145,10 +145,10 @@ public class TestCompressionInTransactionOld extends BaseClassForTests
             client.inTransaction().create().compressed().forPath(path1, data1).and().
             create().forPath(path2, data2).and().commit();
 
-            Assert.assertNotEquals(data1, client.getData().forPath(path1));
-            Assert.assertEquals(data1, client.getData().decompressed().forPath(path1));
+            assertNotEquals(data1, client.getData().forPath(path1));
+            assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
       
-            Assert.assertEquals(data2, client.getData().forPath(path2));            
+            assertArrayEquals(data2, client.getData().forPath(path2));
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreate.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreate.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
@@ -36,6 +35,8 @@ import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -81,7 +82,7 @@ public class TestCreate extends BaseClassForTests
     /**
      * Tests that the ACL list provided to the create builder is used for creating the parents.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateWithParentsWithAcl() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -103,7 +104,7 @@ public class TestCreate extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateWithParentsWithAclApplyToParents() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -128,7 +129,7 @@ public class TestCreate extends BaseClassForTests
     /**
      * Tests that the ACL list provided to the create builder is used for creating the parents.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateWithParentsWithAclInBackground() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -159,7 +160,7 @@ public class TestCreate extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateWithParentsWithAclApplyToParentsInBackground() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -193,7 +194,7 @@ public class TestCreate extends BaseClassForTests
     /**
      * Tests that if no ACL list provided to the create builder, then the ACL list is created based on the client's ACLProvider.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateWithParentsWithoutAcl() throws Exception
     {
         CuratorFramework client = createClient(testACLProvider);
@@ -219,7 +220,7 @@ public class TestCreate extends BaseClassForTests
     /**
      * Tests that if no ACL list provided to the create builder, then the ACL list is created based on the client's ACLProvider.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateWithParentsWithoutAclInBackground() throws Exception
     {
         CuratorFramework client = createClient(testACLProvider);
@@ -253,7 +254,7 @@ public class TestCreate extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateProtectedUtils() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.builder().
@@ -279,7 +280,7 @@ public class TestCreate extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testProtectedUtils() throws Exception
     {
         String name = "_c_53345f98-9423-4e0c-a7b5-9f819e3ec2e1-yo";

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreate.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreate.java
@@ -18,6 +18,12 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.apache.zookeeper.ZooDefs.Ids.ANYONE_ID_UNSAFE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
@@ -30,15 +36,11 @@ import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
-import static org.apache.zookeeper.ZooDefs.Ids.ANYONE_ID_UNSAFE;
 
 public class TestCreate extends BaseClassForTests
 {
@@ -79,7 +81,7 @@ public class TestCreate extends BaseClassForTests
     /**
      * Tests that the ACL list provided to the create builder is used for creating the parents.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateWithParentsWithAcl() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -91,9 +93,9 @@ public class TestCreate extends BaseClassForTests
             List<ACL> acl = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, ANYONE_ID_UNSAFE));
             client.create().creatingParentsIfNeeded().withACL(acl).forPath(path);
             List<ACL> actual_bar_foo = client.getACL().forPath(path);
-            Assert.assertEquals(actual_bar_foo, acl);
+            assertEquals(actual_bar_foo, acl);
             List<ACL> actual_bar = client.getACL().forPath("/bar");
-            Assert.assertEquals(actual_bar, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+            assertEquals(actual_bar, ZooDefs.Ids.OPEN_ACL_UNSAFE);
         }
         finally
         {
@@ -101,7 +103,7 @@ public class TestCreate extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateWithParentsWithAclApplyToParents() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -113,9 +115,9 @@ public class TestCreate extends BaseClassForTests
             List<ACL> acl = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, ANYONE_ID_UNSAFE));
             client.create().creatingParentsIfNeeded().withACL(acl, true).forPath(path);
             List<ACL> actual_bar_foo = client.getACL().forPath(path);
-            Assert.assertEquals(actual_bar_foo, acl);
+            assertEquals(actual_bar_foo, acl);
             List<ACL> actual_bar = client.getACL().forPath("/bar");
-            Assert.assertEquals(actual_bar, acl);
+            assertEquals(actual_bar, acl);
         }
         finally
         {
@@ -126,7 +128,7 @@ public class TestCreate extends BaseClassForTests
     /**
      * Tests that the ACL list provided to the create builder is used for creating the parents.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateWithParentsWithAclInBackground() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -145,11 +147,11 @@ public class TestCreate extends BaseClassForTests
                 }
             };
             client.create().creatingParentsIfNeeded().withACL(acl).inBackground(callback).forPath(path);
-            Assert.assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
+            assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
             List<ACL> actual_bar_foo = client.getACL().forPath(path);
-            Assert.assertEquals(actual_bar_foo, acl);
+            assertEquals(actual_bar_foo, acl);
             List<ACL> actual_bar = client.getACL().forPath("/bar");
-            Assert.assertEquals(actual_bar, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+            assertEquals(actual_bar, ZooDefs.Ids.OPEN_ACL_UNSAFE);
         }
         finally
         {
@@ -157,7 +159,7 @@ public class TestCreate extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateWithParentsWithAclApplyToParentsInBackground() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -176,11 +178,11 @@ public class TestCreate extends BaseClassForTests
                 }
             };
             client.create().creatingParentsIfNeeded().withACL(acl, true).inBackground(callback).forPath(path);
-            Assert.assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
+            assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
             List<ACL> actual_bar_foo = client.getACL().forPath(path);
-            Assert.assertEquals(actual_bar_foo, acl);
+            assertEquals(actual_bar_foo, acl);
             List<ACL> actual_bar = client.getACL().forPath("/bar");
-            Assert.assertEquals(actual_bar, acl);
+            assertEquals(actual_bar, acl);
         }
         finally
         {
@@ -191,7 +193,7 @@ public class TestCreate extends BaseClassForTests
     /**
      * Tests that if no ACL list provided to the create builder, then the ACL list is created based on the client's ACLProvider.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateWithParentsWithoutAcl() throws Exception
     {
         CuratorFramework client = createClient(testACLProvider);
@@ -202,11 +204,11 @@ public class TestCreate extends BaseClassForTests
             String path = "/bar/foo/boo";
             client.create().creatingParentsIfNeeded().forPath(path);
             List<ACL> actual_bar_foo_boo = client.getACL().forPath("/bar/foo/boo");
-            Assert.assertEquals(actual_bar_foo_boo, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+            assertEquals(actual_bar_foo_boo, ZooDefs.Ids.OPEN_ACL_UNSAFE);
             List<ACL> actual_bar_foo = client.getACL().forPath("/bar/foo");
-            Assert.assertEquals(actual_bar_foo, READ_CREATE_WRITE);
+            assertEquals(actual_bar_foo, READ_CREATE_WRITE);
             List<ACL> actual_bar = client.getACL().forPath("/bar");
-            Assert.assertEquals(actual_bar, READ_CREATE);
+            assertEquals(actual_bar, READ_CREATE);
         }
         finally
         {
@@ -217,7 +219,7 @@ public class TestCreate extends BaseClassForTests
     /**
      * Tests that if no ACL list provided to the create builder, then the ACL list is created based on the client's ACLProvider.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateWithParentsWithoutAclInBackground() throws Exception
     {
         CuratorFramework client = createClient(testACLProvider);
@@ -237,13 +239,13 @@ public class TestCreate extends BaseClassForTests
 
             final String path = "/bar/foo/boo";
             client.create().creatingParentsIfNeeded().inBackground(callback).forPath(path);
-            Assert.assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
+            assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
             List<ACL> actual_bar_foo_boo = client.getACL().forPath(path);
-            Assert.assertEquals(actual_bar_foo_boo, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+            assertEquals(actual_bar_foo_boo, ZooDefs.Ids.OPEN_ACL_UNSAFE);
             List<ACL> actual_bar_foo = client.getACL().forPath("/bar/foo");
-            Assert.assertEquals(actual_bar_foo, READ_CREATE_WRITE);
+            assertEquals(actual_bar_foo, READ_CREATE_WRITE);
             List<ACL> actual_bar = client.getACL().forPath("/bar");
-            Assert.assertEquals(actual_bar, READ_CREATE);
+            assertEquals(actual_bar, READ_CREATE);
         }
         finally
         {
@@ -251,7 +253,7 @@ public class TestCreate extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateProtectedUtils() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.builder().
@@ -262,47 +264,47 @@ public class TestCreate extends BaseClassForTests
             client.start();
             client.blockUntilConnected();
             client.create().forPath("/parent");
-            Assert.assertEquals(client.getChildren().forPath("/parent").size(), 0);
+            assertEquals(client.getChildren().forPath("/parent").size(), 0);
             client.create().withProtection().withMode(CreateMode.EPHEMERAL).forPath("/parent/test");
             final List<String> children = client.getChildren().forPath("/parent");
-            Assert.assertEquals(1, children.size());
+            assertEquals(1, children.size());
             final String testZNodeName = children.get(0);
-            Assert.assertEquals(testZNodeName.length(), ProtectedUtils.PROTECTED_PREFIX_WITH_UUID_LENGTH + "test".length());
-            Assert.assertTrue(testZNodeName.startsWith(ProtectedUtils.PROTECTED_PREFIX));
-            Assert.assertEquals(testZNodeName.charAt(ProtectedUtils.PROTECTED_PREFIX_WITH_UUID_LENGTH - 1), ProtectedUtils.PROTECTED_SEPARATOR);
-            Assert.assertTrue(ProtectedUtils.isProtectedZNode(testZNodeName));
-            Assert.assertEquals(ProtectedUtils.normalize(testZNodeName), "test");
-            Assert.assertFalse(ProtectedUtils.isProtectedZNode("parent"));
-            Assert.assertEquals(ProtectedUtils.normalize("parent"), "parent");
+            assertEquals(testZNodeName.length(), ProtectedUtils.PROTECTED_PREFIX_WITH_UUID_LENGTH + "test".length());
+            assertTrue(testZNodeName.startsWith(ProtectedUtils.PROTECTED_PREFIX));
+            assertEquals(testZNodeName.charAt(ProtectedUtils.PROTECTED_PREFIX_WITH_UUID_LENGTH - 1), ProtectedUtils.PROTECTED_SEPARATOR);
+            assertTrue(ProtectedUtils.isProtectedZNode(testZNodeName));
+            assertEquals(ProtectedUtils.normalize(testZNodeName), "test");
+            assertFalse(ProtectedUtils.isProtectedZNode("parent"));
+            assertEquals(ProtectedUtils.normalize("parent"), "parent");
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testProtectedUtils() throws Exception
     {
         String name = "_c_53345f98-9423-4e0c-a7b5-9f819e3ec2e1-yo";
-        Assert.assertTrue(ProtectedUtils.isProtectedZNode(name));
-        Assert.assertEquals(ProtectedUtils.normalize(name), "yo");
-        Assert.assertEquals(ProtectedUtils.extractProtectedId(name).get(), "53345f98-9423-4e0c-a7b5-9f819e3ec2e1");
+        assertTrue(ProtectedUtils.isProtectedZNode(name));
+        assertEquals(ProtectedUtils.normalize(name), "yo");
+        assertEquals(ProtectedUtils.extractProtectedId(name).get(), "53345f98-9423-4e0c-a7b5-9f819e3ec2e1");
         name = "c_53345f98-9423-4e0c-a7b5-9f819e3ec2e1-yo";
-        Assert.assertFalse(ProtectedUtils.isProtectedZNode(name));
-        Assert.assertEquals(ProtectedUtils.normalize(name), name);
-        Assert.assertEquals(ProtectedUtils.extractProtectedId(name), Optional.<String>empty());
+        assertFalse(ProtectedUtils.isProtectedZNode(name));
+        assertEquals(ProtectedUtils.normalize(name), name);
+        assertEquals(ProtectedUtils.extractProtectedId(name), Optional.<String>empty());
         name = "_c_53345f98-hola-4e0c-a7b5-9f819e3ec2e1-yo";
-        Assert.assertFalse(ProtectedUtils.isProtectedZNode(name));
-        Assert.assertEquals(ProtectedUtils.normalize(name), name);
-        Assert.assertEquals(ProtectedUtils.extractProtectedId(name), Optional.<String>empty());
+        assertFalse(ProtectedUtils.isProtectedZNode(name));
+        assertEquals(ProtectedUtils.normalize(name), name);
+        assertEquals(ProtectedUtils.extractProtectedId(name), Optional.<String>empty());
         name = "_c_53345f98-hola-4e0c-a7b5-9f819e3ec2e1+yo";
-        Assert.assertFalse(ProtectedUtils.isProtectedZNode(name));
-        Assert.assertEquals(ProtectedUtils.normalize(name), name);
-        Assert.assertEquals(ProtectedUtils.extractProtectedId(name), Optional.<String>empty());
+        assertFalse(ProtectedUtils.isProtectedZNode(name));
+        assertEquals(ProtectedUtils.normalize(name), name);
+        assertEquals(ProtectedUtils.extractProtectedId(name), Optional.<String>empty());
         name = "_c_53345f98-9423-4e0c-a7b5-9f819e3ec2e1-yo";
-        Assert.assertEquals(name, ProtectedUtils.toProtectedZNode("yo", "53345f98-9423-4e0c-a7b5-9f819e3ec2e1"));
-        Assert.assertEquals("yo", ProtectedUtils.toProtectedZNode("yo", null));
+        assertEquals(name, ProtectedUtils.toProtectedZNode("yo", "53345f98-9423-4e0c-a7b5-9f819e3ec2e1"));
+        assertEquals("yo", ProtectedUtils.toProtectedZNode("yo", null));
         String path = ZKPaths.makePath("hola", "yo");
-        Assert.assertEquals(ProtectedUtils.toProtectedZNodePath(path, "53345f98-9423-4e0c-a7b5-9f819e3ec2e1"), ZKPaths.makePath("hola", name));
-        Assert.assertEquals(ProtectedUtils.toProtectedZNodePath(path, null), path);
+        assertEquals(ProtectedUtils.toProtectedZNodePath(path, "53345f98-9423-4e0c-a7b5-9f819e3ec2e1"), ZKPaths.makePath("hola", name));
+        assertEquals(ProtectedUtils.toProtectedZNodePath(path, null), path);
         path = ZKPaths.makePath("hola", name);
-        Assert.assertEquals(ProtectedUtils.normalizePath(path), "/hola/yo");
+        assertEquals(ProtectedUtils.normalizePath(path), "/hola/yo");
     }
 }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreateReturningStat.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreateReturningStat.java
@@ -18,18 +18,23 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.data.Stat;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -48,10 +53,10 @@ public class TestCreateReturningStat extends CuratorTestBase
     {
         Stat queriedStat = client.checkExists().forPath(path);
         
-        Assert.assertEquals(queriedStat, expected);
+        assertEquals(queriedStat, expected);
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testOrSetDataStoringStatIn() throws Exception {
         try (CuratorFramework client = createClient())
         {
@@ -62,26 +67,26 @@ public class TestCreateReturningStat extends CuratorTestBase
 
             final Stat versionZeroStat = new Stat();
             client.create().orSetData().storingStatIn(versionZeroStat).forPath(path);
-            Assert.assertEquals(0, versionZeroStat.getVersion());
+            assertEquals(0, versionZeroStat.getVersion());
 
             final Stat versionOneStat = new Stat();
             client.create().orSetData().storingStatIn(versionOneStat).forPath(path);
             
-            Assert.assertEquals(versionZeroStat.getAversion(), versionOneStat.getAversion());
-            Assert.assertEquals(versionZeroStat.getCtime(), versionOneStat.getCtime());
-            Assert.assertEquals(versionZeroStat.getCversion(), versionOneStat.getCversion());
-            Assert.assertEquals(versionZeroStat.getCzxid(), versionOneStat.getCzxid());
-            Assert.assertEquals(versionZeroStat.getDataLength(), versionOneStat.getDataLength());
-            Assert.assertEquals(versionZeroStat.getEphemeralOwner(), versionOneStat.getEphemeralOwner());
-            Assert.assertTrue(versionZeroStat.getMtime() <= versionOneStat.getMtime());
-            Assert.assertNotEquals(versionZeroStat.getMzxid(), versionOneStat.getMzxid());
-            Assert.assertEquals(versionZeroStat.getNumChildren(), versionOneStat.getNumChildren());
-            Assert.assertEquals(versionZeroStat.getPzxid(), versionOneStat.getPzxid());
-            Assert.assertEquals(1, versionOneStat.getVersion());
+            assertEquals(versionZeroStat.getAversion(), versionOneStat.getAversion());
+            assertEquals(versionZeroStat.getCtime(), versionOneStat.getCtime());
+            assertEquals(versionZeroStat.getCversion(), versionOneStat.getCversion());
+            assertEquals(versionZeroStat.getCzxid(), versionOneStat.getCzxid());
+            assertEquals(versionZeroStat.getDataLength(), versionOneStat.getDataLength());
+            assertEquals(versionZeroStat.getEphemeralOwner(), versionOneStat.getEphemeralOwner());
+            assertTrue(versionZeroStat.getMtime() <= versionOneStat.getMtime());
+            assertNotEquals(versionZeroStat.getMzxid(), versionOneStat.getMzxid());
+            assertEquals(versionZeroStat.getNumChildren(), versionOneStat.getNumChildren());
+            assertEquals(versionZeroStat.getPzxid(), versionOneStat.getPzxid());
+            assertEquals(1, versionOneStat.getVersion());
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateReturningStat() throws Exception
     {
         CuratorFramework client = createClient();
@@ -101,7 +106,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateReturningStatIncludingParents() throws Exception
     {
         CuratorFramework client = createClient();
@@ -121,7 +126,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateReturningStatIncludingParentsReverse() throws Exception
     {
         CuratorFramework client = createClient();
@@ -141,7 +146,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateReturningStatCompressed() throws Exception
     {
         CuratorFramework client = createClient();
@@ -161,7 +166,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateReturningStatWithProtected() throws Exception
     {
         CuratorFramework client = createClient();
@@ -181,7 +186,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateReturningStatInBackground() throws Exception
     {
         Timing timing = new Timing();
@@ -212,7 +217,7 @@ public class TestCreateReturningStat extends CuratorTestBase
             
             if(!timing.awaitLatch(latch))
             {
-                Assert.fail("Timed out awaing latch");
+                fail("Timed out awaing latch");
             }
             
             compare(client, path, statRef.get());

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreateReturningStat.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreateReturningStat.java
@@ -23,18 +23,18 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -56,7 +56,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         assertEquals(queriedStat, expected);
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testOrSetDataStoringStatIn() throws Exception {
         try (CuratorFramework client = createClient())
         {
@@ -86,7 +86,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateReturningStat() throws Exception
     {
         CuratorFramework client = createClient();
@@ -106,7 +106,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateReturningStatIncludingParents() throws Exception
     {
         CuratorFramework client = createClient();
@@ -126,7 +126,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateReturningStatIncludingParentsReverse() throws Exception
     {
         CuratorFramework client = createClient();
@@ -146,7 +146,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateReturningStatCompressed() throws Exception
     {
         CuratorFramework client = createClient();
@@ -166,7 +166,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateReturningStatWithProtected() throws Exception
     {
         CuratorFramework client = createClient();
@@ -186,7 +186,7 @@ public class TestCreateReturningStat extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateReturningStatInBackground() throws Exception
     {
         Timing timing = new Timing();

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnabledSessionExpiredState.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnabledSessionExpiredState.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -36,6 +35,8 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -87,7 +88,7 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testResetCausesLost() throws Exception
     {
         assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
@@ -98,7 +99,7 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
         assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInjectedWatchedEvent() throws Exception
     {
         assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
@@ -123,7 +124,7 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
         assertTrue(timing.forSessionSleep().awaitLatch(latch));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testKillSession() throws Exception
     {
         assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
@@ -134,7 +135,7 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
         assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testReconnectWithoutExpiration() throws Exception
     {
         assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
@@ -152,7 +153,7 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
         assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSessionExpirationFromTimeout() throws Exception
     {
         assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
@@ -161,7 +162,7 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
         assertEquals(states.poll(timing.forSessionSleep().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSessionExpirationFromTimeoutWithRestart() throws Exception
     {
         assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnabledSessionExpiredState.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnabledSessionExpiredState.java
@@ -18,7 +18,11 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Queues;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -30,10 +34,8 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +47,7 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
     private CuratorFramework client;
     private BlockingQueue<ConnectionState> states;
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setup() throws Exception
     {
@@ -71,7 +73,7 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
         client.getConnectionStateListenable().addListener(listener);
     }
 
-    @AfterMethod
+    @AfterEach
     @Override
     public void teardown() throws Exception
     {
@@ -85,21 +87,21 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testResetCausesLost() throws Exception
     {
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
         client.checkExists().forPath("/");  // establish initial connection
 
         client.getZookeeperClient().reset();
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testInjectedWatchedEvent() throws Exception
     {
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
 
         final CountDownLatch latch = new CountDownLatch(1);
         Watcher watcher = new Watcher()
@@ -118,24 +120,24 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
         };
         client.checkExists().usingWatcher(watcher).forPath("/");
         server.stop();
-        Assert.assertTrue(timing.forSessionSleep().awaitLatch(latch));
+        assertTrue(timing.forSessionSleep().awaitLatch(latch));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testKillSession() throws Exception
     {
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
 
         client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
 
-        Assert.assertEquals(states.poll(timing.forSessionSleep().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
+        assertEquals(states.poll(timing.forSessionSleep().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testReconnectWithoutExpiration() throws Exception
     {
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
         server.stop();
         try
         {
@@ -144,33 +146,33 @@ public class TestEnabledSessionExpiredState extends BaseClassForTests
         catch ( KeeperException.ConnectionLossException ignore )
         {
         }
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
         server.restart();
         client.checkExists().forPath("/");
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSessionExpirationFromTimeout() throws Exception
     {
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
         server.stop();
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
-        Assert.assertEquals(states.poll(timing.forSessionSleep().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+        assertEquals(states.poll(timing.forSessionSleep().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSessionExpirationFromTimeoutWithRestart() throws Exception
     {
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
         server.stop();
         timing.forSessionSleep().sleep();
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
-        Assert.assertEquals(states.poll(timing.forSessionSleep().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+        assertEquals(states.poll(timing.forSessionSleep().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
         server.restart();
         client.checkExists().forPath("/");
-        Assert.assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
+        assertEquals(states.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
 
-        Assert.assertNull(states.poll(timing.multiple(.5).milliseconds(), TimeUnit.MILLISECONDS));  // there should be no other events
+        assertNull(states.poll(timing.multiple(.5).milliseconds(), TimeUnit.MILLISECONDS));  // there should be no other events
     }
 }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnsureContainers.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnsureContainers.java
@@ -21,17 +21,17 @@ package org.apache.curator.framework.imps;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.EnsureContainers;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
 
 public class TestEnsureContainers extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -50,7 +50,7 @@ public class TestEnsureContainers extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSingleExecution() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnsureContainers.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnsureContainers.java
@@ -18,18 +18,20 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.EnsureContainers;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 public class TestEnsureContainers extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -40,7 +42,7 @@ public class TestEnsureContainers extends BaseClassForTests
             EnsureContainers ensureContainers = new EnsureContainers(client, "/one/two/three");
             ensureContainers.ensure();
 
-            Assert.assertNotNull(client.checkExists().forPath("/one/two/three"));
+            assertNotNull(client.checkExists().forPath("/one/two/three"));
         }
         finally
         {
@@ -48,7 +50,7 @@ public class TestEnsureContainers extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSingleExecution() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -59,11 +61,11 @@ public class TestEnsureContainers extends BaseClassForTests
             EnsureContainers ensureContainers = new EnsureContainers(client, "/one/two/three");
             ensureContainers.ensure();
 
-            Assert.assertNotNull(client.checkExists().forPath("/one/two/three"));
+            assertNotNull(client.checkExists().forPath("/one/two/three"));
 
             client.delete().forPath("/one/two/three");
             ensureContainers.ensure();
-            Assert.assertNull(client.checkExists().forPath("/one/two/three"));
+            assertNull(client.checkExists().forPath("/one/two/three"));
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestExistsBuilder.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestExistsBuilder.java
@@ -22,7 +22,6 @@ import static org.apache.zookeeper.ZooDefs.Ids.ANYONE_ID_UNSAFE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
@@ -33,6 +32,8 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -44,7 +45,7 @@ public class TestExistsBuilder extends BaseClassForTests {
      * Tests that the ACL list provided to the exists builder is used for creating the parents, when it is applied to
      * parents.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void  testExistsWithParentsWithAclApplyToParents() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -66,7 +67,7 @@ public class TestExistsBuilder extends BaseClassForTests {
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void  testExistsWithParentsWithAclApplyToParentsInBackground() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestExistsBuilder.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestExistsBuilder.java
@@ -18,6 +18,11 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.apache.zookeeper.ZooDefs.Ids.ANYONE_ID_UNSAFE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
@@ -28,16 +33,10 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
-import static org.apache.zookeeper.ZooDefs.Ids.ANYONE_ID_UNSAFE;
-import static org.testng.Assert.assertNull;
 
 public class TestExistsBuilder extends BaseClassForTests {
 
@@ -45,7 +44,7 @@ public class TestExistsBuilder extends BaseClassForTests {
      * Tests that the ACL list provided to the exists builder is used for creating the parents, when it is applied to
      * parents.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void  testExistsWithParentsWithAclApplyToParents() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -57,9 +56,9 @@ public class TestExistsBuilder extends BaseClassForTests {
             List<ACL> acl = Collections.singletonList(new ACL(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, ANYONE_ID_UNSAFE));
             assertNull(client.checkExists().creatingParentsIfNeeded().withACL(acl).forPath(path));
             List<ACL> actual_bar = client.getACL().forPath("/bar");
-            Assert.assertEquals(actual_bar, acl);
+            assertEquals(actual_bar, acl);
             List<ACL> actual_bar_foo = client.getACL().forPath("/bar/foo");
-            Assert.assertEquals(actual_bar_foo, acl);
+            assertEquals(actual_bar_foo, acl);
         }
         finally
         {
@@ -67,7 +66,7 @@ public class TestExistsBuilder extends BaseClassForTests {
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void  testExistsWithParentsWithAclApplyToParentsInBackground() throws Exception
     {
         CuratorFramework client = createClient(new DefaultACLProvider());
@@ -86,11 +85,11 @@ public class TestExistsBuilder extends BaseClassForTests {
                 }
             };
             client.checkExists().creatingParentsIfNeeded().withACL(acl).inBackground(callback).forPath(path);
-            Assert.assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
+            assertTrue(latch.await(2000, TimeUnit.MILLISECONDS), "Callback not invoked");
             List<ACL> actual_bar = client.getACL().forPath("/bar");
-            Assert.assertEquals(actual_bar, acl);
+            assertEquals(actual_bar, acl);
             List<ACL> actual_bar_foo = client.getACL().forPath("/bar/foo");
-            Assert.assertEquals(actual_bar_foo, acl);
+            assertEquals(actual_bar_foo, acl);
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFailedDeleteManager.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFailedDeleteManager.java
@@ -18,6 +18,13 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -31,16 +38,13 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TestFailedDeleteManager extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testLostSession() throws Exception
     {
         Timing                  timing = new Timing();
@@ -71,26 +75,26 @@ public class TestFailedDeleteManager extends BaseClassForTests
             client.getConnectionStateListenable().addListener(listener);
             server.stop();
 
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
+            assertTrue(timing.acquireSemaphore(semaphore));
             try
             {
                 client.delete().guaranteed().forPath("/test-me");
-                Assert.fail();
+                fail();
             }
             catch ( KeeperException.ConnectionLossException | KeeperException.SessionExpiredException e )
             {
                 // expected
             }
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
+            assertTrue(timing.acquireSemaphore(semaphore));
 
             timing.sleepABit();
 
             server.restart();
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
 
             timing.sleepABit();
 
-            Assert.assertNull(client.checkExists().forPath("/test-me"));
+            assertNull(client.checkExists().forPath("/test-me"));
         }
         finally
         {
@@ -98,7 +102,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testWithNamespaceAndLostSession() throws Exception
     {
         Timing                  timing = new Timing();
@@ -134,26 +138,26 @@ public class TestFailedDeleteManager extends BaseClassForTests
             client.getConnectionStateListenable().addListener(listener);
             server.stop();
 
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
+            assertTrue(timing.acquireSemaphore(semaphore));
             try
             {
                 client.delete().guaranteed().forPath("/test-me");
-                Assert.fail();
+                fail();
             }
             catch ( KeeperException.ConnectionLossException | KeeperException.SessionExpiredException e )
             {
                 // expected
             }
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
+            assertTrue(timing.acquireSemaphore(semaphore));
 
             timing.sleepABit();
 
             server.restart();
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
 
             timing.sleepABit();
 
-            Assert.assertNull(client.checkExists().forPath("/test-me"));
+            assertNull(client.checkExists().forPath("/test-me"));
         }
         finally
         {
@@ -161,7 +165,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testWithNamespaceAndLostSessionAlt() throws Exception
     {
         Timing                  timing = new Timing();
@@ -197,26 +201,26 @@ public class TestFailedDeleteManager extends BaseClassForTests
             namespaceClient.getConnectionStateListenable().addListener(listener);
             server.stop();
 
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
+            assertTrue(timing.acquireSemaphore(semaphore));
             try
             {
                 namespaceClient.delete().guaranteed().forPath("/test-me");
-                Assert.fail();
+                fail();
             }
             catch ( KeeperException.ConnectionLossException | KeeperException.SessionExpiredException e )
             {
                 // expected
             }
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
+            assertTrue(timing.acquireSemaphore(semaphore));
 
             timing.sleepABit();
 
             server.restart();
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
 
             timing.sleepABit();
 
-            Assert.assertNull(namespaceClient.checkExists().forPath("/test-me"));
+            assertNull(namespaceClient.checkExists().forPath("/test-me"));
         }
         finally
         {
@@ -224,7 +228,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasic() throws Exception
     {
         final String PATH = "/one/two/three";
@@ -237,13 +241,13 @@ public class TestFailedDeleteManager extends BaseClassForTests
         try
         {
             client.create().creatingParentsIfNeeded().forPath(PATH);
-            Assert.assertNotNull(client.checkExists().forPath(PATH));
+            assertNotNull(client.checkExists().forPath(PATH));
 
             server.stop(); // cause the next delete to fail
             try
             {
                 client.delete().forPath(PATH);
-                Assert.fail();
+                fail();
             }
             catch ( KeeperException.ConnectionLossException | KeeperException.SessionExpiredException e )
             {
@@ -251,13 +255,13 @@ public class TestFailedDeleteManager extends BaseClassForTests
             }
             
             server.restart();
-            Assert.assertNotNull(client.checkExists().forPath(PATH));
+            assertNotNull(client.checkExists().forPath(PATH));
 
             server.stop(); // cause the next delete to fail
             try
             {
                 client.delete().guaranteed().forPath(PATH);
-                Assert.fail();
+                fail();
             }
             catch ( KeeperException.ConnectionLossException | KeeperException.SessionExpiredException e )
             {
@@ -274,7 +278,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
                     timing.sleepABit();
                 }
             }
-            Assert.assertNull(client.checkExists().forPath(PATH));
+            assertNull(client.checkExists().forPath(PATH));
         }
         finally
         {
@@ -282,7 +286,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testGuaranteedDeleteOnNonExistentNodeInForeground() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -303,12 +307,12 @@ public class TestFailedDeleteManager extends BaseClassForTests
         try
         {
             client.delete().guaranteed().forPath("/nonexistent");
-            Assert.fail();
+            fail();
         }
         catch(NoNodeException e)
         {
             //Exception is expected, the delete should not be retried
-            Assert.assertFalse(pathAdded.get());
+            assertFalse(pathAdded.get());
         }
         finally
         {
@@ -316,7 +320,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
         }        
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testGuaranteedDeleteOnNonExistentNodeInBackground() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -354,7 +358,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
             backgroundLatch.await();
             
             //Exception is expected, the delete should not be retried
-            Assert.assertFalse(pathAdded.get());
+            assertFalse(pathAdded.get());
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFailedDeleteManager.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFailedDeleteManager.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -38,13 +37,15 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TestFailedDeleteManager extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testLostSession() throws Exception
     {
         Timing                  timing = new Timing();
@@ -102,7 +103,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testWithNamespaceAndLostSession() throws Exception
     {
         Timing                  timing = new Timing();
@@ -165,7 +166,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testWithNamespaceAndLostSessionAlt() throws Exception
     {
         Timing                  timing = new Timing();
@@ -228,7 +229,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasic() throws Exception
     {
         final String PATH = "/one/two/three";
@@ -286,7 +287,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGuaranteedDeleteOnNonExistentNodeInForeground() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -320,7 +321,7 @@ public class TestFailedDeleteManager extends BaseClassForTests
         }        
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGuaranteedDeleteOnNonExistentNodeInBackground() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFramework.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFramework.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.AuthInfo;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -56,6 +55,8 @@ import org.apache.zookeeper.data.Stat;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -126,7 +127,7 @@ public class TestFramework extends BaseClassForTests
         assertEquals(10064, polledValue.intValue());
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSessionLossWithLongTimeout() throws Exception
     {
         final Timing timing = new Timing();
@@ -171,7 +172,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConnectionState() throws Exception
     {
         Timing timing = new Timing();
@@ -201,7 +202,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateOrSetData() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -249,7 +250,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testQuietDelete() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -280,7 +281,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNamespaceWithWatcher() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -317,7 +318,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNamespaceInBackground() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -365,7 +366,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateACLSingleAuth() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -422,7 +423,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testACLDeprecatedApis() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
@@ -436,7 +437,7 @@ public class TestFramework extends BaseClassForTests
         assertArrayEquals(builder.getAuthValue(), "me1:pass1".getBytes());
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateACLMultipleAuths() throws Exception
     {
         // Add a few authInfos
@@ -515,7 +516,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateACLWithReset() throws Exception
     {
         Timing timing = new Timing();
@@ -576,7 +577,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateParents() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -598,7 +599,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testOverrideCreateParentContainers() throws Exception
     {
         if ( !checkForContainers() )
@@ -631,7 +632,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateParentContainers() throws Exception
     {
         if ( !checkForContainers() )
@@ -671,7 +672,7 @@ public class TestFramework extends BaseClassForTests
         return true;
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreatingParentsTheSame() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -697,7 +698,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testExistsCreatingParents() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -717,7 +718,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testExistsCreatingParentsInBackground() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -748,7 +749,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testEnsurePathWithNamespace() throws Exception
     {
         final String namespace = "jz";
@@ -772,7 +773,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateContainersWithNamespace() throws Exception
     {
         final String namespace = "container1";
@@ -793,7 +794,7 @@ public class TestFramework extends BaseClassForTests
     }
 
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateContainersUsingNamespace() throws Exception
     {
         final String namespace = "container2";
@@ -814,7 +815,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNamespace() throws Exception
     {
         final String namespace = "TestNamespace";
@@ -846,7 +847,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCustomCallback() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -877,7 +878,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSync() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -913,7 +914,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSyncNew() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -944,7 +945,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackgroundDelete() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -981,7 +982,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackgroundDeleteWithChildren() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -1018,7 +1019,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDelete() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -1036,7 +1037,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeleteWithChildren() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -1056,7 +1057,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeleteGuaranteedWithChildren() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -1076,7 +1077,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGetSequentialChildren() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -1099,7 +1100,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackgroundGetDataWithWatch() throws Exception
     {
         final byte[] data1 = {1, 2, 3};
@@ -1152,7 +1153,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackgroundCreate() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -1185,7 +1186,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateModes() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -1239,7 +1240,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSimple() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -1255,7 +1256,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSequentialWithTrailingSeparator() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
@@ -40,6 +39,7 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.data.ACL;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
@@ -55,7 +55,7 @@ public class TestFrameworkBackground extends BaseClassForTests
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testErrorListener() throws Exception
     {
         //The first call to the ACL provider will return a reasonable
@@ -121,7 +121,7 @@ public class TestFrameworkBackground extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testListenerConnectedAtStart() throws Exception
     {
         server.stop();
@@ -169,7 +169,7 @@ public class TestFrameworkBackground extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRetries() throws Exception
     {
         final int SLEEP = 1000;
@@ -216,7 +216,7 @@ public class TestFrameworkBackground extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         Timing timing = new Timing();
@@ -251,7 +251,7 @@ public class TestFrameworkBackground extends BaseClassForTests
      * Attempt a background operation while Zookeeper server is down.
      * Return code must be {@link Code#CONNECTIONLOSS}
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCuratorCallbackOnError() throws Exception
     {
         Timing timing = new Timing();
@@ -290,7 +290,7 @@ public class TestFrameworkBackground extends BaseClassForTests
      * CURATOR-126
      * Shutdown the Curator client while there are still background operations running.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testShutdown() throws Exception
     {
         Timing timing = new Timing();

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
@@ -19,8 +19,12 @@
 
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
@@ -38,9 +42,6 @@ import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -54,7 +55,7 @@ public class TestFrameworkBackground extends BaseClassForTests
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testErrorListener() throws Exception
     {
         //The first call to the ACL provider will return a reasonable
@@ -112,7 +113,7 @@ public class TestFrameworkBackground extends BaseClassForTests
                 }
             };
             client.create().inBackground().withUnhandledErrorListener(listener).forPath("/foo");
-            Assert.assertTrue(new Timing().awaitLatch(errorLatch));
+            assertTrue(new Timing().awaitLatch(errorLatch));
         }
         finally
         {
@@ -120,7 +121,7 @@ public class TestFrameworkBackground extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testListenerConnectedAtStart() throws Exception
     {
         server.stop();
@@ -157,10 +158,10 @@ public class TestFrameworkBackground extends BaseClassForTests
 
             server.restart();
 
-            Assert.assertTrue(timing.awaitLatch(connectedLatch));
-            Assert.assertFalse(firstListenerAction.get());
+            assertTrue(timing.awaitLatch(connectedLatch));
+            assertFalse(firstListenerAction.get());
             ConnectionState firstconnectionState = firstListenerState.get();
-            Assert.assertEquals(firstconnectionState, ConnectionState.CONNECTED, "First listener state MUST BE CONNECTED but is " + firstconnectionState);
+            assertEquals(firstconnectionState, ConnectionState.CONNECTED, "First listener state MUST BE CONNECTED but is " + firstconnectionState);
         }
         finally
         {
@@ -168,7 +169,7 @@ public class TestFrameworkBackground extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRetries() throws Exception
     {
         final int SLEEP = 1000;
@@ -206,7 +207,7 @@ public class TestFrameworkBackground extends BaseClassForTests
 
             for ( long elapsed : times.subList(1, times.size()) )   // first one isn't a retry
             {
-                Assert.assertTrue(elapsed >= SLEEP, elapsed + ": " + times);
+                assertTrue(elapsed >= SLEEP, elapsed + ": " + times);
             }
         }
         finally
@@ -215,7 +216,7 @@ public class TestFrameworkBackground extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         Timing timing = new Timing();
@@ -234,11 +235,11 @@ public class TestFrameworkBackground extends BaseClassForTests
                 }
             };
             client.create().inBackground(callback).forPath("/one");
-            Assert.assertEquals(paths.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), "/one");
+            assertEquals(paths.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), "/one");
             client.create().inBackground(callback).forPath("/one/two");
-            Assert.assertEquals(paths.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), "/one/two");
+            assertEquals(paths.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), "/one/two");
             client.create().inBackground(callback).forPath("/one/two/three");
-            Assert.assertEquals(paths.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), "/one/two/three");
+            assertEquals(paths.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), "/one/two/three");
         }
         finally
         {
@@ -250,7 +251,7 @@ public class TestFrameworkBackground extends BaseClassForTests
      * Attempt a background operation while Zookeeper server is down.
      * Return code must be {@link Code#CONNECTIONLOSS}
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCuratorCallbackOnError() throws Exception
     {
         Timing timing = new Timing();
@@ -276,7 +277,7 @@ public class TestFrameworkBackground extends BaseClassForTests
             // Attempt to retrieve children list
             client.getChildren().inBackground(curatorCallback).forPath("/");
             // Check if the callback has been called with a correct return code
-            Assert.assertTrue(timing.awaitLatch(latch), "Callback has not been called by curator !");
+            assertTrue(timing.awaitLatch(latch), "Callback has not been called by curator !");
         }
         finally
         {
@@ -289,7 +290,7 @@ public class TestFrameworkBackground extends BaseClassForTests
      * CURATOR-126
      * Shutdown the Curator client while there are still background operations running.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testShutdown() throws Exception
     {
         Timing timing = new Timing();
@@ -345,7 +346,7 @@ public class TestFrameworkBackground extends BaseClassForTests
             timing.sleepABit();
 
             // should not generate an exception
-            Assert.assertFalse(hadIllegalStateException.get());
+            assertFalse(hadIllegalStateException.get());
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkEdges.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFrameworkEdges.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.RetrySleeper;
 import org.apache.curator.framework.CuratorFramework;
@@ -57,6 +56,7 @@ import org.apache.zookeeper.data.Stat;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Collections;
@@ -84,7 +84,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         System.setProperty("zookeeper.extendedTypesEnabled", "true");
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @DisplayName("test case for CURATOR-525")
     public void testValidateConnectionEventRaces() throws Exception
     {
@@ -121,7 +121,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInjectSessionExpiration() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -141,7 +141,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testProtectionWithKilledSession() throws Exception
     {
         server.stop();  // not needed
@@ -211,7 +211,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackgroundLatencyUnSleep() throws Exception
     {
         server.stop();
@@ -248,7 +248,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateContainersForBadConnect() throws Exception
     {
         final int serverPort = server.getPort();
@@ -284,7 +284,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testQuickClose() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), 1, new RetryNTimes(0, 0));
@@ -299,7 +299,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testProtectedCreateNodeDeletion() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), 1, new RetryNTimes(0, 0));
@@ -339,7 +339,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPathsFromProtectingInBackground() throws Exception
     {
         for ( CreateMode mode : CreateMode.values() )
@@ -414,7 +414,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void connectionLossWithBackgroundTest() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), 1, new RetryOneTime(1));
@@ -439,7 +439,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testReconnectAfterLoss() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
@@ -486,7 +486,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGetAclNoStat() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
@@ -508,7 +508,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMissedResponseOnBackgroundESCreate() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
@@ -538,7 +538,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMissedResponseOnESCreate() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
@@ -557,7 +557,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSessionKilled() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
@@ -585,7 +585,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNestedCalls() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
@@ -621,7 +621,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackgroundFailure() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
@@ -655,7 +655,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testFailure() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), 100, 100, new RetryOneTime(1));
@@ -680,7 +680,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRetry() throws Exception
     {
         final int MAX_RETRIES = 3;
@@ -747,7 +747,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNotStarted() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -766,7 +766,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testStopped() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -791,7 +791,7 @@ public class TestFrameworkEdges extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeleteChildrenConcurrently() throws Exception
     {
         final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestGzipCompressionProvider.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestGzipCompressionProvider.java
@@ -18,9 +18,10 @@
  */
 package org.apache.curator.framework.imps;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -36,9 +37,9 @@ public class TestGzipCompressionProvider
         byte[] data = "Hello, world!".getBytes();
         byte[] compressedData = provider.compress(null, data);
         byte[] jdkCompressedData = jdkCompress(data);
-        Assert.assertTrue(Arrays.equals(compressedData, jdkCompressedData));
+        assertTrue(Arrays.equals(compressedData, jdkCompressedData));
         byte[] decompressedData = provider.decompress(null, compressedData);
-        Assert.assertTrue(Arrays.equals(decompressedData, data));
+        assertTrue(Arrays.equals(decompressedData, data));
     }
 
     @Test
@@ -49,10 +50,10 @@ public class TestGzipCompressionProvider
         byte[] compressedData2 = GzipCompressionProvider.doCompress(new byte[0]);
         byte[] jdkCompress = jdkCompress(new byte[0]);
         // Ensures GzipCompressionProvider.COMPRESSED_EMPTY_BYTES value is valid
-        Assert.assertTrue(Arrays.equals(compressedData, compressedData2));
-        Assert.assertTrue(Arrays.equals(compressedData, jdkCompress));
+        assertTrue(Arrays.equals(compressedData, compressedData2));
+        assertTrue(Arrays.equals(compressedData, jdkCompress));
         byte[] decompressedData = provider.decompress(null, compressedData);
-        Assert.assertEquals(0, decompressedData.length);
+        assertEquals(0, decompressedData.length);
     }
 
     /**
@@ -65,7 +66,7 @@ public class TestGzipCompressionProvider
         GzipCompressionProvider provider = new GzipCompressionProvider();
         try {
             provider.decompress(null, new byte[100]);
-            Assert.fail("Expected IOException");
+            fail("Expected IOException");
         } catch (IOException ignore) {
             // expected
         }
@@ -104,9 +105,9 @@ public class TestGzipCompressionProvider
             for (int i = 0; i < 100; i++) {
                 byte[] compressedData = provider.compress(null, data);
                 byte[] jdkCompressedData = jdkCompress(data);
-                Assert.assertTrue(Arrays.equals(compressedData, jdkCompressedData));
+                assertTrue(Arrays.equals(compressedData, jdkCompressedData));
                 byte[] decompressedData = provider.decompress(null, compressedData);
-                Assert.assertTrue(Arrays.equals(decompressedData, data));
+                assertTrue(Arrays.equals(decompressedData, data));
                 // in the end of the iteration to test empty array first
                 random.nextBytes(data);
             }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestMultiClient.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestMultiClient.java
@@ -20,7 +20,6 @@ package org.apache.curator.framework.imps;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -30,12 +29,14 @@ import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.framework.api.CuratorListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.zookeeper.Watcher;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class TestMultiClient extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testNotify() throws Exception
     {
         CuratorFramework client1 = null;

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestMultiClient.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestMultiClient.java
@@ -18,6 +18,9 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -27,14 +30,12 @@ import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.framework.api.CuratorListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.zookeeper.Watcher;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class TestMultiClient extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testNotify() throws Exception
     {
         CuratorFramework client1 = null;
@@ -89,7 +90,7 @@ public class TestMultiClient extends BaseClassForTests
 
             client2.sync().forPath("/test");
 
-            Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.Collections;
 import java.util.List;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -35,10 +34,11 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.KeeperException.NoAuthException;
 import org.apache.zookeeper.data.ACL;
+import org.junit.jupiter.api.Test;
 
 public class TestNamespaceFacade extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testInvalid() throws Exception
     {
         try
@@ -52,7 +52,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testGetNamespace() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -76,7 +76,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSimultaneous() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -99,7 +99,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testCache() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -116,7 +116,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasic() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -143,7 +143,7 @@ public class TestNamespaceFacade extends BaseClassForTests
     /**
      * CURATOR-128: access root node within a namespace.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testRootAccess() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -181,7 +181,7 @@ public class TestNamespaceFacade extends BaseClassForTests
     }
 
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testIsStarted() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -198,7 +198,7 @@ public class TestNamespaceFacade extends BaseClassForTests
      * Test that ACLs work on a NamespaceFacade. See CURATOR-132
      * @throws Exception
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testACL() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -233,7 +233,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testUnfixForEmptyNamespace() {
         CuratorFramework client = CuratorFrameworkFactory.builder().namespace("").retryPolicy(new RetryOneTime(1)).connectString("foo").build();
         CuratorFrameworkImpl clientImpl = (CuratorFrameworkImpl) client;

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
@@ -18,30 +18,33 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.util.Collections;
 import java.util.List;
 
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.KeeperException.NoAuthException;
 import org.apache.zookeeper.data.ACL;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 public class TestNamespaceFacade extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testInvalid() throws Exception
     {
         try
         {
             CuratorFrameworkFactory.builder().namespace("/snafu").retryPolicy(new RetryOneTime(1)).connectString("foo").build();
-            Assert.fail();
+            fail();
         }
         catch ( IllegalArgumentException e )
         {
@@ -49,7 +52,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testGetNamespace() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -61,10 +64,10 @@ public class TestNamespaceFacade extends BaseClassForTests
             CuratorFramework fooClient = client.usingNamespace("foo");
             CuratorFramework barClient = client.usingNamespace("bar");
 
-            Assert.assertEquals(client.getNamespace(), "");
-            Assert.assertEquals(client2.getNamespace(), "snafu");
-            Assert.assertEquals(fooClient.getNamespace(), "foo");
-            Assert.assertEquals(barClient.getNamespace(), "bar");
+            assertEquals(client.getNamespace(), "");
+            assertEquals(client2.getNamespace(), "snafu");
+            assertEquals(fooClient.getNamespace(), "foo");
+            assertEquals(barClient.getNamespace(), "bar");
         }
         finally
         {
@@ -73,7 +76,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSimultaneous() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -87,8 +90,8 @@ public class TestNamespaceFacade extends BaseClassForTests
             fooClient.create().forPath("/one");
             barClient.create().forPath("/one");
 
-            Assert.assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/foo/one", false));
-            Assert.assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/bar/one", false));
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/foo/one", false));
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/bar/one", false));
         }
         finally
         {
@@ -96,7 +99,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testCache() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -104,8 +107,8 @@ public class TestNamespaceFacade extends BaseClassForTests
         {
             client.start();
 
-            Assert.assertSame(client.usingNamespace("foo"), client.usingNamespace("foo"));
-            Assert.assertNotSame(client.usingNamespace("foo"), client.usingNamespace("bar"));
+            assertSame(client.usingNamespace("foo"), client.usingNamespace("foo"));
+            assertNotSame(client.usingNamespace("foo"), client.usingNamespace("bar"));
         }
         finally
         {
@@ -113,7 +116,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasic() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -122,14 +125,14 @@ public class TestNamespaceFacade extends BaseClassForTests
             client.start();
 
             client.create().forPath("/one");
-            Assert.assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/one", false));
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/one", false));
 
             client.usingNamespace("space").create().forPath("/one");
-            Assert.assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/space", false));
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/space", false));
 
             client.usingNamespace("name").create().forPath("/one");
-            Assert.assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/name", false));
-            Assert.assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/name/one", false));
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/name", false));
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/name/one", false));
         }
         finally
         {
@@ -140,7 +143,7 @@ public class TestNamespaceFacade extends BaseClassForTests
     /**
      * CURATOR-128: access root node within a namespace.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testRootAccess() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -149,23 +152,23 @@ public class TestNamespaceFacade extends BaseClassForTests
             client.start();
 
             client.create().forPath("/one");
-            Assert.assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/one", false));
+            assertNotNull(client.getZookeeperClient().getZooKeeper().exists("/one", false));
 
-            Assert.assertNotNull(client.checkExists().forPath("/"));
+            assertNotNull(client.checkExists().forPath("/"));
             try
             {
                 client.checkExists().forPath("");
-                Assert.fail("IllegalArgumentException expected");
+                fail("IllegalArgumentException expected");
             }
             catch ( IllegalArgumentException expected )
             {
             }
 
-            Assert.assertNotNull(client.usingNamespace("one").checkExists().forPath("/"));
+            assertNotNull(client.usingNamespace("one").checkExists().forPath("/"));
             try
             {
                 client.usingNamespace("one").checkExists().forPath("");
-                Assert.fail("IllegalArgumentException expected");
+                fail("IllegalArgumentException expected");
             }
             catch ( IllegalArgumentException expected )
             {
@@ -178,24 +181,24 @@ public class TestNamespaceFacade extends BaseClassForTests
     }
 
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testIsStarted() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
         client.start();
         CuratorFramework    namespaced = client.usingNamespace(null);
 
-        Assert.assertEquals(client.getState(), namespaced.getState(), "Namespaced state did not match true state after call to start.");
+        assertEquals(client.getState(), namespaced.getState(), "Namespaced state did not match true state after call to start.");
 
         client.close();
-        Assert.assertEquals(client.getState(), namespaced.getState(), "Namespaced state did not match true state after call to close.");
+        assertEquals(client.getState(), namespaced.getState(), "Namespaced state did not match true state after call to close.");
     }
     
     /**
      * Test that ACLs work on a NamespaceFacade. See CURATOR-132
      * @throws Exception
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testACL() throws Exception
     {
         CuratorFramework    client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -205,7 +208,7 @@ public class TestNamespaceFacade extends BaseClassForTests
         client.create().creatingParentsIfNeeded().forPath("/parent/child", "A string".getBytes());
         CuratorFramework client2 = client.usingNamespace("parent");
 
-        Assert.assertNotNull(client2.getData().forPath("/child"));  
+        assertNotNull(client2.getData().forPath("/child"));  
         client.setACL().withACL(Collections.singletonList(
             new ACL(ZooDefs.Perms.WRITE, ZooDefs.Ids.ANYONE_ID_UNSAFE))).
                 forPath("/parent/child");
@@ -215,14 +218,14 @@ public class TestNamespaceFacade extends BaseClassForTests
         try
         {
             List<ACL> acls = client2.getACL().forPath("/child");
-            Assert.assertNotNull(acls);
-            Assert.assertEquals(acls.size(), 1);
-            Assert.assertEquals(acls.get(0).getId(), ZooDefs.Ids.ANYONE_ID_UNSAFE);
-            Assert.assertEquals(acls.get(0).getPerms(), ZooDefs.Perms.WRITE);
+            assertNotNull(acls);
+            assertEquals(acls.size(), 1);
+            assertEquals(acls.get(0).getId(), ZooDefs.Ids.ANYONE_ID_UNSAFE);
+            assertEquals(acls.get(0).getPerms(), ZooDefs.Perms.WRITE);
             client2.setACL().withACL(Collections.singletonList(
                 new ACL(ZooDefs.Perms.DELETE, ZooDefs.Ids.ANYONE_ID_UNSAFE))).
                     forPath("/child");
-            Assert.fail("Expected auth exception was not thrown");
+            fail("Expected auth exception was not thrown");
         }
         catch(NoAuthException e)
         {
@@ -230,12 +233,12 @@ public class TestNamespaceFacade extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testUnfixForEmptyNamespace() {
         CuratorFramework client = CuratorFrameworkFactory.builder().namespace("").retryPolicy(new RetryOneTime(1)).connectString("foo").build();
         CuratorFrameworkImpl clientImpl = (CuratorFrameworkImpl) client;
 
-        Assert.assertEquals(clientImpl.unfixForNamespace("/foo/bar"), "/foo/bar");
+        assertEquals(clientImpl.unfixForNamespace("/foo/bar"), "/foo/bar");
 
         CloseableUtils.closeQuietly(client);
     }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNeverConnected.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNeverConnected.java
@@ -19,6 +19,7 @@
 
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.Queues;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -27,8 +28,7 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -58,9 +58,9 @@ public class TestNeverConnected
             client.create().inBackground().forPath("/");
 
             ConnectionState polled = queue.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-            Assert.assertEquals(polled, ConnectionState.SUSPENDED);
+            assertEquals(polled, ConnectionState.SUSPENDED);
             polled = queue.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-            Assert.assertEquals(polled, ConnectionState.LOST);
+            assertEquals(polled, ConnectionState.LOST);
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReadOnly.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReadOnly.java
@@ -22,7 +22,6 @@ package org.apache.curator.framework.imps;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -37,6 +36,8 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.Iterator;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -56,7 +57,7 @@ public class TestReadOnly extends BaseClassForTests
         System.setProperty("readonlymode.enabled", "false");
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConnectionStateNewClient() throws Exception
     {
         Timing timing = new Timing();
@@ -110,7 +111,7 @@ public class TestReadOnly extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testReadOnly() throws Exception
     {
         Timing timing = new Timing();

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReadOnly.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReadOnly.java
@@ -19,7 +19,10 @@
 
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Queues;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -32,10 +35,8 @@ import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import java.util.Iterator;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -43,19 +44,19 @@ import java.util.concurrent.TimeUnit;
 
 public class TestReadOnly extends BaseClassForTests
 {
-    @BeforeMethod
+    @BeforeEach
     public void setup()
     {
         System.setProperty("readonlymode.enabled", "true");
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDown()
     {
         System.setProperty("readonlymode.enabled", "false");
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testConnectionStateNewClient() throws Exception
     {
         Timing timing = new Timing();
@@ -100,7 +101,7 @@ public class TestReadOnly extends BaseClassForTests
             client.checkExists().forPath("/");
 
             ConnectionState state = states.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS);
-            Assert.assertEquals(state, ConnectionState.READ_ONLY);
+            assertEquals(state, ConnectionState.READ_ONLY);
         }
         finally
         {
@@ -109,7 +110,7 @@ public class TestReadOnly extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testReadOnly() throws Exception
     {
         Timing timing = new Timing();
@@ -151,12 +152,12 @@ public class TestReadOnly extends BaseClassForTests
             }
             cluster.killServer(killInstance);
 
-            Assert.assertEquals(reconnectedLatch.getCount(), 1);
-            Assert.assertTrue(timing.awaitLatch(readOnlyLatch));
+            assertEquals(reconnectedLatch.getCount(), 1);
+            assertTrue(timing.awaitLatch(readOnlyLatch));
 
-            Assert.assertEquals(reconnectedLatch.getCount(), 1);
+            assertEquals(reconnectedLatch.getCount(), 1);
             cluster.restartServer(killInstance);
-            Assert.assertTrue(timing.awaitLatch(reconnectedLatch));
+            assertTrue(timing.awaitLatch(reconnectedLatch));
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
@@ -20,7 +20,6 @@
 package org.apache.curator.framework.imps;
 
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -29,7 +28,6 @@ import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.ExponentialBackoffRetry;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.TestingZooKeeperServer;
@@ -101,7 +99,7 @@ public class TestReconfiguration extends CuratorTestBase
     }
 
     @SuppressWarnings("ConstantConditions")
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Disabled
     public void testApiPermutations() throws Exception
     {
@@ -171,7 +169,7 @@ public class TestReconfiguration extends CuratorTestBase
         client.reconfig().inBackground().withNewMembers().storingStatIn(stat).fromConfig(0).forEnsemble();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasicGetConfig() throws Exception
     {
         try ( CuratorFramework client = newClient())
@@ -185,7 +183,7 @@ public class TestReconfiguration extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAddWithoutEnsembleTracker() throws Exception
     {
         final String initialClusterCS = cluster.getConnectString();
@@ -230,7 +228,7 @@ public class TestReconfiguration extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAdd() throws Exception
     {
         try ( CuratorFramework client = newClient())
@@ -259,7 +257,7 @@ public class TestReconfiguration extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAddAsync() throws Exception
     {
         try ( CuratorFramework client = newClient())
@@ -301,7 +299,7 @@ public class TestReconfiguration extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAddAndRemove() throws Exception
     {
         try ( CuratorFramework client = newClient())
@@ -390,7 +388,7 @@ public class TestReconfiguration extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Disabled // it's what this test is inteded to do and it keeps failing - disable for now
     public void testNewMembers() throws Exception
     {
@@ -438,7 +436,7 @@ public class TestReconfiguration extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConfigToConnectionStringIPv4Normal() throws Exception
     {
         String config = "server.1=10.1.2.3:2888:3888:participant;10.2.3.4:2181";
@@ -446,7 +444,7 @@ public class TestReconfiguration extends CuratorTestBase
         assertEquals("10.2.3.4:2181", configString);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConfigToConnectionStringIPv6Normal() throws Exception
     {
         String config = "server.1=[1010:0001:0002:0003:0004:0005:0006:0007]:2888:3888:participant;[2001:db8:85a3:0:0:8a2e:370:7334]:2181";
@@ -454,7 +452,7 @@ public class TestReconfiguration extends CuratorTestBase
         assertEquals("2001:db8:85a3:0:0:8a2e:370:7334:2181", configString);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConfigToConnectionStringIPv4NoClientAddr() throws Exception
     {
         String config = "server.1=10.1.2.3:2888:3888:participant;2181";
@@ -462,7 +460,7 @@ public class TestReconfiguration extends CuratorTestBase
         assertEquals("10.1.2.3:2181", configString);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConfigToConnectionStringIPv4WildcardClientAddr() throws Exception
     {
         String config = "server.1=10.1.2.3:2888:3888:participant;0.0.0.0:2181";
@@ -470,7 +468,7 @@ public class TestReconfiguration extends CuratorTestBase
         assertEquals("10.1.2.3:2181", configString);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConfigToConnectionStringNoClientAddrOrPort() throws Exception
     {
         String config = "server.1=10.1.2.3:2888:3888:participant";
@@ -478,7 +476,7 @@ public class TestReconfiguration extends CuratorTestBase
         assertEquals("", configString);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testIPv6Wildcard1() throws Exception
     {
         String config = "server.1=[2001:db8:85a3:0:0:8a2e:370:7334]:2888:3888:participant;[::]:2181";
@@ -486,7 +484,7 @@ public class TestReconfiguration extends CuratorTestBase
         assertEquals("2001:db8:85a3:0:0:8a2e:370:7334:2181", configString);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testIPv6Wildcard2() throws Exception
     {
         String config = "server.1=[1010:0001:0002:0003:0004:0005:0006:0007]:2888:3888:participant;[::0]:2181";
@@ -494,7 +492,7 @@ public class TestReconfiguration extends CuratorTestBase
         assertEquals("1010:1:2:3:4:5:6:7:2181", configString);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMixedIPv1() throws Exception
     {
         String config = "server.1=10.1.2.3:2888:3888:participant;[::]:2181";
@@ -502,7 +500,7 @@ public class TestReconfiguration extends CuratorTestBase
         assertEquals("10.1.2.3:2181", configString);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMixedIPv2() throws Exception
     {
         String config = "server.1=[2001:db8:85a3:0:0:8a2e:370:7334]:2888:3888:participant;127.0.0.1:2181";

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTempFramework.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTempFramework.java
@@ -21,19 +21,20 @@ package org.apache.curator.framework.imps;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.CuratorTempFramework;
 import org.apache.curator.retry.RetryOneTime;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class TestTempFramework extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         CuratorTempFramework        client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).buildTemp();
@@ -50,7 +51,7 @@ public class TestTempFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInactivity() throws Exception
     {
         final CuratorTempFrameworkImpl        client = (CuratorTempFrameworkImpl)CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).buildTemp(1, TimeUnit.SECONDS);

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTempFramework.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTempFramework.java
@@ -18,20 +18,22 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.CuratorTempFramework;
 import org.apache.curator.retry.RetryOneTime;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class TestTempFramework extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         CuratorTempFramework        client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).buildTemp();
@@ -40,7 +42,7 @@ public class TestTempFramework extends BaseClassForTests
             client.inTransaction().create().forPath("/foo", "data".getBytes()).and().commit();
 
             byte[] bytes = client.getData().forPath("/foo");
-            Assert.assertEquals(bytes, "data".getBytes());
+            assertArrayEquals(bytes, "data".getBytes());
         }
         finally
         {
@@ -48,7 +50,7 @@ public class TestTempFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testInactivity() throws Exception
     {
         final CuratorTempFrameworkImpl        client = (CuratorTempFrameworkImpl)CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).buildTemp(1, TimeUnit.SECONDS);
@@ -68,8 +70,8 @@ public class TestTempFramework extends BaseClassForTests
             service.shutdownNow();
             Thread.sleep(2000);
 
-            Assert.assertNull(client.getCleanup());
-            Assert.assertNull(client.getClient());
+            assertNull(client.getCleanup());
+            assertNull(client.getClient());
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsNew.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsNew.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -44,6 +43,8 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -52,7 +53,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestTransactionsNew extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testErrors() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -84,7 +85,7 @@ public class TestTransactionsNew extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCheckVersion() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -114,7 +115,7 @@ public class TestTransactionsNew extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWithNamespace() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
@@ -145,7 +146,7 @@ public class TestTransactionsNew extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -174,7 +175,7 @@ public class TestTransactionsNew extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackground() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -214,7 +215,7 @@ public class TestTransactionsNew extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackgroundWithNamespace() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsNew.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsNew.java
@@ -19,8 +19,17 @@
 
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Queues;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -35,8 +44,6 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -45,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestTransactionsNew extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testErrors() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -65,11 +72,11 @@ public class TestTransactionsNew extends BaseClassForTests
             };
             client.transaction().inBackground(callback).forOperations(createOp1, createOp2);
             CuratorEvent event = callbackQueue.poll(new Timing().milliseconds(), TimeUnit.MILLISECONDS);
-            Assert.assertNotNull(event);
-            Assert.assertNotNull(event.getOpResults());
-            Assert.assertEquals(event.getOpResults().size(), 2);
-            Assert.assertEquals(event.getOpResults().get(0).getError(), KeeperException.Code.OK.intValue());
-            Assert.assertEquals(event.getOpResults().get(1).getError(), KeeperException.Code.NONODE.intValue());
+            assertNotNull(event);
+            assertNotNull(event.getOpResults());
+            assertEquals(event.getOpResults().size(), 2);
+            assertEquals(event.getOpResults().get(0).getError(), KeeperException.Code.OK.intValue());
+            assertEquals(event.getOpResults().get(1).getError(), KeeperException.Code.NONODE.intValue());
         }
         finally
         {
@@ -77,7 +84,7 @@ public class TestTransactionsNew extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCheckVersion() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -92,14 +99,14 @@ public class TestTransactionsNew extends BaseClassForTests
             try
             {
                 client.transaction().forOperations(statOp, createOp);
-                Assert.fail();
+                fail();
             }
             catch ( KeeperException.BadVersionException correct )
             {
                 // correct
             }
 
-            Assert.assertNull(client.checkExists().forPath("/bar"));
+            assertNull(client.checkExists().forPath("/bar"));
         }
         finally
         {
@@ -107,7 +114,7 @@ public class TestTransactionsNew extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWithNamespace() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
@@ -122,15 +129,15 @@ public class TestTransactionsNew extends BaseClassForTests
 
             Collection<CuratorTransactionResult> results = client.transaction().forOperations(createOp1, createOp2, setDataOp, createOp3, deleteOp);
 
-            Assert.assertTrue(client.checkExists().forPath("/foo") != null);
-            Assert.assertTrue(client.usingNamespace(null).checkExists().forPath("/galt/foo") != null);
-            Assert.assertEquals(client.getData().forPath("/foo"), "two".getBytes());
-            Assert.assertTrue(client.checkExists().forPath("/foo/bar") == null);
+            assertTrue(client.checkExists().forPath("/foo") != null);
+            assertTrue(client.usingNamespace(null).checkExists().forPath("/galt/foo") != null);
+            assertArrayEquals(client.getData().forPath("/foo"), "two".getBytes());
+            assertTrue(client.checkExists().forPath("/foo/bar") == null);
 
             CuratorTransactionResult ephemeralResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/test-"));
-            Assert.assertNotNull(ephemeralResult);
-            Assert.assertNotEquals(ephemeralResult.getResultPath(), "/test-");
-            Assert.assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
+            assertNotNull(ephemeralResult);
+            assertNotEquals(ephemeralResult.getResultPath(), "/test-");
+            assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
         }
         finally
         {
@@ -138,7 +145,7 @@ public class TestTransactionsNew extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -150,16 +157,16 @@ public class TestTransactionsNew extends BaseClassForTests
 
             Collection<CuratorTransactionResult> results = client.transaction().forOperations(createOp1, createOp2);
 
-            Assert.assertTrue(client.checkExists().forPath("/foo/bar") != null);
-            Assert.assertEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
+            assertTrue(client.checkExists().forPath("/foo/bar") != null);
+            assertArrayEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
 
             CuratorTransactionResult fooResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo"));
             CuratorTransactionResult fooBarResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo/bar"));
-            Assert.assertNotNull(fooResult);
-            Assert.assertNotNull(fooBarResult);
-            Assert.assertNotSame(fooResult, fooBarResult);
-            Assert.assertEquals(fooResult.getResultPath(), "/foo");
-            Assert.assertEquals(fooBarResult.getResultPath(), "/foo/bar");
+            assertNotNull(fooResult);
+            assertNotNull(fooBarResult);
+            assertNotSame(fooResult, fooBarResult);
+            assertEquals(fooResult.getResultPath(), "/foo");
+            assertEquals(fooBarResult.getResultPath(), "/foo/bar");
         }
         finally
         {
@@ -167,7 +174,7 @@ public class TestTransactionsNew extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBackground() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -189,17 +196,17 @@ public class TestTransactionsNew extends BaseClassForTests
             client.transaction().inBackground(callback).forOperations(createOp1, createOp2);
             Collection<CuratorTransactionResult> results = queue.poll(5, TimeUnit.SECONDS);
 
-            Assert.assertNotNull(results);
-            Assert.assertTrue(client.checkExists().forPath("/foo/bar") != null);
-            Assert.assertEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
+            assertNotNull(results);
+            assertTrue(client.checkExists().forPath("/foo/bar") != null);
+            assertArrayEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
 
             CuratorTransactionResult fooResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo"));
             CuratorTransactionResult fooBarResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo/bar"));
-            Assert.assertNotNull(fooResult);
-            Assert.assertNotNull(fooBarResult);
-            Assert.assertNotSame(fooResult, fooBarResult);
-            Assert.assertEquals(fooResult.getResultPath(), "/foo");
-            Assert.assertEquals(fooBarResult.getResultPath(), "/foo/bar");
+            assertNotNull(fooResult);
+            assertNotNull(fooBarResult);
+            assertNotSame(fooResult, fooBarResult);
+            assertEquals(fooResult.getResultPath(), "/foo");
+            assertEquals(fooBarResult.getResultPath(), "/foo/bar");
         }
         finally
         {
@@ -207,7 +214,7 @@ public class TestTransactionsNew extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBackgroundWithNamespace() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
@@ -233,16 +240,16 @@ public class TestTransactionsNew extends BaseClassForTests
 
             Collection<CuratorTransactionResult> results = queue.poll(5, TimeUnit.SECONDS);
 
-            Assert.assertNotNull(results);
-            Assert.assertTrue(client.checkExists().forPath("/foo") != null);
-            Assert.assertTrue(client.usingNamespace(null).checkExists().forPath("/galt/foo") != null);
-            Assert.assertEquals(client.getData().forPath("/foo"), "two".getBytes());
-            Assert.assertTrue(client.checkExists().forPath("/foo/bar") == null);
+            assertNotNull(results);
+            assertTrue(client.checkExists().forPath("/foo") != null);
+            assertTrue(client.usingNamespace(null).checkExists().forPath("/galt/foo") != null);
+            assertArrayEquals(client.getData().forPath("/foo"), "two".getBytes());
+            assertTrue(client.checkExists().forPath("/foo/bar") == null);
 
             CuratorTransactionResult ephemeralResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/test-"));
-            Assert.assertNotNull(ephemeralResult);
-            Assert.assertNotEquals(ephemeralResult.getResultPath(), "/test-");
-            Assert.assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
+            assertNotNull(ephemeralResult);
+            assertNotEquals(ephemeralResult.getResultPath(), "/test-");
+            assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsOld.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsOld.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Iterables;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
@@ -39,12 +38,14 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collection;
 
 @SuppressWarnings("deprecation")
 public class TestTransactionsOld extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testCheckVersion() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -78,7 +79,7 @@ public class TestTransactionsOld extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testWithNamespace() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
@@ -115,7 +116,7 @@ public class TestTransactionsOld extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testWithCompression() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
@@ -158,7 +159,7 @@ public class TestTransactionsOld extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasic() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsOld.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTransactionsOld.java
@@ -18,7 +18,16 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Iterables;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
@@ -30,14 +39,12 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.Stat;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Collection;
 
 @SuppressWarnings("deprecation")
 public class TestTransactionsOld extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testCheckVersion() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -56,14 +63,14 @@ public class TestTransactionsOld extends BaseClassForTests
                 .and()
                     .commit();
 
-                Assert.fail();
+                fail();
             }
             catch ( KeeperException.BadVersionException correct )
             {
                 // correct
             }
 
-            Assert.assertNull(client.checkExists().forPath("/bar"));
+            assertNull(client.checkExists().forPath("/bar"));
         }
         finally
         {
@@ -71,7 +78,7 @@ public class TestTransactionsOld extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testWithNamespace() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
@@ -92,15 +99,15 @@ public class TestTransactionsOld extends BaseClassForTests
                 .and()
                     .commit();
 
-            Assert.assertTrue(client.checkExists().forPath("/foo") != null);
-            Assert.assertTrue(client.usingNamespace(null).checkExists().forPath("/galt/foo") != null);
-            Assert.assertEquals(client.getData().forPath("/foo"), "two".getBytes());
-            Assert.assertTrue(client.checkExists().forPath("/foo/bar") == null);
+            assertTrue(client.checkExists().forPath("/foo") != null);
+            assertTrue(client.usingNamespace(null).checkExists().forPath("/galt/foo") != null);
+            assertArrayEquals(client.getData().forPath("/foo"), "two".getBytes());
+            assertTrue(client.checkExists().forPath("/foo/bar") == null);
 
             CuratorTransactionResult    ephemeralResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/test-"));
-            Assert.assertNotNull(ephemeralResult);
-            Assert.assertNotEquals(ephemeralResult.getResultPath(), "/test-");
-            Assert.assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
+            assertNotNull(ephemeralResult);
+            assertNotEquals(ephemeralResult.getResultPath(), "/test-");
+            assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
         }
         finally
         {
@@ -108,7 +115,7 @@ public class TestTransactionsOld extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testWithCompression() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).namespace("galt").build();
@@ -129,21 +136,21 @@ public class TestTransactionsOld extends BaseClassForTests
                     .and()
                         .commit();
 
-            Assert.assertTrue(client.checkExists().forPath("/foo") != null);
-            Assert.assertEquals(client.getData().decompressed().forPath("/foo"), "five".getBytes());
+            assertTrue(client.checkExists().forPath("/foo") != null);
+            assertArrayEquals(client.getData().decompressed().forPath("/foo"), "five".getBytes());
 
-            Assert.assertTrue(client.checkExists().forPath("/bar") != null);
-            Assert.assertEquals(client.getData().decompressed().forPath("/bar"), "two".getBytes());
-            Assert.assertEquals(client.getACL().forPath("/bar"), ZooDefs.Ids.READ_ACL_UNSAFE);
+            assertTrue(client.checkExists().forPath("/bar") != null);
+            assertArrayEquals(client.getData().decompressed().forPath("/bar"), "two".getBytes());
+            assertEquals(client.getACL().forPath("/bar"), ZooDefs.Ids.READ_ACL_UNSAFE);
 
             CuratorTransactionResult    ephemeralResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/test-"));
-            Assert.assertNotNull(ephemeralResult);
-            Assert.assertNotEquals(ephemeralResult.getResultPath(), "/test-");
-            Assert.assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
+            assertNotNull(ephemeralResult);
+            assertNotEquals(ephemeralResult.getResultPath(), "/test-");
+            assertTrue(ephemeralResult.getResultPath().startsWith("/test-"));
 
-            Assert.assertTrue(client.checkExists().forPath("/baz") != null);
-            Assert.assertEquals(client.getData().decompressed().forPath("/baz"), "four".getBytes());
-            Assert.assertEquals(client.getACL().forPath("/baz"), ZooDefs.Ids.READ_ACL_UNSAFE);
+            assertTrue(client.checkExists().forPath("/baz") != null);
+            assertArrayEquals(client.getData().decompressed().forPath("/baz"), "four".getBytes());
+            assertEquals(client.getACL().forPath("/baz"), ZooDefs.Ids.READ_ACL_UNSAFE);
         }
         finally
         {
@@ -151,7 +158,7 @@ public class TestTransactionsOld extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasic() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -166,16 +173,16 @@ public class TestTransactionsOld extends BaseClassForTests
                 .and()
                     .commit();
 
-            Assert.assertTrue(client.checkExists().forPath("/foo/bar") != null);
-            Assert.assertEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
+            assertTrue(client.checkExists().forPath("/foo/bar") != null);
+            assertArrayEquals(client.getData().forPath("/foo/bar"), "snafu".getBytes());
 
             CuratorTransactionResult    fooResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo"));
             CuratorTransactionResult    fooBarResult = Iterables.find(results, CuratorTransactionResult.ofTypeAndPath(OperationType.CREATE, "/foo/bar"));
-            Assert.assertNotNull(fooResult);
-            Assert.assertNotNull(fooBarResult);
-            Assert.assertNotSame(fooResult, fooBarResult);
-            Assert.assertEquals(fooResult.getResultPath(), "/foo");
-            Assert.assertEquals(fooBarResult.getResultPath(), "/foo/bar");
+            assertNotNull(fooResult);
+            assertNotNull(fooBarResult);
+            assertNotSame(fooResult, fooBarResult);
+            assertEquals(fooResult.getResultPath(), "/foo");
+            assertEquals(fooBarResult.getResultPath(), "/foo/bar");
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTtlNodes.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTtlNodes.java
@@ -18,29 +18,32 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.Timing;
 import org.apache.zookeeper.CreateMode;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import java.util.concurrent.CountDownLatch;
 
 public class TestTtlNodes extends CuratorTestBase
 {
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         System.setProperty("zookeeper.extendedTypesEnabled", "true");
     }
     
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setup() throws Exception
     {
@@ -48,7 +51,7 @@ public class TestTtlNodes extends CuratorTestBase
         super.setup();
     }
 
-    @AfterMethod
+    @AfterEach
     @Override
     public void teardown() throws Exception
     {
@@ -56,7 +59,7 @@ public class TestTtlNodes extends CuratorTestBase
         System.clearProperty("znode.container.checkIntervalMs");
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -65,11 +68,11 @@ public class TestTtlNodes extends CuratorTestBase
 
             client.create().withTtl(10).creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_WITH_TTL).forPath("/a/b/c");
             Thread.sleep(20);
-            Assert.assertNull(client.checkExists().forPath("/a/b/c"));
+            assertNull(client.checkExists().forPath("/a/b/c"));
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasicInBackground() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -86,9 +89,9 @@ public class TestTtlNodes extends CuratorTestBase
                 }
             };
             client.create().withTtl(10).creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_WITH_TTL).inBackground(callback).forPath("/a/b/c");
-            Assert.assertTrue(new Timing().awaitLatch(latch));
+            assertTrue(new Timing().awaitLatch(latch));
             Thread.sleep(20);
-            Assert.assertNull(client.checkExists().forPath("/a/b/c"));
+            assertNull(client.checkExists().forPath("/a/b/c"));
         }
     }
 }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTtlNodes.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestTtlNodes.java
@@ -21,19 +21,19 @@ package org.apache.curator.framework.imps;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.Timing;
 import org.apache.zookeeper.CreateMode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 
 public class TestTtlNodes extends CuratorTestBase
@@ -59,7 +59,7 @@ public class TestTtlNodes extends CuratorTestBase
         System.clearProperty("znode.container.checkIntervalMs");
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -72,7 +72,7 @@ public class TestTtlNodes extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasicInBackground() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatcherIdentity.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatcherIdentity.java
@@ -18,7 +18,10 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import com.google.common.collect.Sets;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.CuratorWatcher;
@@ -28,8 +31,6 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -59,7 +60,7 @@ public class TestWatcherIdentity extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSameWatcherPerZKDocs() throws Exception
     {
         CountZKWatcher actualWatcher = new CountZKWatcher();
@@ -77,13 +78,13 @@ public class TestWatcherIdentity extends BaseClassForTests
             client.setData().forPath("/test", "foo".getBytes());
             client.delete().forPath("/test");
             timing.sleepABit();
-            Assert.assertEquals(actualWatcher.count.getAndSet(0), 1);
+            assertEquals(actualWatcher.count.getAndSet(0), 1);
 
             client.create().forPath("/test");
             client.checkExists().usingWatcher(actualWatcher).forPath("/test");
             client.delete().forPath("/test");
             timing.sleepABit();
-            Assert.assertEquals(actualWatcher.count.get(), 1);
+            assertEquals(actualWatcher.count.get(), 1);
         }
         finally
         {
@@ -91,7 +92,7 @@ public class TestWatcherIdentity extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSameCuratorWatcherPerZKDocs() throws Exception
     {
         CountCuratorWatcher actualWatcher = new CountCuratorWatcher();
@@ -109,13 +110,13 @@ public class TestWatcherIdentity extends BaseClassForTests
             client.setData().forPath("/test", "foo".getBytes());
             client.delete().forPath("/test");
             timing.sleepABit();
-            Assert.assertEquals(actualWatcher.count.getAndSet(0), 1);
+            assertEquals(actualWatcher.count.getAndSet(0), 1);
 
             client.create().forPath("/test");
             client.checkExists().usingWatcher(actualWatcher).forPath("/test");
             client.delete().forPath("/test");
             timing.sleepABit();
-            Assert.assertEquals(actualWatcher.count.get(), 1);
+            assertEquals(actualWatcher.count.get(), 1);
         }
         finally
         {
@@ -123,7 +124,7 @@ public class TestWatcherIdentity extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSetAddition()
     {
         Watcher watcher = new Watcher()
@@ -136,16 +137,16 @@ public class TestWatcherIdentity extends BaseClassForTests
         };
         NamespaceWatcher namespaceWatcher1 = new NamespaceWatcher(null, watcher, "/foo");
         NamespaceWatcher namespaceWatcher2 = new NamespaceWatcher(null, watcher, "/foo");
-        Assert.assertEquals(namespaceWatcher1, namespaceWatcher2);
-        Assert.assertFalse(namespaceWatcher1.equals(watcher));
-        Assert.assertFalse(watcher.equals(namespaceWatcher1));
+        assertEquals(namespaceWatcher1, namespaceWatcher2);
+        assertFalse(namespaceWatcher1.equals(watcher));
+        assertFalse(watcher.equals(namespaceWatcher1));
         Set<Watcher> set = Sets.newHashSet();
         set.add(namespaceWatcher1);
         set.add(namespaceWatcher2);
-        Assert.assertEquals(set.size(), 1);
+        assertEquals(set.size(), 1);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCuratorWatcher() throws Exception
     {
         Timing timing = new Timing();
@@ -161,7 +162,7 @@ public class TestWatcherIdentity extends BaseClassForTests
             // Ok, let's test it
             client.setData().forPath(PATH, new byte[]{});
             timing.sleepABit();
-            Assert.assertEquals(1, watcher.count.get());
+            assertEquals(1, watcher.count.get());
         }
         finally
         {
@@ -170,7 +171,7 @@ public class TestWatcherIdentity extends BaseClassForTests
     }
 
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testZKWatcher() throws Exception
     {
         Timing timing = new Timing();
@@ -186,7 +187,7 @@ public class TestWatcherIdentity extends BaseClassForTests
             // Ok, let's test it
             client.setData().forPath(PATH, new byte[]{});
             timing.sleepABit();
-            Assert.assertEquals(1, watcher.count.get());
+            assertEquals(1, watcher.count.get());
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatcherIdentity.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatcherIdentity.java
@@ -21,7 +21,6 @@ package org.apache.curator.framework.imps;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import com.google.common.collect.Sets;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.CuratorWatcher;
@@ -31,6 +30,8 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
+import org.junit.jupiter.api.Test;
+
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -60,7 +61,7 @@ public class TestWatcherIdentity extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSameWatcherPerZKDocs() throws Exception
     {
         CountZKWatcher actualWatcher = new CountZKWatcher();
@@ -92,7 +93,7 @@ public class TestWatcherIdentity extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSameCuratorWatcherPerZKDocs() throws Exception
     {
         CountCuratorWatcher actualWatcher = new CountCuratorWatcher();
@@ -124,7 +125,7 @@ public class TestWatcherIdentity extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetAddition()
     {
         Watcher watcher = new Watcher()
@@ -146,7 +147,7 @@ public class TestWatcherIdentity extends BaseClassForTests
         assertEquals(set.size(), 1);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCuratorWatcher() throws Exception
     {
         Timing timing = new Timing();
@@ -171,7 +172,7 @@ public class TestWatcherIdentity extends BaseClassForTests
     }
 
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testZKWatcher() throws Exception
     {
         Timing timing = new Timing();

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatcherRemovalManager.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatcherRemovalManager.java
@@ -18,27 +18,31 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.WatcherRemoveCuratorFramework;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.WatchersDebug;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 
 public class TestWatcherRemovalManager extends CuratorTestBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSameWatcherDifferentPaths1Triggered() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -60,7 +64,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
             removerClient.create().creatingParentsIfNeeded().forPath("/d/e/f");
 
             Timing timing = new Timing();
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
             timing.sleepABit();
 
             removerClient.removeWatchers();
@@ -71,7 +75,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSameWatcherDifferentPaths() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -89,7 +93,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
             };
             removerClient.checkExists().usingWatcher(watcher).forPath("/a/b/c");
             removerClient.checkExists().usingWatcher(watcher).forPath("/d/e/f");
-            Assert.assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 2);
+            assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 2);
             removerClient.removeWatchers();
         }
         finally
@@ -98,7 +102,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSameWatcherDifferentKinds1Triggered() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -122,7 +126,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
             removerClient.setData().forPath("/a/b/c", "new".getBytes());
 
             Timing timing = new Timing();
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
             timing.sleepABit();
 
             removerClient.removeWatchers();
@@ -133,7 +137,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSameWatcherDifferentKinds() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -161,7 +165,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWithRetry() throws Exception
     {
         server.stop();
@@ -181,13 +185,13 @@ public class TestWatcherRemovalManager extends CuratorTestBase
             try
             {
                 removerClient.checkExists().usingWatcher(w).forPath("/one/two/three");
-                Assert.fail("Should have thrown ConnectionLossException");
+                fail("Should have thrown ConnectionLossException");
             }
             catch ( KeeperException.ConnectionLossException expected )
             {
                 // expected
             }
-            Assert.assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 0);
+            assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 0);
         }
         finally
         {
@@ -195,7 +199,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWithRetryInBackground() throws Exception
     {
         server.stop();
@@ -223,8 +227,8 @@ public class TestWatcherRemovalManager extends CuratorTestBase
                 }
             };
             removerClient.checkExists().usingWatcher(w).inBackground(callback).forPath("/one/two/three");
-            Assert.assertTrue(new Timing().awaitLatch(latch));
-            Assert.assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 0);
+            assertTrue(new Timing().awaitLatch(latch));
+            assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 0);
         }
         finally
         {
@@ -232,7 +236,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testMissingNode() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -251,7 +255,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
             try
             {
                 removerClient.getData().usingWatcher(w).forPath("/one/two/three");
-                Assert.fail("Should have thrown NoNodeException");
+                fail("Should have thrown NoNodeException");
             }
             catch ( KeeperException.NoNodeException expected )
             {
@@ -265,7 +269,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testMissingNodeInBackground() throws Exception
     {
         final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -294,8 +298,8 @@ public class TestWatcherRemovalManager extends CuratorTestBase
                     }
                 };
                 removerClient.getData().usingWatcher(w).inBackground(callback).forPath("/one/two/three");
-                Assert.assertTrue(new Timing().awaitLatch(latch));
-                Assert.assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 0);
+                assertTrue(new Timing().awaitLatch(latch));
+                assertEquals(removerClient.getWatcherRemovalManager().getEntries().size(), 0);
                 removerClient.removeWatchers();
                 return null;
             }
@@ -303,7 +307,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         TestCleanState.test(client, proc);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -318,7 +322,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasicNamespace1() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -333,7 +337,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasicNamespace2() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder()
@@ -352,7 +356,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasicNamespace3() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder()
@@ -371,7 +375,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSameWatcher() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -392,9 +396,9 @@ public class TestWatcherRemovalManager extends CuratorTestBase
             };
 
             removerClient.getData().usingWatcher(watcher).forPath("/test");
-            Assert.assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
             removerClient.getData().usingWatcher(watcher).forPath("/test");
-            Assert.assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
             removerClient.removeWatchers();
         }
         finally
@@ -403,7 +407,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testTriggered() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -427,12 +431,12 @@ public class TestWatcherRemovalManager extends CuratorTestBase
             };
 
             removerClient.checkExists().usingWatcher(watcher).forPath("/yo");
-            Assert.assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
             removerClient.create().forPath("/yo");
 
-            Assert.assertTrue(new Timing().awaitLatch(latch));
+            assertTrue(new Timing().awaitLatch(latch));
 
-            Assert.assertEquals(removerClient.getRemovalManager().getEntries().size(), 0);
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 0);
         }
         finally
         {
@@ -440,7 +444,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testResetFromWatcher() throws Exception
     {
         Timing timing = new Timing();
@@ -478,17 +482,17 @@ public class TestWatcherRemovalManager extends CuratorTestBase
             };
 
             removerClient.checkExists().usingWatcher(watcher).forPath("/yo");
-            Assert.assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
             removerClient.create().forPath("/yo");
 
-            Assert.assertTrue(timing.awaitLatch(createdLatch));
-            Assert.assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
+            assertTrue(timing.awaitLatch(createdLatch));
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 1);
 
             removerClient.delete().forPath("/yo");
 
-            Assert.assertTrue(timing.awaitLatch(deletedLatch));
+            assertTrue(timing.awaitLatch(deletedLatch));
 
-            Assert.assertEquals(removerClient.getRemovalManager().getEntries().size(), 0);
+            assertEquals(removerClient.getRemovalManager().getEntries().size(), 0);
         }
         finally
         {
@@ -515,13 +519,13 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         removerClient.checkExists().usingWatcher(watcher).forPath("/hey");
 
         List<String> existWatches = WatchersDebug.getExistWatches(client.getZookeeperClient().getZooKeeper());
-        Assert.assertEquals(existWatches.size(), 1);
+        assertEquals(existWatches.size(), 1);
 
         removerClient.removeWatchers();
 
-        Assert.assertTrue(new Timing().awaitLatch(latch));
+        assertTrue(new Timing().awaitLatch(latch));
 
         existWatches = WatchersDebug.getExistWatches(client.getZookeeperClient().getZooKeeper());
-        Assert.assertEquals(existWatches.size(), 0);
+        assertEquals(existWatches.size(), 0);
     }
 }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatcherRemovalManager.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatcherRemovalManager.java
@@ -22,27 +22,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.WatcherRemoveCuratorFramework;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.WatchersDebug;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 
 public class TestWatcherRemovalManager extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSameWatcherDifferentPaths1Triggered() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -75,7 +75,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSameWatcherDifferentPaths() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -102,7 +102,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSameWatcherDifferentKinds1Triggered() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -137,7 +137,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSameWatcherDifferentKinds() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -165,7 +165,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWithRetry() throws Exception
     {
         server.stop();
@@ -199,7 +199,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWithRetryInBackground() throws Exception
     {
         server.stop();
@@ -236,7 +236,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMissingNode() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -269,7 +269,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMissingNodeInBackground() throws Exception
     {
         final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -307,7 +307,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         TestCleanState.test(client, proc);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -322,7 +322,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasicNamespace1() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -337,7 +337,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasicNamespace2() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder()
@@ -356,7 +356,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasicNamespace3() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder()
@@ -375,7 +375,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSameWatcher() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -407,7 +407,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testTriggered() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -444,7 +444,7 @@ public class TestWatcherRemovalManager extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testResetFromWatcher() throws Exception
     {
         Timing timing = new Timing();

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatchesBuilder.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatchesBuilder.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -35,7 +34,6 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
@@ -48,6 +46,8 @@ import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.Watcher.WatcherType;
 import org.apache.zookeeper.ZooKeeper;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -102,7 +102,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveCuratorDefaultWatcher() throws Exception
     {
         Timing timing = new Timing();
@@ -141,7 +141,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveCuratorWatch() throws Exception
     {       
         Timing timing = new Timing();
@@ -180,7 +180,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }    
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveWatch() throws Exception
     {       
         Timing timing = new Timing();
@@ -209,7 +209,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveWatchInBackgroundWithCallback() throws Exception
     {       
         Timing timing = new Timing();
@@ -252,7 +252,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveWatchInBackgroundWithNoCallback() throws Exception
     {       
         Timing timing = new Timing();
@@ -281,7 +281,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }        
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveAllWatches() throws Exception
     {       
         Timing timing = new Timing();
@@ -312,7 +312,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }  
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveAllDataWatches() throws Exception
     {       
         Timing timing = new Timing();
@@ -345,7 +345,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveAllChildWatches() throws Exception
     {       
         Timing timing = new Timing();
@@ -378,7 +378,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }     
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveLocalWatch() throws Exception {
         Timing timing = new Timing();
         CuratorFrameworkImpl client = (CuratorFrameworkImpl)CuratorFrameworkFactory.builder().
@@ -414,7 +414,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveLocalWatchInBackground() throws Exception {
         Timing timing = new Timing();
         CuratorFrameworkImpl client = (CuratorFrameworkImpl)CuratorFrameworkFactory.builder().
@@ -455,7 +455,7 @@ public class TestWatchesBuilder extends CuratorTestBase
      * be thrown. 
      * @throws Exception
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveUnregisteredWatcher() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder().
@@ -494,7 +494,7 @@ public class TestWatchesBuilder extends CuratorTestBase
      * Test the case where we try and remove an unregistered watcher but have the quietly flag set. In this case we expect success. 
      * @throws Exception
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemoveUnregisteredWatcherQuietly() throws Exception
     {
         Timing timing = new Timing();
@@ -524,7 +524,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGuaranteedRemoveWatch() throws Exception {
         Timing timing = new Timing();
         CuratorFramework client = CuratorFrameworkFactory.builder().
@@ -569,7 +569,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGuaranteedRemoveWatchInBackground() throws Exception {
         Timing timing = new Timing();
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(),
@@ -618,7 +618,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Tag(CuratorTestBase.zk36Group)
     public void testPersistentWatch() throws Exception
     {
@@ -639,7 +639,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Tag(CuratorTestBase.zk36Group)
     public void testPersistentWatchInBackground() throws Exception
     {
@@ -663,7 +663,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Tag(CuratorTestBase.zk36Group)
     public void testPersistentRecursiveWatch() throws Exception
     {
@@ -686,7 +686,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Tag(CuratorTestBase.zk36Group)
     public void testPersistentRecursiveWatchInBackground() throws Exception
     {
@@ -712,7 +712,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Tag(CuratorTestBase.zk36Group)
     public void testPersistentRecursiveDefaultWatch() throws Exception
     {

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatchesBuilder.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatchesBuilder.java
@@ -18,6 +18,11 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -30,6 +35,7 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
@@ -41,8 +47,7 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.Watcher.WatcherType;
 import org.apache.zookeeper.ZooKeeper;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -97,7 +102,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveCuratorDefaultWatcher() throws Exception
     {
         Timing timing = new Timing();
@@ -128,7 +133,7 @@ public class TestWatchesBuilder extends CuratorTestBase
             
             client.watches().removeAll().forPath(path);
             
-            Assert.assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
         }
         finally
         {
@@ -136,7 +141,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveCuratorWatch() throws Exception
     {       
         Timing timing = new Timing();
@@ -167,7 +172,7 @@ public class TestWatchesBuilder extends CuratorTestBase
 
             client.watches().remove(watcher).forPath(path);
 
-            Assert.assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
         }
         finally
         {
@@ -175,7 +180,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }    
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveWatch() throws Exception
     {       
         Timing timing = new Timing();
@@ -196,7 +201,7 @@ public class TestWatchesBuilder extends CuratorTestBase
 
             client.watches().remove(watcher).forPath(path);
 
-            Assert.assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
         }
         finally
         {
@@ -204,7 +209,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveWatchInBackgroundWithCallback() throws Exception
     {       
         Timing timing = new Timing();
@@ -238,7 +243,7 @@ public class TestWatchesBuilder extends CuratorTestBase
 
             client.watches().remove(watcher).ofType(WatcherType.Any).inBackground(callback).forPath(path);
 
-            Assert.assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
             
         }
         finally
@@ -247,7 +252,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveWatchInBackgroundWithNoCallback() throws Exception
     {       
         Timing timing = new Timing();
@@ -267,7 +272,7 @@ public class TestWatchesBuilder extends CuratorTestBase
 
             client.watches().remove(watcher).inBackground().forPath(path);
 
-            Assert.assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
             
         }
         finally
@@ -276,7 +281,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }        
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveAllWatches() throws Exception
     {       
         Timing timing = new Timing();
@@ -299,7 +304,7 @@ public class TestWatchesBuilder extends CuratorTestBase
 
             client.watches().removeAll().forPath(path);
 
-            Assert.assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
         }
         finally
         {
@@ -307,7 +312,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }  
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveAllDataWatches() throws Exception
     {       
         Timing timing = new Timing();
@@ -331,8 +336,8 @@ public class TestWatchesBuilder extends CuratorTestBase
             
             client.watches().removeAll().ofType(WatcherType.Data).forPath(path);
             
-            Assert.assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
-            Assert.assertEquals(removedFlag.get(), false);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertEquals(removedFlag.get(), false);
         }
         finally
         {
@@ -340,7 +345,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveAllChildWatches() throws Exception
     {       
         Timing timing = new Timing();
@@ -364,8 +369,8 @@ public class TestWatchesBuilder extends CuratorTestBase
             
             client.watches().removeAll().ofType(WatcherType.Children).forPath(path);
             
-            Assert.assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
-            Assert.assertEquals(removedFlag.get(), false);
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertEquals(removedFlag.get(), false);
         }
         finally
         {
@@ -373,7 +378,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }     
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveLocalWatch() throws Exception {
         Timing timing = new Timing();
         CuratorFrameworkImpl client = (CuratorFrameworkImpl)CuratorFrameworkFactory.builder().
@@ -397,11 +402,11 @@ public class TestWatchesBuilder extends CuratorTestBase
             //Stop the server so we can check if we can remove watches locally when offline
             server.stop();
             
-            Assert.assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
+            assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
                        
             client.watches().removeAll().locally().forPath(path);
 
-            Assert.assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
         }
         finally
         {
@@ -409,7 +414,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveLocalWatchInBackground() throws Exception {
         Timing timing = new Timing();
         CuratorFrameworkImpl client = (CuratorFrameworkImpl)CuratorFrameworkFactory.builder().
@@ -433,11 +438,11 @@ public class TestWatchesBuilder extends CuratorTestBase
             //Stop the server so we can check if we can remove watches locally when offline
             server.stop();
             
-            Assert.assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
+            assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
                        
             client.watches().removeAll().locally().inBackground().forPath(path);
 
-            Assert.assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
+            assertTrue(timing.awaitLatch(removedLatch), "Timed out waiting for watch removal");
         }
         finally
         {
@@ -450,7 +455,7 @@ public class TestWatchesBuilder extends CuratorTestBase
      * be thrown. 
      * @throws Exception
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveUnregisteredWatcher() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder().
@@ -472,7 +477,7 @@ public class TestWatchesBuilder extends CuratorTestBase
             try
             {
                 client.watches().remove(watcher).forPath(path);
-                Assert.fail("Expected KeeperException.NoWatcherException");
+                fail("Expected KeeperException.NoWatcherException");
             }
             catch ( KeeperException.NoWatcherException expected )
             {
@@ -484,12 +489,12 @@ public class TestWatchesBuilder extends CuratorTestBase
             CloseableUtils.closeQuietly(client);
         }
     }
-    
+
     /**
      * Test the case where we try and remove an unregistered watcher but have the quietly flag set. In this case we expect success. 
      * @throws Exception
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemoveUnregisteredWatcherQuietly() throws Exception
     {
         Timing timing = new Timing();
@@ -511,7 +516,7 @@ public class TestWatchesBuilder extends CuratorTestBase
             timing.sleepABit();
             
             //There should be no watcher removed as none were registered.
-            Assert.assertEquals(watcherRemoved.get(), false);
+            assertEquals(watcherRemoved.get(), false);
         }
         finally
         {
@@ -519,7 +524,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testGuaranteedRemoveWatch() throws Exception {
         Timing timing = new Timing();
         CuratorFramework client = CuratorFrameworkFactory.builder().
@@ -541,13 +546,13 @@ public class TestWatchesBuilder extends CuratorTestBase
             
             server.stop();           
             
-            Assert.assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
+            assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
             
             //Remove the watch while we're not connected
             try 
             {
                 client.watches().remove(watcher).guaranteed().forPath(path);
-                Assert.fail();
+                fail();
             }
             catch(KeeperException.ConnectionLossException e)
             {
@@ -564,7 +569,7 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testGuaranteedRemoveWatchInBackground() throws Exception {
         Timing timing = new Timing();
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(),
@@ -596,7 +601,7 @@ public class TestWatchesBuilder extends CuratorTestBase
             client.checkExists().usingWatcher(watcher).forPath(path);
             
             server.stop();           
-            Assert.assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
+            assertTrue(blockUntilDesiredConnectionState(stateRef, timing, ConnectionState.SUSPENDED));
             
             //Remove the watch while we're not connected
             client.watches().remove(watcher).guaranteed().inBackground().forPath(path);
@@ -613,7 +618,8 @@ public class TestWatchesBuilder extends CuratorTestBase
         }
     }
 
-    @Test(groups = CuratorTestBase.zk36Group)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Tag(CuratorTestBase.zk36Group)
     public void testPersistentWatch() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -629,11 +635,12 @@ public class TestWatchesBuilder extends CuratorTestBase
             client.setData().forPath("/test/foo", "hey".getBytes());
             client.delete().forPath("/test/foo");
 
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
         }
     }
 
-    @Test(groups = CuratorTestBase.zk36Group)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Tag(CuratorTestBase.zk36Group)
     public void testPersistentWatchInBackground() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -651,12 +658,13 @@ public class TestWatchesBuilder extends CuratorTestBase
             client.setData().forPath("/test/foo", "hey".getBytes());
             client.delete().forPath("/test/foo");
 
-            Assert.assertTrue(timing.awaitLatch(backgroundLatch));
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(backgroundLatch));
+            assertTrue(timing.awaitLatch(latch));
         }
     }
 
-    @Test(groups = CuratorTestBase.zk36Group)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Tag(CuratorTestBase.zk36Group)
     public void testPersistentRecursiveWatch() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -674,11 +682,12 @@ public class TestWatchesBuilder extends CuratorTestBase
             client.create().forPath("/test/a/b/c");
             client.create().forPath("/test/a/b/c/d");
 
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
         }
     }
 
-    @Test(groups = CuratorTestBase.zk36Group)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Tag(CuratorTestBase.zk36Group)
     public void testPersistentRecursiveWatchInBackground() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -698,12 +707,13 @@ public class TestWatchesBuilder extends CuratorTestBase
             client.create().forPath("/test/a/b/c");
             client.create().forPath("/test/a/b/c/d");
 
-            Assert.assertTrue(timing.awaitLatch(backgroundLatch));
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(backgroundLatch));
+            assertTrue(timing.awaitLatch(latch));
         }
     }
 
-    @Test(groups = CuratorTestBase.zk36Group)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Tag(CuratorTestBase.zk36Group)
     public void testPersistentRecursiveDefaultWatch() throws Exception
     {
         CountDownLatch latch = new CountDownLatch(6);   // 5 creates plus the initial sync
@@ -727,7 +737,7 @@ public class TestWatchesBuilder extends CuratorTestBase
             client.create().forPath("/test/a/b/c");
             client.create().forPath("/test/a/b/c/d");
 
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
         }
     }
 

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWithCluster.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWithCluster.java
@@ -21,8 +21,6 @@ package org.apache.curator.framework.imps;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -35,11 +33,13 @@ import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.Timing;
 import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 
 public class TestWithCluster extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSessionSurvives() throws Exception
     {
         Timing              timing = new Timing();
@@ -86,7 +86,7 @@ public class TestWithCluster extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSplitBrain() throws Exception
     {
         Timing              timing = new Timing();

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWithCluster.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWithCluster.java
@@ -18,6 +18,11 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -30,13 +35,11 @@ import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.Timing;
 import org.apache.zookeeper.CreateMode;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.CountDownLatch;
 
 public class TestWithCluster extends CuratorTestBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSessionSurvives() throws Exception
     {
         Timing              timing = new Timing();
@@ -63,7 +66,7 @@ public class TestWithCluster extends CuratorTestBase
             client.getConnectionStateListenable().addListener(listener);
 
             client.create().withMode(CreateMode.EPHEMERAL).forPath("/temp", "value".getBytes());
-            Assert.assertNotNull(client.checkExists().forPath("/temp"));
+            assertNotNull(client.checkExists().forPath("/temp"));
 
             for ( InstanceSpec spec : cluster.getInstances() )
             {
@@ -73,8 +76,8 @@ public class TestWithCluster extends CuratorTestBase
                 timing.sleepABit();
             }
 
-            Assert.assertTrue(timing.awaitLatch(reconnectedLatch));
-            Assert.assertNotNull(client.checkExists().forPath("/temp"));
+            assertTrue(timing.awaitLatch(reconnectedLatch));
+            assertNotNull(client.checkExists().forPath("/temp"));
         }
         finally
         {
@@ -83,7 +86,7 @@ public class TestWithCluster extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSplitBrain() throws Exception
     {
         Timing              timing = new Timing();
@@ -127,11 +130,11 @@ public class TestWithCluster extends CuratorTestBase
             {
                 if ( !instanceSpec.equals(cluster.findConnectionInstance(client.getZookeeperClient().getZooKeeper())) )
                 {
-                    Assert.assertTrue(cluster.killServer(instanceSpec));
+                    assertTrue(cluster.killServer(instanceSpec));
                 }
             }
 
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
         }
         finally
         {

--- a/curator-framework/src/test/java/org/apache/curator/framework/schema/TestSchema.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/schema/TestSchema.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.transaction.CuratorOp;
@@ -36,13 +35,15 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.ACL;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 public class TestSchema extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasics() throws Exception
     {
         SchemaSet schemaSet = loadSchemaSet("schema1.json", null);
@@ -78,7 +79,7 @@ public class TestSchema extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSchemaValidator() throws Exception
     {
         final SchemaValidator schemaValidator = new SchemaValidator()
@@ -121,7 +122,7 @@ public class TestSchema extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMulti() throws Exception
     {
         SchemaSet schemaSet = loadSchemaSet("schema2.json", null);
@@ -156,7 +157,7 @@ public class TestSchema extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testTransaction() throws Exception
     {
         final SchemaValidator schemaValidator = new SchemaValidator()
@@ -238,7 +239,7 @@ public class TestSchema extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testYaml() throws Exception
     {
         String yaml = Resources.toString(Resources.getResource("schema.yaml"), Charsets.UTF_8);
@@ -252,7 +253,7 @@ public class TestSchema extends BaseClassForTests
         assertEquals(schemas.get(1).getMetadata().get("two"), "2");
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testOrdering() throws Exception
     {
         SchemaSet schemaSet = loadSchemaSet("schema5.json", null);

--- a/curator-framework/src/test/java/org/apache/curator/framework/schema/TestSchema.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/schema/TestSchema.java
@@ -18,12 +18,16 @@
  */
 package org.apache.curator.framework.schema;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.transaction.CuratorOp;
@@ -32,24 +36,22 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.ACL;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 public class TestSchema extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasics() throws Exception
     {
         SchemaSet schemaSet = loadSchemaSet("schema1.json", null);
         Schema schema = schemaSet.getNamedSchema("test");
-        Assert.assertNotNull(schema);
+        assertNotNull(schema);
         Map<String, String> expectedMetadata = Maps.newHashMap();
         expectedMetadata.put("one", "1");
         expectedMetadata.put("two", "2");
-        Assert.assertEquals(schema.getMetadata(), expectedMetadata);
+        assertEquals(schema.getMetadata(), expectedMetadata);
 
         CuratorFramework client = newClient(schemaSet);
         try
@@ -59,9 +61,9 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 String rawPath = schema.getRawPath();
-                Assert.assertEquals(rawPath, "/a/b/c");
+                assertEquals(rawPath, "/a/b/c");
                 client.create().creatingParentsIfNeeded().forPath(rawPath);
-                Assert.fail("Should've violated schema");
+                fail("Should've violated schema");
             }
             catch ( SchemaViolation dummy )
             {
@@ -76,7 +78,7 @@ public class TestSchema extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSchemaValidator() throws Exception
     {
         final SchemaValidator schemaValidator = new SchemaValidator()
@@ -104,7 +106,7 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 client.create().forPath("/test", new byte[0]);
-                Assert.fail("Should've violated schema");
+                fail("Should've violated schema");
             }
             catch ( SchemaViolation dummy )
             {
@@ -119,7 +121,7 @@ public class TestSchema extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testMulti() throws Exception
     {
         SchemaSet schemaSet = loadSchemaSet("schema2.json", null);
@@ -131,7 +133,7 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 client.create().creatingParentsIfNeeded().forPath("/a/b/c");
-                Assert.fail("Should've violated schema: test");
+                fail("Should've violated schema: test");
             }
             catch ( SchemaViolation dummy )
             {
@@ -141,7 +143,7 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath("/a/b/c/d/e");
-                Assert.fail("Should've violated schema: test2");
+                fail("Should've violated schema: test2");
             }
             catch ( SchemaViolation dummy )
             {
@@ -154,7 +156,7 @@ public class TestSchema extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testTransaction() throws Exception
     {
         final SchemaValidator schemaValidator = new SchemaValidator()
@@ -190,7 +192,7 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 client.transaction().forOperations(createAPersistent, createAEphemeral);
-                Assert.fail("Should've violated schema");
+                fail("Should've violated schema");
             }
             catch ( SchemaViolation dummy )
             {
@@ -201,7 +203,7 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 client.transaction().forOperations(deleteA);
-                Assert.fail("Should've violated schema");
+                fail("Should've violated schema");
             }
             catch ( SchemaViolation dummy )
             {
@@ -211,7 +213,7 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 client.transaction().forOperations(createBEmptyData);
-                Assert.fail("Should've violated schema");
+                fail("Should've violated schema");
             }
             catch ( SchemaViolation dummy )
             {
@@ -222,7 +224,7 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 client.transaction().forOperations(setBEmptyData);
-                Assert.fail("Should've violated schema");
+                fail("Should've violated schema");
             }
             catch ( SchemaViolation dummy )
             {
@@ -236,21 +238,21 @@ public class TestSchema extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testYaml() throws Exception
     {
         String yaml = Resources.toString(Resources.getResource("schema.yaml"), Charsets.UTF_8);
         JsonNode root = new ObjectMapper(new YAMLFactory()).readTree(yaml);
         List<Schema> schemas = new SchemaSetLoader(root, null).getSchemas();
-        Assert.assertEquals(schemas.size(), 2);
-        Assert.assertEquals(schemas.get(0).getName(), "test");
-        Assert.assertEquals(schemas.get(0).getMetadata().size(), 0);
-        Assert.assertEquals(schemas.get(1).getName(), "test2");
-        Assert.assertEquals(schemas.get(1).getMetadata().size(), 2);
-        Assert.assertEquals(schemas.get(1).getMetadata().get("two"), "2");
+        assertEquals(schemas.size(), 2);
+        assertEquals(schemas.get(0).getName(), "test");
+        assertEquals(schemas.get(0).getMetadata().size(), 0);
+        assertEquals(schemas.get(1).getName(), "test2");
+        assertEquals(schemas.get(1).getMetadata().size(), 2);
+        assertEquals(schemas.get(1).getMetadata().get("two"), "2");
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testOrdering() throws Exception
     {
         SchemaSet schemaSet = loadSchemaSet("schema5.json", null);
@@ -262,7 +264,7 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath("/exact/match");
-                Assert.fail("Should've violated schema");
+                fail("Should've violated schema");
             }
             catch ( SchemaViolation dummy )
             {
@@ -272,7 +274,7 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath("/exact/foo/bar");
-                Assert.fail("Should've violated schema");
+                fail("Should've violated schema");
             }
             catch ( SchemaViolation dummy )
             {
@@ -282,7 +284,7 @@ public class TestSchema extends BaseClassForTests
             try
             {
                 client.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT_SEQUENTIAL).forPath("/exact/other/bar");
-                Assert.fail("Should've violated schema");
+                fail("Should've violated schema");
             }
             catch ( SchemaViolation dummy )
             {

--- a/curator-framework/src/test/java/org/apache/curator/framework/state/TestConnectionStateManager.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/state/TestConnectionStateManager.java
@@ -18,6 +18,9 @@
  */
 package org.apache.curator.framework.state;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -25,15 +28,14 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestConnectionStateManager extends BaseClassForTests {
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSessionConnectionStateErrorPolicyWithExpirationPercent30() throws Exception {
         Timing2 timing = new Timing2();
         CuratorFramework client = CuratorFrameworkFactory.builder()
@@ -71,10 +73,10 @@ public class TestConnectionStateManager extends BaseClassForTests {
 
             client.getConnectionStateListenable().addListener(stateListener);
             client.start();
-            Assert.assertTrue(timing.awaitLatch(connectedLatch));
+            assertTrue(timing.awaitLatch(connectedLatch));
             server.close();
 
-            Assert.assertTrue(lostLatch.await(lostStateExpectedMs, TimeUnit.MILLISECONDS));
+            assertTrue(lostLatch.await(lostStateExpectedMs, TimeUnit.MILLISECONDS));
         }
         finally {
             CloseableUtils.closeQuietly(client);

--- a/curator-framework/src/test/java/org/apache/curator/framework/state/TestConnectionStateManager.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/state/TestConnectionStateManager.java
@@ -20,7 +20,6 @@ package org.apache.curator.framework.state;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -29,13 +28,15 @@ import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestConnectionStateManager extends BaseClassForTests {
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSessionConnectionStateErrorPolicyWithExpirationPercent30() throws Exception {
         Timing2 timing = new Timing2();
         CuratorFramework client = CuratorFrameworkFactory.builder()

--- a/curator-recipes/pom.xml
+++ b/curator-recipes/pom.xml
@@ -70,8 +70,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.artsok</groupId>
+            <artifactId>rerunner-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/curator-recipes/pom.xml
+++ b/curator-recipes/pom.xml
@@ -76,12 +76,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.artsok</groupId>
-            <artifactId>rerunner-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>

--- a/curator-recipes/src/test/java/org/apache/curator/connection/TestThreadLocalRetryLoop.java
+++ b/curator-recipes/src/test/java/org/apache/curator/connection/TestThreadLocalRetryLoop.java
@@ -18,6 +18,11 @@
  */
 package org.apache.curator.connection;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.RetryLoop;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.RetrySleeper;
@@ -25,11 +30,11 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.KeeperException;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.DisplayName;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -41,7 +46,8 @@ public class TestThreadLocalRetryLoop extends CuratorTestBase
     private static final int retryCount = 4;
     private static final String backgroundThreadNameBase = "ignore-curator-background-thread";
 
-    @Test(description = "Check for fix for CURATOR-559")
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @DisplayName("Check for fix for CURATOR-559")
     public void testRecursingRetry() throws Exception
     {
         AtomicInteger count = new AtomicInteger();
@@ -49,11 +55,12 @@ public class TestThreadLocalRetryLoop extends CuratorTestBase
         {
             prep(client, count);
             doOperation(client);
-            Assert.assertEquals(count.get(), retryCount + 1);    // Curator's retry policy has been off by 1 since inception - we might consider fixing it someday
+            assertEquals(count.get(), retryCount + 1);    // Curator's retry policy has been off by 1 since inception - we might consider fixing it someday
         }
     }
 
-    @Test(description = "Check for fix for CURATOR-559 with multiple threads")
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @DisplayName("Check for fix for CURATOR-559 with multiple threads")
     public void testThreadedRecursingRetry() throws Exception
     {
         final int threadQty = 4;
@@ -67,16 +74,18 @@ public class TestThreadLocalRetryLoop extends CuratorTestBase
                 executorService.submit(() -> doOperation(client));
             }
             executorService.shutdown();
-            Assert.assertTrue(executorService.awaitTermination(timing.milliseconds(), TimeUnit.MILLISECONDS));
-            Assert.assertEquals(count.get(), threadQty * (retryCount + 1));    // Curator's retry policy has been off by 1 since inception - we might consider fixing it someday
+            assertTrue(executorService.awaitTermination(timing.milliseconds(), TimeUnit.MILLISECONDS));
+            assertEquals(count.get(), threadQty * (retryCount + 1));    // Curator's retry policy has been off by 1 since inception - we might consider fixing it someday
         }
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBadReleaseWithNoGet()
     {
-        ThreadLocalRetryLoop retryLoopStack = new ThreadLocalRetryLoop();
-        retryLoopStack.release();
+        assertThrows(NullPointerException.class, ()-> {
+                    ThreadLocalRetryLoop retryLoopStack = new ThreadLocalRetryLoop();
+                    retryLoopStack.release();
+                });
     }
 
     private CuratorFramework newClient(AtomicInteger count)
@@ -97,7 +106,7 @@ public class TestThreadLocalRetryLoop extends CuratorTestBase
             }
         });
         server.stop();
-        Assert.assertTrue(timing.awaitLatch(lostLatch));
+        assertTrue(timing.awaitLatch(lostLatch));
         count.set(0);   // in case the server shutdown incremented the count
     }
 
@@ -109,7 +118,7 @@ public class TestThreadLocalRetryLoop extends CuratorTestBase
                 client.checkExists().forPath("/hey");
                 return null;
             });
-            Assert.fail("Should have thrown an exception");
+            fail("Should have thrown an exception");
         }
         catch ( KeeperException dummy )
         {

--- a/curator-recipes/src/test/java/org/apache/curator/connection/TestThreadLocalRetryLoop.java
+++ b/curator-recipes/src/test/java/org/apache/curator/connection/TestThreadLocalRetryLoop.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.RetryLoop;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.RetrySleeper;
@@ -30,11 +29,12 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryNTimes;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.KeeperException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -46,7 +46,7 @@ public class TestThreadLocalRetryLoop extends CuratorTestBase
     private static final int retryCount = 4;
     private static final String backgroundThreadNameBase = "ignore-curator-background-thread";
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @DisplayName("Check for fix for CURATOR-559")
     public void testRecursingRetry() throws Exception
     {
@@ -59,7 +59,7 @@ public class TestThreadLocalRetryLoop extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @DisplayName("Check for fix for CURATOR-559 with multiple threads")
     public void testThreadedRecursingRetry() throws Exception
     {
@@ -79,7 +79,7 @@ public class TestThreadLocalRetryLoop extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBadReleaseWithNoGet()
     {
         assertThrows(NullPointerException.class, ()-> {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/client/TestBackgroundStates.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/client/TestBackgroundStates.java
@@ -22,7 +22,6 @@ package org.apache.curator.framework.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.nodes.PersistentEphemeralNode;
@@ -33,6 +32,8 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class TestBackgroundStates extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testListenersReconnectedIsOK() throws Exception
     {
         server.close();
@@ -94,7 +95,7 @@ public class TestBackgroundStates extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConnectionStateListener() throws Exception
     {
         server.close();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/client/TestBackgroundStates.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/client/TestBackgroundStates.java
@@ -19,7 +19,10 @@
 
 package org.apache.curator.framework.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Queues;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.nodes.PersistentEphemeralNode;
@@ -30,8 +33,6 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +42,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class TestBackgroundStates extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testListenersReconnectedIsOK() throws Exception
     {
         server.close();
@@ -77,14 +78,14 @@ public class TestBackgroundStates extends BaseClassForTests
             client.getConnectionStateListenable().addListener(listener);
             timing.sleepABit();
             server = new TestingServer(server.getPort());
-            Assert.assertTrue(timing.awaitLatch(connectedLatch));
+            assertTrue(timing.awaitLatch(connectedLatch));
             timing.sleepABit();
-            Assert.assertTrue(node.waitForInitialCreate(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS));
+            assertTrue(node.waitForInitialCreate(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS));
             server.restart();
             timing.sleepABit();
-            Assert.assertTrue(timing.awaitLatch(reconnectedLatch));
+            assertTrue(timing.awaitLatch(reconnectedLatch));
             timing.sleepABit();
-            Assert.assertEquals(lastState.get(), ConnectionState.RECONNECTED);
+            assertEquals(lastState.get(), ConnectionState.RECONNECTED);
         }
         finally
         {
@@ -93,7 +94,7 @@ public class TestBackgroundStates extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testConnectionStateListener() throws Exception
     {
         server.close();
@@ -118,15 +119,15 @@ public class TestBackgroundStates extends BaseClassForTests
 
             client.getConnectionStateListenable().addListener(listener);
             server = new TestingServer(server.getPort());
-            Assert.assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+            assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
             server.stop();
-            Assert.assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
-            Assert.assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+            assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+            assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
             server.restart();
-            Assert.assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
+            assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
             server.close();
-            Assert.assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
-            Assert.assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+            assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+            assertEquals(stateVector.poll(waitingTiming.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/client/TestResetConnectionWithBackgroundFailure.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/client/TestResetConnectionWithBackgroundFailure.java
@@ -21,7 +21,6 @@ package org.apache.curator.framework.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.leader.LeaderSelector;
@@ -33,6 +32,7 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.concurrent.BlockingQueue;
@@ -42,7 +42,7 @@ public class TestResetConnectionWithBackgroundFailure extends BaseClassForTests
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConnectionStateListener() throws Exception
     {
         server.stop();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/client/TestResetConnectionWithBackgroundFailure.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/client/TestResetConnectionWithBackgroundFailure.java
@@ -19,26 +19,22 @@
 
 package org.apache.curator.framework.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.Queues;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
 import org.apache.curator.framework.recipes.leader.LeaderSelector;
 import org.apache.curator.framework.recipes.leader.LeaderSelectorListener;
 import org.apache.curator.framework.recipes.leader.LeaderSelectorListenerAdapter;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
-import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.ZooDefs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -46,7 +42,7 @@ public class TestResetConnectionWithBackgroundFailure extends BaseClassForTests
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testConnectionStateListener() throws Exception
     {
         server.stop();
@@ -86,21 +82,21 @@ public class TestResetConnectionWithBackgroundFailure extends BaseClassForTests
             client.getConnectionStateListenable().addListener(listener1);
             log.debug("Starting ZK server");
             server.restart();
-            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
+            assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED);
 
             log.debug("Stopping ZK server");
             server.stop();
-            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
-            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+            assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+            assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
 
             log.debug("Starting ZK server");
             server.restart();
-            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
+            assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED);
 
             log.debug("Stopping ZK server");
             server.close();
-            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
-            Assert.assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
+            assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.SUSPENDED);
+            assertEquals(listenerSequence.poll(forWaiting.milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.LOST);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/atomic/TestCachedAtomicCounter.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/atomic/TestCachedAtomicCounter.java
@@ -22,16 +22,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.atomic.AtomicReference;
 
 public class TestCachedAtomicCounter extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void         testWithError() throws Exception
     {
         final int        FACTOR = 100;
@@ -116,7 +117,7 @@ public class TestCachedAtomicCounter extends BaseClassForTests
         }
         }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void         testBasic() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/atomic/TestCachedAtomicCounter.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/atomic/TestCachedAtomicCounter.java
@@ -18,17 +18,20 @@
  */
 package org.apache.curator.framework.recipes.atomic;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class TestCachedAtomicCounter extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void         testWithError() throws Exception
     {
         final int        FACTOR = 100;
@@ -92,9 +95,9 @@ public class TestCachedAtomicCounter extends BaseClassForTests
             for ( int i = 0; i < FACTOR; ++i )
             {
                 value = cachedLong.next();
-                Assert.assertTrue(value.succeeded());
-                Assert.assertEquals(value.preValue().longValue(), i);
-                Assert.assertEquals(value.postValue().longValue(), i + 1);
+                assertTrue(value.succeeded());
+                assertEquals(value.preValue().longValue(), i);
+                assertEquals(value.postValue().longValue(), i + 1);
 
                 if ( i == 0 )
                 {
@@ -105,7 +108,7 @@ public class TestCachedAtomicCounter extends BaseClassForTests
             }
 
             value = cachedLong.next();
-            Assert.assertFalse(value.succeeded());
+            assertFalse(value.succeeded());
         }
         finally
         {
@@ -113,7 +116,7 @@ public class TestCachedAtomicCounter extends BaseClassForTests
         }
         }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void         testBasic() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -125,9 +128,9 @@ public class TestCachedAtomicCounter extends BaseClassForTests
             for ( long i = 0; i < 200; ++i )
             {
                 AtomicValue<Long>       value = cachedLong.next();
-                Assert.assertTrue(value.succeeded());
-                Assert.assertEquals(value.preValue().longValue(), i);
-                Assert.assertEquals(value.postValue().longValue(), i + 1);
+                assertTrue(value.succeeded());
+                assertEquals(value.preValue().longValue(), i);
+                assertEquals(value.postValue().longValue(), i + 1);
             }
         }
         finally

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/atomic/TestDistributedAtomicLong.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/atomic/TestDistributedAtomicLong.java
@@ -18,6 +18,13 @@
  */
 package org.apache.curator.framework.recipes.atomic;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -27,9 +34,6 @@ import org.apache.commons.math.stat.descriptive.SummaryStatistics;
 import org.apache.commons.math.stat.descriptive.SynchronizedSummaryStatistics;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import org.testng.collections.Lists;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.util.List;
@@ -43,7 +47,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestDistributedAtomicLong extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testCorruptedValue() throws Exception
     {
         final CuratorFramework      client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -58,11 +62,11 @@ public class TestDistributedAtomicLong extends BaseClassForTests
             }
             catch ( BufferUnderflowException e )
             {
-                Assert.fail("", e);
+                fail("", e);
             }
             catch ( BufferOverflowException e )
             {
-                Assert.fail("", e);
+                fail("", e);
             }
             catch ( RuntimeException e )
             {
@@ -75,7 +79,7 @@ public class TestDistributedAtomicLong extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCompareAndSetWithFreshInstance() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -84,13 +88,13 @@ public class TestDistributedAtomicLong extends BaseClassForTests
             client.start();
             DistributedAtomicLong dal = new DistributedAtomicLong(client, "/counter", new RetryOneTime(1));
             AtomicValue<Long> result = dal.compareAndSet(0L, 1L);
-            Assert.assertFalse(result.succeeded());
+            assertFalse(result.succeeded());
 
-            Assert.assertTrue(dal.initialize(0L));
+            assertTrue(dal.initialize(0L));
             result = dal.compareAndSet(0L, 1L);
-            Assert.assertTrue(result.succeeded());
+            assertTrue(result.succeeded());
 
-            Assert.assertFalse(dal.initialize(0L));
+            assertFalse(dal.initialize(0L));
         }
         finally
         {
@@ -98,7 +102,7 @@ public class TestDistributedAtomicLong extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testCompareAndSet() throws Exception
     {
         final CuratorFramework      client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -130,11 +134,11 @@ public class TestDistributedAtomicLong extends BaseClassForTests
             };
             dal.forceSet(1L);
 
-            Assert.assertTrue(dal.compareAndSet(1L, 5L).succeeded());
-            Assert.assertFalse(dal.compareAndSet(1L, 5L).succeeded());
+            assertTrue(dal.compareAndSet(1L, 5L).succeeded());
+            assertFalse(dal.compareAndSet(1L, 5L).succeeded());
 
             doIncrement.set(true);
-            Assert.assertFalse(dal.compareAndSet(5L, 10L).succeeded());
+            assertFalse(dal.compareAndSet(5L, 10L).succeeded());
         }
         finally
         {
@@ -142,7 +146,7 @@ public class TestDistributedAtomicLong extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testForceSet() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -185,7 +189,7 @@ public class TestDistributedAtomicLong extends BaseClassForTests
                 }
             );
 
-            Assert.assertTrue(dal.get().preValue() < 10);
+            assertTrue(dal.get().preValue() < 10);
         }
         finally
         {
@@ -193,7 +197,7 @@ public class TestDistributedAtomicLong extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSimulation() throws Exception
     {
         final int           threadQty = 20;
@@ -237,12 +241,12 @@ public class TestDistributedAtomicLong extends BaseClassForTests
         System.out.println("Min time: " + timingStats.getMin());
         System.out.println("Qty: " + timingStats.getN());
 
-        Assert.assertEquals(errors.get(), 0);
-        Assert.assertTrue(optimisticTries.get() > 0);
-        Assert.assertTrue(promotedLockTries.get() > 0);
+        assertEquals(errors.get(), 0);
+        assertTrue(optimisticTries.get() > 0);
+        assertTrue(promotedLockTries.get() > 0);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasic() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -252,32 +256,32 @@ public class TestDistributedAtomicLong extends BaseClassForTests
             DistributedAtomicLong dal = new DistributedAtomicLong(client, "/foo/bar/counter", new RetryOneTime(1));
 
             AtomicValue<Long>           value = dal.increment();
-            Assert.assertTrue(value.succeeded());
-            Assert.assertEquals(value.getStats().getOptimisticTries(), 1);
-            Assert.assertEquals(value.getStats().getPromotedLockTries(), 0);
-            Assert.assertEquals(value.preValue().longValue(), 0L);
-            Assert.assertEquals(value.postValue().longValue(), 1L);
+            assertTrue(value.succeeded());
+            assertEquals(value.getStats().getOptimisticTries(), 1);
+            assertEquals(value.getStats().getPromotedLockTries(), 0);
+            assertEquals(value.preValue().longValue(), 0L);
+            assertEquals(value.postValue().longValue(), 1L);
 
             value = dal.decrement();
-            Assert.assertTrue(value.succeeded());
-            Assert.assertEquals(value.getStats().getOptimisticTries(), 1);
-            Assert.assertEquals(value.getStats().getPromotedLockTries(), 0);
-            Assert.assertEquals(value.preValue().longValue(), 1L);
-            Assert.assertEquals(value.postValue().longValue(), 0L);
+            assertTrue(value.succeeded());
+            assertEquals(value.getStats().getOptimisticTries(), 1);
+            assertEquals(value.getStats().getPromotedLockTries(), 0);
+            assertEquals(value.preValue().longValue(), 1L);
+            assertEquals(value.postValue().longValue(), 0L);
 
             value = dal.add(10L);
-            Assert.assertTrue(value.succeeded());
-            Assert.assertEquals(value.getStats().getOptimisticTries(), 1);
-            Assert.assertEquals(value.getStats().getPromotedLockTries(), 0);
-            Assert.assertEquals(value.preValue().longValue(), 0L);
-            Assert.assertEquals(value.postValue().longValue(), 10L);
+            assertTrue(value.succeeded());
+            assertEquals(value.getStats().getOptimisticTries(), 1);
+            assertEquals(value.getStats().getPromotedLockTries(), 0);
+            assertEquals(value.preValue().longValue(), 0L);
+            assertEquals(value.postValue().longValue(), 10L);
 
             value = dal.subtract(5L);
-            Assert.assertTrue(value.succeeded());
-            Assert.assertEquals(value.getStats().getOptimisticTries(), 1);
-            Assert.assertEquals(value.getStats().getPromotedLockTries(), 0);
-            Assert.assertEquals(value.preValue().longValue(), 10L);
-            Assert.assertEquals(value.postValue().longValue(), 5L);
+            assertTrue(value.succeeded());
+            assertEquals(value.getStats().getOptimisticTries(), 1);
+            assertEquals(value.getStats().getPromotedLockTries(), 0);
+            assertEquals(value.preValue().longValue(), 10L);
+            assertEquals(value.postValue().longValue(), 5L);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/atomic/TestDistributedAtomicLong.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/atomic/TestDistributedAtomicLong.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -34,6 +33,8 @@ import org.apache.commons.math.stat.descriptive.SummaryStatistics;
 import org.apache.commons.math.stat.descriptive.SynchronizedSummaryStatistics;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.util.List;
@@ -47,7 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestDistributedAtomicLong extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testCorruptedValue() throws Exception
     {
         final CuratorFramework      client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -79,7 +80,7 @@ public class TestDistributedAtomicLong extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCompareAndSetWithFreshInstance() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -102,7 +103,7 @@ public class TestDistributedAtomicLong extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testCompareAndSet() throws Exception
     {
         final CuratorFramework      client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -146,7 +147,7 @@ public class TestDistributedAtomicLong extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testForceSet() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -197,7 +198,7 @@ public class TestDistributedAtomicLong extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSimulation() throws Exception
     {
         final int           threadQty = 20;
@@ -246,7 +247,7 @@ public class TestDistributedAtomicLong extends BaseClassForTests
         assertTrue(promotedLockTries.get() > 0);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasic() throws Exception
     {
         CuratorFramework        client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/barriers/TestDistributedBarrier.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/barriers/TestDistributedBarrier.java
@@ -21,13 +21,14 @@ package org.apache.curator.framework.recipes.barriers;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.zookeeper.KeeperException;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -37,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestDistributedBarrier extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testServerCrash() throws Exception
     {
         final int                         TIMEOUT = 1000;
@@ -79,7 +80,7 @@ public class TestDistributedBarrier extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testMultiClient() throws Exception
     {
         CuratorFramework            client1 = null;
@@ -151,7 +152,7 @@ public class TestDistributedBarrier extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testNoBarrier() throws Exception
     {
         CuratorFramework            client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -184,7 +185,7 @@ public class TestDistributedBarrier extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasic() throws Exception
     {
         CuratorFramework            client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/barriers/TestDistributedBarrier.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/barriers/TestDistributedBarrier.java
@@ -18,15 +18,16 @@
  */
 package org.apache.curator.framework.recipes.barriers;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.zookeeper.KeeperException;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -36,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestDistributedBarrier extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testServerCrash() throws Exception
     {
         final int                         TIMEOUT = 1000;
@@ -66,7 +67,7 @@ public class TestDistributedBarrier extends BaseClassForTests
 
             barrier.waitOnBarrier(TIMEOUT * 2, TimeUnit.SECONDS);
             future.get();
-            Assert.fail();
+            fail();
         }
         catch ( KeeperException.ConnectionLossException expected )
         {
@@ -78,7 +79,7 @@ public class TestDistributedBarrier extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testMultiClient() throws Exception
     {
         CuratorFramework            client1 = null;
@@ -150,7 +151,7 @@ public class TestDistributedBarrier extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testNoBarrier() throws Exception
     {
         CuratorFramework            client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -159,7 +160,7 @@ public class TestDistributedBarrier extends BaseClassForTests
             client.start();
 
             final DistributedBarrier      barrier = new DistributedBarrier(client, "/barrier");
-            Assert.assertTrue(barrier.waitOnBarrier(10, TimeUnit.SECONDS));
+            assertTrue(barrier.waitOnBarrier(10, TimeUnit.SECONDS));
 
             // just for grins, test the infinite wait
             ExecutorService         service = Executors.newSingleThreadExecutor();
@@ -175,7 +176,7 @@ public class TestDistributedBarrier extends BaseClassForTests
                     }
                 }
             );
-            Assert.assertTrue(future.get(10, TimeUnit.SECONDS) != null);
+            assertTrue(future.get(10, TimeUnit.SECONDS) != null);
         }
         finally
         {
@@ -183,7 +184,7 @@ public class TestDistributedBarrier extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasic() throws Exception
     {
         CuratorFramework            client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -209,7 +210,7 @@ public class TestDistributedBarrier extends BaseClassForTests
                 }
             );
 
-            Assert.assertTrue(barrier.waitOnBarrier(10, TimeUnit.SECONDS));
+            assertTrue(barrier.waitOnBarrier(10, TimeUnit.SECONDS));
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/barriers/TestDistributedDoubleBarrier.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/barriers/TestDistributedDoubleBarrier.java
@@ -18,15 +18,16 @@
  */
 package org.apache.curator.framework.recipes.barriers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -43,7 +44,7 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
 {
     private static final int           QTY = 5;
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testMultiClient() throws Exception
     {
         final Timing            timing = new Timing();
@@ -68,7 +69,7 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
                             client.start();
                             DistributedDoubleBarrier        barrier = new DistributedDoubleBarrier(client, "/barrier", QTY);
 
-                            Assert.assertTrue(barrier.enter(timing.seconds(), TimeUnit.SECONDS));
+                            assertTrue(barrier.enter(timing.seconds(), TimeUnit.SECONDS));
 
                             synchronized(TestDistributedDoubleBarrier.this)
                             {
@@ -80,15 +81,15 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
                             }
 
                             postEnterLatch.countDown();
-                            Assert.assertTrue(timing.awaitLatch(postEnterLatch));
+                            assertTrue(timing.awaitLatch(postEnterLatch));
 
-                            Assert.assertEquals(count.get(), QTY);
+                            assertEquals(count.get(), QTY);
 
-                            Assert.assertTrue(barrier.leave(timing.seconds(), TimeUnit.SECONDS));
+                            assertTrue(barrier.leave(timing.seconds(), TimeUnit.SECONDS));
                             count.decrementAndGet();
 
                             postLeaveLatch.countDown();
-                            Assert.assertTrue(timing.awaitLatch(postEnterLatch));
+                            assertTrue(timing.awaitLatch(postEnterLatch));
                         }
                         finally
                         {
@@ -106,11 +107,11 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
         {
             f.get();
         }
-        Assert.assertEquals(count.get(), 0);
-        Assert.assertEquals(max.get(), QTY);
+        assertEquals(count.get(), 0);
+        assertEquals(max.get(), QTY);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testOverSubscribed() throws Exception
     {
         final Timing                    timing = new Timing();
@@ -138,19 +139,19 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
                                 protected List<String> getChildrenForEntering() throws Exception
                                 {
                                     semaphore.release();
-                                    Assert.assertTrue(timing.awaitLatch(latch));
+                                    assertTrue(timing.awaitLatch(latch));
                                     return super.getChildrenForEntering();
                                 }
                             };
-                            Assert.assertTrue(barrier.enter(timing.seconds(), TimeUnit.SECONDS));
-                            Assert.assertTrue(barrier.leave(timing.seconds(), TimeUnit.SECONDS));
+                            assertTrue(barrier.enter(timing.seconds(), TimeUnit.SECONDS));
+                            assertTrue(barrier.leave(timing.seconds(), TimeUnit.SECONDS));
                             return null;
                         }
                     }
                 );
             }
 
-            Assert.assertTrue(semaphore.tryAcquire(QTY + 1, timing.seconds(), TimeUnit.SECONDS));   // wait until all QTY+1 barriers are trying to enter
+            assertTrue(semaphore.tryAcquire(QTY + 1, timing.seconds(), TimeUnit.SECONDS));   // wait until all QTY+1 barriers are trying to enter
             latch.countDown();
 
             for ( int i = 0; i < (QTY + 1); ++i )
@@ -165,7 +166,7 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasic() throws Exception
     {
         final Timing              timing = new Timing();
@@ -193,7 +194,7 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
                         {
                             DistributedDoubleBarrier        barrier = new DistributedDoubleBarrier(client, "/barrier", QTY);
 
-                            Assert.assertTrue(barrier.enter(timing.seconds(), TimeUnit.SECONDS));
+                            assertTrue(barrier.enter(timing.seconds(), TimeUnit.SECONDS));
 
                             synchronized(TestDistributedDoubleBarrier.this)
                             {
@@ -205,15 +206,15 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
                             }
 
                             postEnterLatch.countDown();
-                            Assert.assertTrue(timing.awaitLatch(postEnterLatch));
+                            assertTrue(timing.awaitLatch(postEnterLatch));
 
-                            Assert.assertEquals(count.get(), QTY);
+                            assertEquals(count.get(), QTY);
 
-                            Assert.assertTrue(barrier.leave(10, TimeUnit.SECONDS));
+                            assertTrue(barrier.leave(10, TimeUnit.SECONDS));
                             count.decrementAndGet();
 
                             postLeaveLatch.countDown();
-                            Assert.assertTrue(timing.awaitLatch(postLeaveLatch));
+                            assertTrue(timing.awaitLatch(postLeaveLatch));
 
                             return null;
                         }
@@ -226,8 +227,8 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
             {
                 f.get();
             }
-            Assert.assertEquals(count.get(), 0);
-            Assert.assertEquals(max.get(), QTY);
+            assertEquals(count.get(), 0);
+            assertEquals(max.get(), QTY);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/barriers/TestDistributedDoubleBarrier.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/barriers/TestDistributedDoubleBarrier.java
@@ -21,13 +21,14 @@ package org.apache.curator.framework.recipes.barriers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
+import org.junit.jupiter.api.Test;
+
 import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -44,7 +45,7 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
 {
     private static final int           QTY = 5;
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testMultiClient() throws Exception
     {
         final Timing            timing = new Timing();
@@ -111,7 +112,7 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
         assertEquals(max.get(), QTY);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testOverSubscribed() throws Exception
     {
         final Timing                    timing = new Timing();
@@ -166,7 +167,7 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasic() throws Exception
     {
         final Timing              timing = new Timing();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/BaseTestTreeCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/BaseTestTreeCache.java
@@ -27,13 +27,21 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseTestTreeCache extends BaseClassForTests
 {
@@ -96,7 +104,7 @@ public class BaseTestTreeCache extends BaseClassForTests
     }
 
     @Override
-    @BeforeMethod(alwaysRun = true)
+    @BeforeEach
     public void setup() throws Exception
     {
         super.setup();
@@ -111,14 +119,14 @@ public class BaseTestTreeCache extends BaseClassForTests
     }
 
     @Override
-    @AfterMethod(alwaysRun = true)
+    @AfterEach
     public void teardown() throws Exception
     {
         try
         {
             try
             {
-                Assert.assertFalse(hadBackgroundException.get(), "Background exceptions were thrown, see stderr for details");
+                assertFalse(hadBackgroundException.get(), "Background exceptions were thrown, see stderr for details");
                 assertNoMoreEvents();
             }
             finally
@@ -139,7 +147,7 @@ public class BaseTestTreeCache extends BaseClassForTests
     void assertNoMoreEvents() throws InterruptedException
     {
         timing.sleepABit();
-        Assert.assertTrue(events.isEmpty(), String.format("Expected no events, found %d; first event: %s", events.size(), events.peek()));
+        assertTrue(events.isEmpty(), String.format("Expected no events, found %d; first event: %s", events.size(), events.peek()));
     }
 
     /**
@@ -169,7 +177,7 @@ public class BaseTestTreeCache extends BaseClassForTests
     TreeCacheEvent assertEvent(TreeCacheEvent.Type expectedType, String expectedPath, byte[] expectedData, boolean ignoreConnectionEvents) throws InterruptedException
     {
         TreeCacheEvent event = events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-        Assert.assertNotNull(event, String.format("Expected type: %s, path: %s", expectedType, expectedPath));
+        assertNotNull(event, String.format("Expected type: %s, path: %s", expectedType, expectedPath));
         if ( ignoreConnectionEvents )
         {
             if ( (event.getType() == TreeCacheEvent.Type.CONNECTION_SUSPENDED) || (event.getType() == TreeCacheEvent.Type.CONNECTION_LOST) || (event.getType() == TreeCacheEvent.Type.CONNECTION_RECONNECTED) )
@@ -179,28 +187,28 @@ public class BaseTestTreeCache extends BaseClassForTests
         }
 
         String message = event.toString();
-        Assert.assertEquals(event.getType(), expectedType, message);
+        assertEquals(event.getType(), expectedType, message);
         if ( expectedPath == null )
         {
-            Assert.assertNull(event.getData(), message);
+            assertNull(event.getData(), message);
         }
         else
         {
-            Assert.assertNotNull(event.getData(), message);
-            Assert.assertEquals(event.getData().getPath(), expectedPath, message);
+            assertNotNull(event.getData(), message);
+            assertEquals(event.getData().getPath(), expectedPath, message);
         }
         if ( expectedData != null )
         {
-            Assert.assertEquals(event.getData().getData(), expectedData, message);
+            assertArrayEquals(event.getData().getData(), expectedData, message);
         }
 
         if ( event.getType() == TreeCacheEvent.Type.NODE_UPDATED)
         {
-            Assert.assertNotNull(event.getOldData());
+            assertNotNull(event.getOldData());
         }
         else
         {
-            Assert.assertNull(event.getOldData());
+            assertNull(event.getOldData());
         }
 
         return event;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/BaseTestTreeCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/BaseTestTreeCache.java
@@ -28,7 +28,6 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.util.concurrent.BlockingQueue;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCache.java
@@ -24,13 +24,13 @@ import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.bu
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Tag(CuratorTestBase.zk36Group)
 public class TestCuratorCache extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testUpdateWhenNotCachingData() throws Exception // mostly copied from TestPathChildrenCache
     {
         CuratorCacheStorage storage = new StandardCuratorCacheStorage(false);
@@ -63,7 +63,7 @@ public class TestCuratorCache extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAfterInitialized() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1)))
@@ -105,7 +105,7 @@ public class TestCuratorCache extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testListenerBuilder() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1)))
@@ -147,7 +147,7 @@ public class TestCuratorCache extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testClearOnClose() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1)))

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCache.java
@@ -19,23 +19,26 @@
 
 package org.apache.curator.framework.recipes.cache;
 
+import static org.apache.curator.framework.recipes.cache.CuratorCache.Options.DO_NOT_CLEAR_ON_CLOSE;
+import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.builder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.apache.curator.framework.recipes.cache.CuratorCache.Options.DO_NOT_CLEAR_ON_CLOSE;
-import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.builder;
-
-@Test(groups = CuratorTestBase.zk36Group)
+@Tag(CuratorTestBase.zk36Group)
 public class TestCuratorCache extends CuratorTestBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testUpdateWhenNotCachingData() throws Exception // mostly copied from TestPathChildrenCache
     {
         CuratorCacheStorage storage = new StandardCuratorCacheStorage(false);
@@ -52,15 +55,15 @@ public class TestCuratorCache extends CuratorTestBase
                 cache.start();
 
                 client.create().forPath("/test/foo", "first".getBytes());
-                Assert.assertTrue(timing.awaitLatch(addedLatch));
+                assertTrue(timing.awaitLatch(addedLatch));
 
                 client.setData().forPath("/test/foo", "something new".getBytes());
-                Assert.assertTrue(timing.awaitLatch(updatedLatch));
+                assertTrue(timing.awaitLatch(updatedLatch));
             }
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testAfterInitialized() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1)))
@@ -90,19 +93,19 @@ public class TestCuratorCache extends CuratorTestBase
                 };
                 cache.listenable().addListener(builder().forAll(listener).afterInitialized().build());
                 cache.start();
-                Assert.assertTrue(timing.awaitLatch(initializedLatch));
+                assertTrue(timing.awaitLatch(initializedLatch));
 
-                Assert.assertEquals(initializedLatch.getCount(), 0);
-                Assert.assertEquals(cache.size(), 4);
-                Assert.assertTrue(cache.get("/test").isPresent());
-                Assert.assertTrue(cache.get("/test/one").isPresent());
-                Assert.assertTrue(cache.get("/test/one/two").isPresent());
-                Assert.assertTrue(cache.get("/test/one/two/three").isPresent());
+                assertEquals(initializedLatch.getCount(), 0);
+                assertEquals(cache.size(), 4);
+                assertTrue(cache.get("/test").isPresent());
+                assertTrue(cache.get("/test/one").isPresent());
+                assertTrue(cache.get("/test/one/two").isPresent());
+                assertTrue(cache.get("/test/one/two/three").isPresent());
             }
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testListenerBuilder() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1)))
@@ -121,30 +124,30 @@ public class TestCuratorCache extends CuratorTestBase
                 cache.start();
 
                 client.create().forPath("/test");
-                Assert.assertTrue(timing.acquireSemaphore(all, 1));
-                Assert.assertTrue(timing.acquireSemaphore(creates, 1));
-                Assert.assertTrue(timing.acquireSemaphore(createsAndChanges, 1));
-                Assert.assertEquals(changes.availablePermits(), 0);
-                Assert.assertEquals(deletes.availablePermits(), 0);
+                assertTrue(timing.acquireSemaphore(all, 1));
+                assertTrue(timing.acquireSemaphore(creates, 1));
+                assertTrue(timing.acquireSemaphore(createsAndChanges, 1));
+                assertEquals(changes.availablePermits(), 0);
+                assertEquals(deletes.availablePermits(), 0);
 
                 client.setData().forPath("/test", "new".getBytes());
-                Assert.assertTrue(timing.acquireSemaphore(all, 1));
-                Assert.assertTrue(timing.acquireSemaphore(changes, 1));
-                Assert.assertTrue(timing.acquireSemaphore(createsAndChanges, 1));
-                Assert.assertEquals(creates.availablePermits(), 0);
-                Assert.assertEquals(deletes.availablePermits(), 0);
+                assertTrue(timing.acquireSemaphore(all, 1));
+                assertTrue(timing.acquireSemaphore(changes, 1));
+                assertTrue(timing.acquireSemaphore(createsAndChanges, 1));
+                assertEquals(creates.availablePermits(), 0);
+                assertEquals(deletes.availablePermits(), 0);
 
                 client.delete().forPath("/test");
-                Assert.assertTrue(timing.acquireSemaphore(all, 1));
-                Assert.assertTrue(timing.acquireSemaphore(deletes, 1));
-                Assert.assertEquals(creates.availablePermits(), 0);
-                Assert.assertEquals(changes.availablePermits(), 0);
-                Assert.assertEquals(createsAndChanges.availablePermits(), 0);
+                assertTrue(timing.acquireSemaphore(all, 1));
+                assertTrue(timing.acquireSemaphore(deletes, 1));
+                assertEquals(creates.availablePermits(), 0);
+                assertEquals(changes.availablePermits(), 0);
+                assertEquals(createsAndChanges.availablePermits(), 0);
             }
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testClearOnClose() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1)))
@@ -161,7 +164,7 @@ public class TestCuratorCache extends CuratorTestBase
                 client.create().forPath("/test/bar", "bar".getBytes());
                 timing.sleepABit();
             }
-            Assert.assertEquals(storage.size(), 2);
+            assertEquals(storage.size(), 2);
 
             try ( CuratorCache cache = CuratorCache.build(client, "/test") )
             {
@@ -170,7 +173,7 @@ public class TestCuratorCache extends CuratorTestBase
 
                 timing.sleepABit();
             }
-            Assert.assertEquals(storage.size(), 0);
+            assertEquals(storage.size(), 0);
         }
     }
 }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheBridge.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheBridge.java
@@ -19,17 +19,20 @@
 
 package org.apache.curator.framework.recipes.cache;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.Compatibility;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 public class TestCuratorCacheBridge extends CuratorTestBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testImplementationSelection()
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -37,26 +40,26 @@ public class TestCuratorCacheBridge extends CuratorTestBase
             CuratorCacheBridge cache = CuratorCache.bridgeBuilder(client, "/foo").build();
             if ( Compatibility.hasPersistentWatchers() )
             {
-                Assert.assertTrue(cache instanceof CuratorCacheImpl);
-                Assert.assertTrue(cache.isCuratorCache());
+                assertTrue(cache instanceof CuratorCacheImpl);
+                assertTrue(cache.isCuratorCache());
             }
             else
             {
-                Assert.assertTrue(cache instanceof CompatibleCuratorCacheBridge);
-                Assert.assertFalse(cache.isCuratorCache());
+                assertTrue(cache instanceof CompatibleCuratorCacheBridge);
+                assertFalse(cache.isCuratorCache());
             }
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testForceTreeCache()
     {
         System.setProperty("curator-cache-bridge-force-tree-cache", "true");
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
         {
             CuratorCacheBridge cache = CuratorCache.bridgeBuilder(client, "/foo").build();
-            Assert.assertTrue(cache instanceof CompatibleCuratorCacheBridge);
-            Assert.assertFalse(cache.isCuratorCache());
+            assertTrue(cache instanceof CompatibleCuratorCacheBridge);
+            assertFalse(cache.isCuratorCache());
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheBridge.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheBridge.java
@@ -22,17 +22,16 @@ package org.apache.curator.framework.recipes.cache;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.Compatibility;
+import org.junit.jupiter.api.Test;
 
 public class TestCuratorCacheBridge extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testImplementationSelection()
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -51,7 +50,7 @@ public class TestCuratorCacheBridge extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testForceTreeCache()
     {
         System.setProperty("curator-cache-bridge-force-tree-cache", "true");

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheConsistency.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheConsistency.java
@@ -23,16 +23,15 @@ import static org.apache.curator.framework.recipes.cache.CuratorCache.Options.DO
 import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.builder;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.ZKPaths;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.Closeable;
@@ -120,7 +119,7 @@ public class TestCuratorCacheConsistency extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConsistencyAfterSimulation() throws Exception
     {
         int clientQty = random.nextInt(10, 20);

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheConsistency.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheConsistency.java
@@ -19,17 +19,22 @@
 
 package org.apache.curator.framework.recipes.cache;
 
+import static org.apache.curator.framework.recipes.cache.CuratorCache.Options.DO_NOT_CLEAR_ON_CLOSE;
+import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.builder;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.ZKPaths;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.io.Closeable;
 import java.time.Duration;
 import java.time.Instant;
@@ -45,14 +50,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.curator.framework.recipes.cache.CuratorCache.Options.DO_NOT_CLEAR_ON_CLOSE;
-import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.builder;
-
 /**
  * Randomly create nodes in a tree while a set of CuratorCaches listens. Afterwards, validate
  * that the caches contain the same values as ZK itself
  */
-@Test(groups = CuratorTestBase.zk36Group)
+@Tag(CuratorTestBase.zk36Group)
 public class TestCuratorCacheConsistency extends CuratorTestBase
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
@@ -118,7 +120,7 @@ public class TestCuratorCacheConsistency extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testConsistencyAfterSimulation() throws Exception
     {
         int clientQty = random.nextInt(10, 20);
@@ -166,7 +168,7 @@ public class TestCuratorCacheConsistency extends CuratorTestBase
                 log.error("");
             });
 
-            Assert.fail("Errors found");
+            fail("Errors found");
         }
     }
 
@@ -192,7 +194,7 @@ public class TestCuratorCacheConsistency extends CuratorTestBase
         }
         catch ( Exception e )
         {
-            Assert.fail("", e);
+            fail("", e);
         }
     }
 
@@ -229,7 +231,7 @@ public class TestCuratorCacheConsistency extends CuratorTestBase
             Exception errorSignalException = errorSignal.get();
             if ( errorSignalException != null )
             {
-                Assert.fail("A client's error handler was called", errorSignalException);
+                fail("A client's error handler was called", errorSignalException);
             }
 
             Duration elapsedFromLastServerKill = Duration.between(lastServerKill, Instant.now());
@@ -267,7 +269,7 @@ public class TestCuratorCacheConsistency extends CuratorTestBase
         }
         catch ( Exception e )
         {
-            Assert.fail("Could not create/set: " + thisPath);
+            fail("Could not create/set: " + thisPath);
         }
     }
 
@@ -283,7 +285,7 @@ public class TestCuratorCacheConsistency extends CuratorTestBase
         }
         catch ( Exception e )
         {
-            Assert.fail("Could not delete: " + thisPath);
+            fail("Could not delete: " + thisPath);
         }
     }
 

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheEdges.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheEdges.java
@@ -24,22 +24,22 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 
 @Tag(CuratorTestBase.zk36Group)
 public class TestCuratorCacheEdges extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testReconnectConsistency() throws Exception
     {
         final byte[] first = "one".getBytes();
@@ -105,7 +105,7 @@ public class TestCuratorCacheEdges extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testServerLoss() throws Exception   // mostly copied from TestPathChildrenCacheInCluster
     {
         try (TestingCluster cluster = new TestingCluster(3))

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheEdges.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheEdges.java
@@ -19,23 +19,26 @@
 
 package org.apache.curator.framework.recipes.cache;
 
+import static org.apache.curator.framework.recipes.cache.CuratorCache.Options.DO_NOT_CLEAR_ON_CLOSE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.compatibility.CuratorTestBase;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.concurrent.CountDownLatch;
 
-import static org.apache.curator.framework.recipes.cache.CuratorCache.Options.DO_NOT_CLEAR_ON_CLOSE;
-
-@Test(groups = CuratorTestBase.zk36Group)
+@Tag(CuratorTestBase.zk36Group)
 public class TestCuratorCacheEdges extends CuratorTestBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testReconnectConsistency() throws Exception
     {
         final byte[] first = "one".getBytes();
@@ -59,7 +62,7 @@ public class TestCuratorCacheEdges extends CuratorTestBase
                 CountDownLatch latch = new CountDownLatch(1);
                 cache.listenable().addListener(CuratorCacheListener.builder().forInitialized(latch::countDown).build());
                 cache.start();
-                Assert.assertTrue(timing.awaitLatch(latch));
+                assertTrue(timing.awaitLatch(latch));
             }
 
             // we now have a storage loaded with the initial nodes created
@@ -83,25 +86,25 @@ public class TestCuratorCacheEdges extends CuratorTestBase
                 CountDownLatch latch = new CountDownLatch(1);
                 cache.listenable().addListener(CuratorCacheListener.builder().forInitialized(latch::countDown).build());
                 cache.start();
-                Assert.assertTrue(timing.awaitLatch(latch));
+                assertTrue(timing.awaitLatch(latch));
             }
 
-            Assert.assertEquals(storage.size(), 11);
-            Assert.assertEquals(storage.get("/root").map(ChildData::getData).orElse(null), second);
-            Assert.assertEquals(storage.get("/root/1").map(ChildData::getData).orElse(null), first);
-            Assert.assertEquals(storage.get("/root/1/11").map(ChildData::getData).orElse(null), first);
-            Assert.assertEquals(storage.get("/root/1/11/111").map(ChildData::getData).orElse(null), second);
-            Assert.assertEquals(storage.get("/root/1/11/111/1111").map(ChildData::getData).orElse(null), second);
-            Assert.assertEquals(storage.get("/root/1/11/111/1112").map(ChildData::getData).orElse(null), second);
-            Assert.assertEquals(storage.get("/root/1/12").map(ChildData::getData).orElse(null), first);
-            Assert.assertEquals(storage.get("/root/1/13").map(ChildData::getData).orElse(null), first);
-            Assert.assertEquals(storage.get("/root/1/13/131").map(ChildData::getData).orElse(null), second);
-            Assert.assertEquals(storage.get("/root/1/13/132").map(ChildData::getData).orElse(null), second);
-            Assert.assertEquals(storage.get("/root/1/13/132/1321").map(ChildData::getData).orElse(null), second);
+            assertEquals(storage.size(), 11);
+            assertEquals(storage.get("/root").map(ChildData::getData).orElse(null), second);
+            assertEquals(storage.get("/root/1").map(ChildData::getData).orElse(null), first);
+            assertEquals(storage.get("/root/1/11").map(ChildData::getData).orElse(null), first);
+            assertEquals(storage.get("/root/1/11/111").map(ChildData::getData).orElse(null), second);
+            assertEquals(storage.get("/root/1/11/111/1111").map(ChildData::getData).orElse(null), second);
+            assertEquals(storage.get("/root/1/11/111/1112").map(ChildData::getData).orElse(null), second);
+            assertEquals(storage.get("/root/1/12").map(ChildData::getData).orElse(null), first);
+            assertEquals(storage.get("/root/1/13").map(ChildData::getData).orElse(null), first);
+            assertEquals(storage.get("/root/1/13/131").map(ChildData::getData).orElse(null), second);
+            assertEquals(storage.get("/root/1/13/132").map(ChildData::getData).orElse(null), second);
+            assertEquals(storage.get("/root/1/13/132/1321").map(ChildData::getData).orElse(null), second);
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testServerLoss() throws Exception   // mostly copied from TestPathChildrenCacheInCluster
     {
         try (TestingCluster cluster = new TestingCluster(3))
@@ -131,16 +134,16 @@ public class TestCuratorCacheEdges extends CuratorTestBase
                     client.create().forPath("/test/two");
                     client.create().forPath("/test/three");
 
-                    Assert.assertTrue(timing.awaitLatch(latch));
+                    assertTrue(timing.awaitLatch(latch));
 
                     InstanceSpec connectionInstance = cluster.findConnectionInstance(client.getZookeeperClient().getZooKeeper());
                     cluster.killServer(connectionInstance);
 
-                    Assert.assertTrue(timing.awaitLatch(reconnectLatch));
+                    assertTrue(timing.awaitLatch(reconnectLatch));
 
                     timing.sleepABit();
 
-                    Assert.assertEquals(cache.stream().count(), 4);
+                    assertEquals(cache.stream().count(), 4);
                 }
             }
         }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheEdges.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheEdges.java
@@ -20,6 +20,7 @@
 package org.apache.curator.framework.recipes.cache;
 
 import static org.apache.curator.framework.recipes.cache.CuratorCache.Options.DO_NOT_CLEAR_ON_CLOSE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,17 +91,17 @@ public class TestCuratorCacheEdges extends CuratorTestBase
             }
 
             assertEquals(storage.size(), 11);
-            assertEquals(storage.get("/root").map(ChildData::getData).orElse(null), second);
-            assertEquals(storage.get("/root/1").map(ChildData::getData).orElse(null), first);
-            assertEquals(storage.get("/root/1/11").map(ChildData::getData).orElse(null), first);
-            assertEquals(storage.get("/root/1/11/111").map(ChildData::getData).orElse(null), second);
-            assertEquals(storage.get("/root/1/11/111/1111").map(ChildData::getData).orElse(null), second);
-            assertEquals(storage.get("/root/1/11/111/1112").map(ChildData::getData).orElse(null), second);
-            assertEquals(storage.get("/root/1/12").map(ChildData::getData).orElse(null), first);
-            assertEquals(storage.get("/root/1/13").map(ChildData::getData).orElse(null), first);
-            assertEquals(storage.get("/root/1/13/131").map(ChildData::getData).orElse(null), second);
-            assertEquals(storage.get("/root/1/13/132").map(ChildData::getData).orElse(null), second);
-            assertEquals(storage.get("/root/1/13/132/1321").map(ChildData::getData).orElse(null), second);
+            assertArrayEquals(storage.get("/root").map(ChildData::getData).orElse(null), second);
+            assertArrayEquals(storage.get("/root/1").map(ChildData::getData).orElse(null), first);
+            assertArrayEquals(storage.get("/root/1/11").map(ChildData::getData).orElse(null), first);
+            assertArrayEquals(storage.get("/root/1/11/111").map(ChildData::getData).orElse(null), second);
+            assertArrayEquals(storage.get("/root/1/11/111/1111").map(ChildData::getData).orElse(null), second);
+            assertArrayEquals(storage.get("/root/1/11/111/1112").map(ChildData::getData).orElse(null), second);
+            assertArrayEquals(storage.get("/root/1/12").map(ChildData::getData).orElse(null), first);
+            assertArrayEquals(storage.get("/root/1/13").map(ChildData::getData).orElse(null), first);
+            assertArrayEquals(storage.get("/root/1/13/131").map(ChildData::getData).orElse(null), second);
+            assertArrayEquals(storage.get("/root/1/13/132").map(ChildData::getData).orElse(null), second);
+            assertArrayEquals(storage.get("/root/1/13/132/1321").map(ChildData::getData).orElse(null), second);
         }
     }
 

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheEventOrdering.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheEventOrdering.java
@@ -20,10 +20,10 @@ package org.apache.curator.framework.recipes.cache;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.compatibility.CuratorTestBase;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.concurrent.BlockingQueue;
 
-@Test(groups = CuratorTestBase.zk36Group)
+@Tag(CuratorTestBase.zk36Group)
 public class TestCuratorCacheEventOrdering extends TestEventOrdering<CuratorCache>
 {
     @Override

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheWrappers.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCacheWrappers.java
@@ -28,13 +28,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.ImmutableSet;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -49,7 +49,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 @Tag(CuratorTestBase.zk36Group)
 public class TestCuratorCacheWrappers extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPathChildrenCache() throws Exception    // copied from TestPathChildrenCache#testBasics()
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1)))
@@ -102,7 +102,7 @@ public class TestCuratorCacheWrappers extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testTreeCache() throws Exception    // copied from TestTreeCache#testBasics()
     {
         BaseTestTreeCache treeCacheBase = new BaseTestTreeCache();
@@ -142,7 +142,7 @@ public class TestCuratorCacheWrappers extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNodeCache() throws Exception    // copied from TestNodeCache#testBasics()
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1)) )

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestEventOrdering.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestEventOrdering.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -30,6 +29,8 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException;
+import org.junit.jupiter.api.Test;
+
 import java.io.Closeable;
 import java.util.List;
 import java.util.Random;
@@ -67,7 +68,7 @@ public abstract class TestEventOrdering<T extends Closeable> extends BaseClassFo
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testEventOrdering() throws Exception
     {
         ExecutorService executorService = Executors.newFixedThreadPool(THREAD_QTY);

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestEventOrdering.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestEventOrdering.java
@@ -18,8 +18,11 @@
  */
 package org.apache.curator.framework.recipes.cache;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -27,8 +30,6 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Random;
@@ -66,7 +67,7 @@ public abstract class TestEventOrdering<T extends Closeable> extends BaseClassFo
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testEventOrdering() throws Exception
     {
         ExecutorService executorService = Executors.newFixedThreadPool(THREAD_QTY);
@@ -135,7 +136,7 @@ public abstract class TestEventOrdering<T extends Closeable> extends BaseClassFo
                 };
                 executorService.submit(wrapped);
             }
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
 
             timing.sleepABit();
 
@@ -148,7 +149,7 @@ public abstract class TestEventOrdering<T extends Closeable> extends BaseClassFo
                 eventSuggestedQty += (event.eventType == EventType.ADDED) ? 1 : -1;
             }
             int actualQty = getActualQty(cache);
-            Assert.assertEquals(actualQty, eventSuggestedQty, String.format("actual %s expected %s:\n %s", actualQty, eventSuggestedQty, asString(localEvents)));
+            assertEquals(actualQty, eventSuggestedQty, String.format("actual %s expected %s:\n %s", actualQty, eventSuggestedQty, asString(localEvents)));
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestNodeCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestNodeCache.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
@@ -37,6 +36,8 @@ import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
@@ -50,7 +51,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestNodeCache extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testDeleteThenCreate() throws Exception
     {
         NodeCache           cache = null;
@@ -112,7 +113,7 @@ public class TestNodeCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testRebuildAgainstOtherProcesses() throws Exception
     {
         Timing2                 timing2 = new Timing2();
@@ -176,7 +177,7 @@ public class TestNodeCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testKilledSession() throws Exception
     {
         NodeCache           cache = null;
@@ -219,7 +220,7 @@ public class TestNodeCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasics() throws Exception
     {
         NodeCache           cache = null;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestNodeCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestNodeCache.java
@@ -18,6 +18,14 @@
  */
 package org.apache.curator.framework.recipes.cache;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
@@ -28,8 +36,7 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
@@ -40,10 +47,10 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestNodeCache extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testDeleteThenCreate() throws Exception
     {
         NodeCache           cache = null;
@@ -81,20 +88,20 @@ public class TestNodeCache extends BaseClassForTests
             );
             cache.start(true);
 
-            Assert.assertEquals(cache.getCurrentData().getData(), "one".getBytes());
+            assertArrayEquals(cache.getCurrentData().getData(), "one".getBytes());
 
             client.delete().forPath("/test/foo");
-            Assert.assertTrue(semaphore.tryAcquire(1, 10, TimeUnit.SECONDS));
+            assertTrue(semaphore.tryAcquire(1, 10, TimeUnit.SECONDS));
             client.create().forPath("/test/foo", "two".getBytes());
-            Assert.assertTrue(semaphore.tryAcquire(1, 10, TimeUnit.SECONDS));
+            assertTrue(semaphore.tryAcquire(1, 10, TimeUnit.SECONDS));
 
             Throwable t = error.get();
             if ( t != null )
             {
-                Assert.fail("Assert", t);
+                fail("Assert", t);
             }
 
-            Assert.assertEquals(cache.getCurrentData().getData(), "two".getBytes());
+            assertArrayEquals(cache.getCurrentData().getData(), "two".getBytes());
 
             cache.close();
         }
@@ -105,7 +112,7 @@ public class TestNodeCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testRebuildAgainstOtherProcesses() throws Exception
     {
         Timing2                 timing2 = new Timing2();
@@ -147,7 +154,7 @@ public class TestNodeCache extends BaseClassForTests
                         client.setData().forPath("/test/snafu", "other".getBytes());
 
                         ChildData       currentData = finalCache.getCurrentData();
-                        Assert.assertNotNull(currentData);
+                        assertNotNull(currentData);
 
                         finalCache.rebuildTestExchanger.exchange(new Object(), timing2.forWaiting().seconds(), TimeUnit.SECONDS);
 
@@ -158,9 +165,9 @@ public class TestNodeCache extends BaseClassForTests
             cache.start(false);
             future.get();
 
-            Assert.assertTrue(timing2.awaitLatch(latch));
-            Assert.assertNotNull(cache.getCurrentData());
-            Assert.assertEquals(cache.getCurrentData().getData(), "other".getBytes());
+            assertTrue(timing2.awaitLatch(latch));
+            assertNotNull(cache.getCurrentData());
+            assertArrayEquals(cache.getCurrentData().getData(), "other".getBytes());
         }
         finally
         {
@@ -169,7 +176,7 @@ public class TestNodeCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testKilledSession() throws Exception
     {
         NodeCache           cache = null;
@@ -200,10 +207,10 @@ public class TestNodeCache extends BaseClassForTests
             client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
             Thread.sleep(timing.multiple(1.5).session());
 
-            Assert.assertEquals(cache.getCurrentData().getData(), "start".getBytes());
+            assertArrayEquals(cache.getCurrentData().getData(), "start".getBytes());
 
             client.setData().forPath("/test/node", "new data".getBytes());
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
         }
         finally
         {
@@ -212,7 +219,7 @@ public class TestNodeCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasics() throws Exception
     {
         NodeCache           cache = null;
@@ -239,19 +246,19 @@ public class TestNodeCache extends BaseClassForTests
                 }
             );
 
-            Assert.assertNull(cache.getCurrentData());
+            assertNull(cache.getCurrentData());
 
             client.create().forPath("/test/node", "a".getBytes());
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
-            Assert.assertEquals(cache.getCurrentData().getData(), "a".getBytes());
+            assertTrue(timing.acquireSemaphore(semaphore));
+            assertArrayEquals(cache.getCurrentData().getData(), "a".getBytes());
 
             client.setData().forPath("/test/node", "b".getBytes());
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
-            Assert.assertEquals(cache.getCurrentData().getData(), "b".getBytes());
+            assertTrue(timing.acquireSemaphore(semaphore));
+            assertArrayEquals(cache.getCurrentData().getData(), "b".getBytes());
 
             client.delete().forPath("/test/node");
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
-            Assert.assertNull(cache.getCurrentData());
+            assertTrue(timing.acquireSemaphore(semaphore));
+            assertNull(cache.getCurrentData());
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestPathChildrenCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestPathChildrenCache.java
@@ -19,8 +19,17 @@
 
 package org.apache.curator.framework.recipes.cache;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.UnhandledErrorListener;
@@ -36,19 +45,16 @@ import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.testng.AssertJUnit.assertNotNull;
-
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestPathChildrenCache extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testParentContainerMissing() throws Exception
     {
         Timing timing = new Timing();
@@ -64,7 +70,7 @@ public class TestPathChildrenCache extends BaseClassForTests
                     startedLatch.countDown();
                 }
             });
-            Assert.assertTrue(timing.awaitLatch(startedLatch));
+            assertTrue(timing.awaitLatch(startedLatch));
 
             final BlockingQueue<PathChildrenCacheEvent.Type> events = Queues.newLinkedBlockingQueue();
             PathChildrenCacheListener listener = new PathChildrenCacheListener()
@@ -77,23 +83,23 @@ public class TestPathChildrenCache extends BaseClassForTests
             };
             cache.getListenable().addListener(listener);
             cache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
-            Assert.assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.INITIALIZED);
+            assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.INITIALIZED);
 
             client.create().forPath("/a/b/test/one");
             client.create().forPath("/a/b/test/two");
-            Assert.assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
-            Assert.assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
+            assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
+            assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
 
             client.delete().forPath("/a/b/test/one");
             client.delete().forPath("/a/b/test/two");
             client.delete().forPath("/a/b/test");
-            Assert.assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_REMOVED);
-            Assert.assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_REMOVED);
+            assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_REMOVED);
+            assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_REMOVED);
 
             timing.sleepABit();
 
             client.create().creatingParentContainersIfNeeded().forPath("/a/b/test/new");
-            Assert.assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
+            assertEquals(events.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
         }
         finally
         {
@@ -102,7 +108,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testInitializedEvenIfChildDeleted() throws Exception
     {
         final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -143,8 +149,8 @@ public class TestPathChildrenCache extends BaseClassForTests
 
             cache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
 
-            Assert.assertTrue(timing.awaitLatch(cacheInitialized));
-            Assert.assertEquals(cache.getCurrentData().size(), 0);
+            assertTrue(timing.awaitLatch(cacheInitialized));
+            assertEquals(cache.getCurrentData().size(), 0);
         }
         finally
         {
@@ -153,7 +159,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWithBadConnect() throws Exception
     {
         final int serverPort = server.getPort();
@@ -197,7 +203,7 @@ public class TestPathChildrenCache extends BaseClassForTests
             };
             cache.getListenable().addListener(listener);
             cache.start();
-            Assert.assertTrue(timing.awaitLatch(ensurePathLatch));
+            assertTrue(timing.awaitLatch(ensurePathLatch));
 
             final CountDownLatch connectedLatch = new CountDownLatch(1);
             client.getConnectionStateListenable().addListener(new ConnectionStateListener()
@@ -215,15 +221,15 @@ public class TestPathChildrenCache extends BaseClassForTests
 
             server = new TestingServer(serverPort, true);
 
-            Assert.assertTrue(timing.awaitLatch(connectedLatch));
+            assertTrue(timing.awaitLatch(connectedLatch));
 
             client.create().creatingParentContainersIfNeeded().forPath("/baz", new byte[]{1, 2, 3});
 
-            assertNotNull("/baz does not exist", client.checkExists().forPath("/baz"));
+            assertNotNull(client.checkExists().forPath("/baz"), "/baz does not exist");
 
-            Assert.assertTrue(timing.awaitLatch(addedLatch));
+            assertTrue(timing.awaitLatch(addedLatch));
 
-            assertNotNull("cache doesn't see /baz", cache.getCurrentData("/baz"));
+            assertNotNull(cache.getCurrentData("/baz"), "cache doesn't see /baz");
         }
         finally
         {
@@ -231,7 +237,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testPostInitializedForEmpty() throws Exception
     {
         Timing timing = new Timing();
@@ -258,7 +264,7 @@ public class TestPathChildrenCache extends BaseClassForTests
                     }
                 );
             cache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
         }
         finally
         {
@@ -267,7 +273,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testAsyncInitialPopulation() throws Exception
     {
         Timing timing = new Timing();
@@ -296,11 +302,11 @@ public class TestPathChildrenCache extends BaseClassForTests
             cache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
 
             PathChildrenCacheEvent event = events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-            Assert.assertEquals(event.getType(), PathChildrenCacheEvent.Type.CHILD_ADDED);
+            assertEquals(event.getType(), PathChildrenCacheEvent.Type.CHILD_ADDED);
 
             event = events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-            Assert.assertEquals(event.getType(), PathChildrenCacheEvent.Type.INITIALIZED);
-            Assert.assertEquals(event.getInitialData().size(), 1);
+            assertEquals(event.getType(), PathChildrenCacheEvent.Type.INITIALIZED);
+            assertEquals(event.getInitialData().size(), 1);
         }
         finally
         {
@@ -309,7 +315,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testChildrenInitialized() throws Exception
     {
         Timing timing = new Timing();
@@ -349,12 +355,12 @@ public class TestPathChildrenCache extends BaseClassForTests
 
             cache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
 
-            Assert.assertTrue(timing.awaitLatch(addedLatch));
-            Assert.assertTrue(timing.awaitLatch(initLatch));
-            Assert.assertEquals(cache.getCurrentData().size(), 3);
-            Assert.assertEquals(cache.getCurrentData().get(0).getData(), "1".getBytes());
-            Assert.assertEquals(cache.getCurrentData().get(1).getData(), "2".getBytes());
-            Assert.assertEquals(cache.getCurrentData().get(2).getData(), "3".getBytes());
+            assertTrue(timing.awaitLatch(addedLatch));
+            assertTrue(timing.awaitLatch(initLatch));
+            assertEquals(cache.getCurrentData().size(), 3);
+            assertArrayEquals(cache.getCurrentData().get(0).getData(), "1".getBytes());
+            assertArrayEquals(cache.getCurrentData().get(1).getData(), "2".getBytes());
+            assertArrayEquals(cache.getCurrentData().get(2).getData(), "3".getBytes());
         }
         finally
         {
@@ -363,7 +369,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testChildrenInitializedNormal() throws Exception
     {
         Timing timing = new Timing();
@@ -384,7 +390,7 @@ public class TestPathChildrenCache extends BaseClassForTests
                         @Override
                         public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception
                         {
-                            Assert.assertNotEquals(event.getType(), PathChildrenCacheEvent.Type.INITIALIZED);
+                            assertNotEquals(event.getType(), PathChildrenCacheEvent.Type.INITIALIZED);
                             if ( event.getType() == PathChildrenCacheEvent.Type.CHILD_ADDED )
                             {
                                 addedLatch.countDown();
@@ -399,11 +405,11 @@ public class TestPathChildrenCache extends BaseClassForTests
 
             cache.start(PathChildrenCache.StartMode.NORMAL);
 
-            Assert.assertTrue(timing.awaitLatch(addedLatch));
-            Assert.assertEquals(cache.getCurrentData().size(), 3);
-            Assert.assertEquals(cache.getCurrentData().get(0).getData(), "1".getBytes());
-            Assert.assertEquals(cache.getCurrentData().get(1).getData(), "2".getBytes());
-            Assert.assertEquals(cache.getCurrentData().get(2).getData(), "3".getBytes());
+            assertTrue(timing.awaitLatch(addedLatch));
+            assertEquals(cache.getCurrentData().size(), 3);
+            assertArrayEquals(cache.getCurrentData().get(0).getData(), "1".getBytes());
+            assertArrayEquals(cache.getCurrentData().get(1).getData(), "2".getBytes());
+            assertArrayEquals(cache.getCurrentData().get(2).getData(), "3".getBytes());
         }
         finally
         {
@@ -412,7 +418,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testUpdateWhenNotCachingData() throws Exception
     {
         Timing timing = new Timing();
@@ -447,10 +453,10 @@ public class TestPathChildrenCache extends BaseClassForTests
             cache.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
 
             client.create().forPath("/test/foo", "first".getBytes());
-            Assert.assertTrue(timing.awaitLatch(addedLatch));
+            assertTrue(timing.awaitLatch(addedLatch));
 
             client.setData().forPath("/test/foo", "something new".getBytes());
-            Assert.assertTrue(timing.awaitLatch(updatedLatch));
+            assertTrue(timing.awaitLatch(updatedLatch));
         }
         finally
         {
@@ -459,7 +465,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testEnsurePath() throws Exception
     {
         Timing timing = new Timing();
@@ -479,7 +485,7 @@ public class TestPathChildrenCache extends BaseClassForTests
                 }
                 catch ( KeeperException.NoNodeException e )
                 {
-                    Assert.fail("Path should exist", e);
+                    fail("Path should exist", e);
                 }
             }
             timing.sleepABit();
@@ -490,7 +496,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDeleteThenCreate() throws Exception
     {
         Timing timing = new Timing();
@@ -529,13 +535,13 @@ public class TestPathChildrenCache extends BaseClassForTests
                                 if ( event.getType() == PathChildrenCacheEvent.Type.CHILD_REMOVED )
                                 {
                                     removedLatch.countDown();
-                                    Assert.assertTrue(postRemovedLatch.await(10, TimeUnit.SECONDS));
+                                    assertTrue(postRemovedLatch.await(10, TimeUnit.SECONDS));
                                 }
                                 else
                                 {
                                     try
                                     {
-                                        Assert.assertEquals(event.getData().getData(), "two".getBytes());
+                                        assertArrayEquals(event.getData().getData(), "two".getBytes());
                                     }
                                     finally
                                     {
@@ -548,15 +554,15 @@ public class TestPathChildrenCache extends BaseClassForTests
                 cache.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
 
                 client.delete().forPath("/test/foo");
-                Assert.assertTrue(timing.awaitLatch(removedLatch));
+                assertTrue(timing.awaitLatch(removedLatch));
                 client.create().forPath("/test/foo", "two".getBytes());
                 postRemovedLatch.countDown();
-                Assert.assertTrue(timing.awaitLatch(dataLatch));
+                assertTrue(timing.awaitLatch(dataLatch));
 
                 Throwable t = error.get();
                 if ( t != null )
                 {
-                    Assert.fail("Assert", t);
+                    fail("Assert", t);
                 }
             }
         }
@@ -566,7 +572,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRebuildAgainstOtherProcesses() throws Exception
     {
         Timing timing = new Timing();
@@ -622,7 +628,7 @@ public class TestPathChildrenCache extends BaseClassForTests
                                 client.create().forPath("/test/test");
 
                                 List<ChildData> currentData = cache.getCurrentData();
-                                Assert.assertTrue(currentData.size() > 0);
+                                assertTrue(currentData.size() > 0);
 
                                 // simulate another process removing a node while we're rebuilding
                                 client.delete().forPath(currentData.get(0).getPath());
@@ -636,7 +642,7 @@ public class TestPathChildrenCache extends BaseClassForTests
                                     childData = cache.getCurrentData("/test/snafu");
                                     Thread.sleep(1000);
                                 }
-                                Assert.assertEquals(childData.getData(), "original".getBytes());
+                                assertArrayEquals(childData.getData(), "original".getBytes());
                                 client.setData().forPath("/test/snafu", "grilled".getBytes());
 
                                 cache.rebuildTestExchanger.exchange(new Object());
@@ -648,10 +654,10 @@ public class TestPathChildrenCache extends BaseClassForTests
                 cache.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
                 future.get();
 
-                Assert.assertTrue(timing.awaitLatch(addedLatch));
-                Assert.assertNotNull(cache.getCurrentData("/test/test"));
-                Assert.assertNull(cache.getCurrentData(deletedPath.get()));
-                Assert.assertEquals(cache.getCurrentData("/test/snafu").getData(), "grilled".getBytes());
+                assertTrue(timing.awaitLatch(addedLatch));
+                assertNotNull(cache.getCurrentData("/test/test"));
+                assertNull(cache.getCurrentData(deletedPath.get()));
+                assertArrayEquals(cache.getCurrentData("/test/snafu").getData(), "grilled".getBytes());
             }
         }
         finally
@@ -661,7 +667,7 @@ public class TestPathChildrenCache extends BaseClassForTests
     }
 
     // see https://github.com/Netflix/curator/issues/27 - was caused by not comparing old->new data
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testIssue27() throws Exception
     {
         Timing timing = new Timing();
@@ -694,13 +700,13 @@ public class TestPathChildrenCache extends BaseClassForTests
                 );
             cache.start();
 
-            Assert.assertTrue(timing.acquireSemaphore(semaphore, 3));
+            assertTrue(timing.acquireSemaphore(semaphore, 3));
 
             client.delete().forPath("/base/a");
-            Assert.assertTrue(timing.acquireSemaphore(semaphore, 1));
+            assertTrue(timing.acquireSemaphore(semaphore, 1));
 
             client.create().forPath("/base/a");
-            Assert.assertTrue(timing.acquireSemaphore(semaphore, 1));
+            assertTrue(timing.acquireSemaphore(semaphore, 1));
 
             List<PathChildrenCacheEvent.Type> expected = Lists.newArrayList
                 (
@@ -710,7 +716,7 @@ public class TestPathChildrenCache extends BaseClassForTests
                     PathChildrenCacheEvent.Type.CHILD_REMOVED,
                     PathChildrenCacheEvent.Type.CHILD_ADDED
                 );
-            Assert.assertEquals(expected, events);
+            assertEquals(expected, events);
         }
         finally
         {
@@ -720,7 +726,7 @@ public class TestPathChildrenCache extends BaseClassForTests
     }
 
     // test Issue 27 using new rebuild() method
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testIssue27Alt() throws Exception
     {
         Timing timing = new Timing();
@@ -754,17 +760,17 @@ public class TestPathChildrenCache extends BaseClassForTests
             cache.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
 
             client.delete().forPath("/base/a");
-            Assert.assertTrue(timing.acquireSemaphore(semaphore, 1));
+            assertTrue(timing.acquireSemaphore(semaphore, 1));
 
             client.create().forPath("/base/a");
-            Assert.assertTrue(timing.acquireSemaphore(semaphore, 1));
+            assertTrue(timing.acquireSemaphore(semaphore, 1));
 
             List<PathChildrenCacheEvent.Type> expected = Lists.newArrayList
                 (
                     PathChildrenCacheEvent.Type.CHILD_REMOVED,
                     PathChildrenCacheEvent.Type.CHILD_ADDED
                 );
-            Assert.assertEquals(expected, events);
+            assertEquals(expected, events);
         }
         finally
         {
@@ -773,7 +779,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testKilledSession() throws Exception
     {
         Timing timing = new Timing();
@@ -820,12 +826,12 @@ public class TestPathChildrenCache extends BaseClassForTests
                 );
 
             client.create().withMode(CreateMode.EPHEMERAL).forPath("/test/me", "data".getBytes());
-            Assert.assertTrue(timing.awaitLatch(childAddedLatch));
+            assertTrue(timing.awaitLatch(childAddedLatch));
 
             client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
-            Assert.assertTrue(timing.awaitLatch(lostLatch));
-            Assert.assertTrue(timing.awaitLatch(reconnectedLatch));
-            Assert.assertTrue(timing.awaitLatch(removedLatch));
+            assertTrue(timing.awaitLatch(lostLatch));
+            assertTrue(timing.awaitLatch(reconnectedLatch));
+            assertTrue(timing.awaitLatch(removedLatch));
         }
         finally
         {
@@ -834,7 +840,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testModes() throws Exception
     {
         Timing timing = new Timing();
@@ -858,7 +864,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRebuildNode() throws Exception
     {
         Timing timing = new Timing();
@@ -885,13 +891,13 @@ public class TestPathChildrenCache extends BaseClassForTests
             };
             cache.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
 
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
 
             int saveCounter = counter.get();
             client.setData().forPath("/test/one", "alt".getBytes());
             cache.rebuildNode("/test/one");
-            Assert.assertEquals(cache.getCurrentData("/test/one").getData(), "alt".getBytes());
-            Assert.assertEquals(saveCounter, counter.get());
+            assertArrayEquals(cache.getCurrentData("/test/one").getData(), "alt".getBytes());
+            assertEquals(saveCounter, counter.get());
 
             semaphore.release(1000);
             timing.sleepABit();
@@ -926,25 +932,25 @@ public class TestPathChildrenCache extends BaseClassForTests
 
             client.create().forPath("/test/one", "one".getBytes());
             client.create().forPath("/test/two", "two".getBytes());
-            Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
 
             for ( ChildData data : cache.getCurrentData() )
             {
                 if ( cacheData )
                 {
-                    Assert.assertNotNull(data.getData());
-                    Assert.assertNotNull(data.getStat());
+                    assertNotNull(data.getData());
+                    assertNotNull(data.getStat());
                 }
                 else
                 {
-                    Assert.assertNull(data.getData());
-                    Assert.assertNotNull(data.getStat());
+                    assertNull(data.getData());
+                    assertNotNull(data.getStat());
                 }
             }
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasics() throws Exception
     {
         Timing timing = new Timing();
@@ -974,14 +980,14 @@ public class TestPathChildrenCache extends BaseClassForTests
                 cache.start();
 
                 client.create().forPath("/test/one", "hey there".getBytes());
-                Assert.assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
+                assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
 
                 client.setData().forPath("/test/one", "sup!".getBytes());
-                Assert.assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_UPDATED);
-                Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "sup!");
+                assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_UPDATED);
+                assertEquals(new String(cache.getCurrentData("/test/one").getData()), "sup!");
 
                 client.delete().forPath("/test/one");
-                Assert.assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_REMOVED);
+                assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_REMOVED);
             }
         }
         finally
@@ -990,7 +996,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasicsOnTwoCachesWithSameExecutor() throws Exception
     {
         Timing timing = new Timing();
@@ -1040,18 +1046,18 @@ public class TestPathChildrenCache extends BaseClassForTests
                     cache2.start();
 
                     client.create().forPath("/test/one", "hey there".getBytes());
-                    Assert.assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
-                    Assert.assertEquals(events2.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
+                    assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
+                    assertEquals(events2.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_ADDED);
 
                     client.setData().forPath("/test/one", "sup!".getBytes());
-                    Assert.assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_UPDATED);
-                    Assert.assertEquals(events2.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_UPDATED);
-                    Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "sup!");
-                    Assert.assertEquals(new String(cache2.getCurrentData("/test/one").getData()), "sup!");
+                    assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_UPDATED);
+                    assertEquals(events2.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_UPDATED);
+                    assertEquals(new String(cache.getCurrentData("/test/one").getData()), "sup!");
+                    assertEquals(new String(cache2.getCurrentData("/test/one").getData()), "sup!");
 
                     client.delete().forPath("/test/one");
-                    Assert.assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_REMOVED);
-                    Assert.assertEquals(events2.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_REMOVED);
+                    assertEquals(events.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_REMOVED);
+                    assertEquals(events2.poll(timing.forWaiting().seconds(), TimeUnit.SECONDS), PathChildrenCacheEvent.Type.CHILD_REMOVED);
                 }
             }
         }
@@ -1061,7 +1067,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDeleteNodeAfterCloseDoesntCallExecutor()
         throws Exception
     {
@@ -1079,16 +1085,16 @@ public class TestPathChildrenCache extends BaseClassForTests
                 client.create().forPath("/test/one", "hey there".getBytes());
 
                 cache.rebuild();
-                Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
-                Assert.assertTrue(exec.isExecuteCalled());
+                assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
+                assertTrue(exec.isExecuteCalled());
 
                 exec.setExecuteCalled(false);
             }
-            Assert.assertFalse(exec.isExecuteCalled());
+            assertFalse(exec.isExecuteCalled());
 
             client.delete().forPath("/test/one");
             timing.sleepABit();
-            Assert.assertFalse(exec.isExecuteCalled());
+            assertFalse(exec.isExecuteCalled());
         }
         finally
         {
@@ -1102,7 +1108,7 @@ public class TestPathChildrenCache extends BaseClassForTests
      * shut down. See CURATOR-121, this was causing misleading warning messages to be logged.
      * @throws Exception
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testInterruptedOperationOnShutdown() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), 30000, 30000, new RetryOneTime(1));
@@ -1137,7 +1143,7 @@ public class TestPathChildrenCache extends BaseClassForTests
 
             latch.await(5, TimeUnit.SECONDS);
 
-            Assert.assertTrue(latch.getCount() == 1, "Unexpected exception occurred");
+            assertTrue(latch.getCount() == 1, "Unexpected exception occurred");
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestPathChildrenCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestPathChildrenCache.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.UnhandledErrorListener;
@@ -46,6 +45,8 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -54,7 +55,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestPathChildrenCache extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testParentContainerMissing() throws Exception
     {
         Timing timing = new Timing();
@@ -108,7 +109,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInitializedEvenIfChildDeleted() throws Exception
     {
         final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -159,7 +160,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWithBadConnect() throws Exception
     {
         final int serverPort = server.getPort();
@@ -237,7 +238,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPostInitializedForEmpty() throws Exception
     {
         Timing timing = new Timing();
@@ -273,7 +274,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAsyncInitialPopulation() throws Exception
     {
         Timing timing = new Timing();
@@ -315,7 +316,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testChildrenInitialized() throws Exception
     {
         Timing timing = new Timing();
@@ -369,7 +370,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testChildrenInitializedNormal() throws Exception
     {
         Timing timing = new Timing();
@@ -418,7 +419,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testUpdateWhenNotCachingData() throws Exception
     {
         Timing timing = new Timing();
@@ -465,7 +466,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testEnsurePath() throws Exception
     {
         Timing timing = new Timing();
@@ -496,7 +497,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeleteThenCreate() throws Exception
     {
         Timing timing = new Timing();
@@ -572,7 +573,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRebuildAgainstOtherProcesses() throws Exception
     {
         Timing timing = new Timing();
@@ -667,7 +668,7 @@ public class TestPathChildrenCache extends BaseClassForTests
     }
 
     // see https://github.com/Netflix/curator/issues/27 - was caused by not comparing old->new data
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testIssue27() throws Exception
     {
         Timing timing = new Timing();
@@ -726,7 +727,7 @@ public class TestPathChildrenCache extends BaseClassForTests
     }
 
     // test Issue 27 using new rebuild() method
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testIssue27Alt() throws Exception
     {
         Timing timing = new Timing();
@@ -779,7 +780,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testKilledSession() throws Exception
     {
         Timing timing = new Timing();
@@ -840,7 +841,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testModes() throws Exception
     {
         Timing timing = new Timing();
@@ -864,7 +865,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRebuildNode() throws Exception
     {
         Timing timing = new Timing();
@@ -950,7 +951,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasics() throws Exception
     {
         Timing timing = new Timing();
@@ -996,7 +997,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasicsOnTwoCachesWithSameExecutor() throws Exception
     {
         Timing timing = new Timing();
@@ -1067,7 +1068,7 @@ public class TestPathChildrenCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeleteNodeAfterCloseDoesntCallExecutor()
         throws Exception
     {
@@ -1108,7 +1109,7 @@ public class TestPathChildrenCache extends BaseClassForTests
      * shut down. See CURATOR-121, this was causing misleading warning messages to be logged.
      * @throws Exception
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInterruptedOperationOnShutdown() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), 30000, 30000, new RetryOneTime(1));

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestPathChildrenCacheInCluster.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestPathChildrenCacheInCluster.java
@@ -21,7 +21,6 @@ package org.apache.curator.framework.recipes.cache;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
@@ -33,6 +32,8 @@ import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.Timing;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +42,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestPathChildrenCacheInCluster extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Disabled  // this test is very flakey - it needs to be re-written at some point
     public void testMissedDelete() throws Exception
     {
@@ -98,7 +99,7 @@ public class TestPathChildrenCacheInCluster extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testServerLoss() throws Exception
     {
         Timing                  timing = new Timing();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCache.java
@@ -25,22 +25,22 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.ImmutableSet;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.curator.framework.recipes.cache.TreeCacheEvent.Type;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestTreeCache extends BaseTestTreeCache
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSelector() throws Exception
     {
         client.create().forPath("/root");
@@ -79,7 +79,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testStartup() throws Exception
     {
         client.create().forPath("/test");
@@ -104,7 +104,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNull(cache.getCurrentChildren("/test/non_exist"));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateParents() throws Exception
     {
         cache = newTreeCacheWithListeners(client, "/one/two/three");
@@ -122,7 +122,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNotNull(client.checkExists().forPath("/one/two/three"));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testStartEmpty() throws Exception
     {
         cache = newTreeCacheWithListeners(client, "/test");
@@ -134,7 +134,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testStartEmptyDeeper() throws Exception
     {
         cache = newTreeCacheWithListeners(client, "/test/foo/bar");
@@ -148,7 +148,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDepth0() throws Exception
     {
         client.create().forPath("/test");
@@ -169,7 +169,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNull(cache.getCurrentData("/test/non_exist"));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDepth1() throws Exception
     {
         client.create().forPath("/test");
@@ -195,7 +195,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNull(cache.getCurrentChildren("/test/non_exist"));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDepth1Deeper() throws Exception
     {
         client.create().forPath("/test");
@@ -216,7 +216,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAsyncInitialPopulation() throws Exception
     {
         client.create().forPath("/test");
@@ -230,7 +230,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testFromRoot() throws Exception
     {
         client.create().forPath("/test");
@@ -250,7 +250,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testFromRootWithDepth() throws Exception
     {
         client.create().forPath("/test");
@@ -269,7 +269,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNull(cache.getCurrentChildren("/test/one"));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWithNamespace() throws Exception
     {
         client.create().forPath("/outer");
@@ -289,7 +289,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWithNamespaceAtRoot() throws Exception
     {
         client.create().forPath("/outer");
@@ -312,7 +312,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSyncInitialPopulation() throws Exception
     {
         cache = newTreeCacheWithListeners(client, "/test");
@@ -326,7 +326,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testChildrenInitialized() throws Exception
     {
         client.create().forPath("/test", "".getBytes());
@@ -344,7 +344,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testUpdateWhenNotCachingData() throws Exception
     {
         client.create().forPath("/test");
@@ -366,7 +366,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNull(cache.getCurrentData("/test/foo").getData());
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeleteThenCreate() throws Exception
     {
         client.create().forPath("/test");
@@ -391,7 +391,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeleteThenCreateRoot() throws Exception
     {
         client.create().forPath("/test");
@@ -415,7 +415,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testKilledSession() throws Exception
     {
         client.create().forPath("/test");
@@ -437,7 +437,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasics() throws Exception
     {
         client.create().forPath("/test");
@@ -470,7 +470,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasicsWithNoZkWatches() throws Exception
     {
         client.create().forPath("/test");
@@ -494,7 +494,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasicsOnTwoCaches() throws Exception
     {
         TreeCache cache2 = newTreeCacheWithListeners(client, "/test");
@@ -550,7 +550,7 @@ public class TestTreeCache extends BaseTestTreeCache
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeleteNodeAfterCloseDoesntCallExecutor() throws Exception
     {
         client.create().forPath("/test");
@@ -574,7 +574,7 @@ public class TestTreeCache extends BaseTestTreeCache
     /**
      * Make sure TreeCache gets to a sane state when we can't initially connect to server.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testServerNotStartedYet() throws Exception
     {
         // Stop the existing server.
@@ -599,7 +599,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testErrorListener() throws Exception
     {
         client.create().forPath("/test");

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCache.java
@@ -19,22 +19,28 @@
 
 package org.apache.curator.framework.recipes.cache;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.ImmutableSet;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.curator.framework.recipes.cache.TreeCacheEvent.Type;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestTreeCache extends BaseTestTreeCache
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSelector() throws Exception
     {
         client.create().forPath("/root");
@@ -73,7 +79,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testStartup() throws Exception
     {
         client.create().forPath("/test");
@@ -92,20 +98,20 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
         assertNoMoreEvents();
 
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("1", "2", "3"));
-        Assert.assertEquals(cache.getCurrentChildren("/test/1").keySet(), ImmutableSet.of());
-        Assert.assertEquals(cache.getCurrentChildren("/test/2").keySet(), ImmutableSet.of("sub"));
-        Assert.assertNull(cache.getCurrentChildren("/test/non_exist"));
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("1", "2", "3"));
+        assertEquals(cache.getCurrentChildren("/test/1").keySet(), ImmutableSet.of());
+        assertEquals(cache.getCurrentChildren("/test/2").keySet(), ImmutableSet.of("sub"));
+        assertNull(cache.getCurrentChildren("/test/non_exist"));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateParents() throws Exception
     {
         cache = newTreeCacheWithListeners(client, "/one/two/three");
         cache.start();
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
         assertNoMoreEvents();
-        Assert.assertNull(client.checkExists().forPath("/one/two/three"));
+        assertNull(client.checkExists().forPath("/one/two/three"));
         cache.close();
 
         cache = buildWithListeners(TreeCache.newBuilder(client, "/one/two/three").setCreateParentNodes(true));
@@ -113,10 +119,10 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEvent(TreeCacheEvent.Type.NODE_ADDED, "/one/two/three");
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
         assertNoMoreEvents();
-        Assert.assertNotNull(client.checkExists().forPath("/one/two/three"));
+        assertNotNull(client.checkExists().forPath("/one/two/three"));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testStartEmpty() throws Exception
     {
         cache = newTreeCacheWithListeners(client, "/test");
@@ -128,7 +134,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testStartEmptyDeeper() throws Exception
     {
         cache = newTreeCacheWithListeners(client, "/test/foo/bar");
@@ -142,7 +148,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDepth0() throws Exception
     {
         client.create().forPath("/test");
@@ -157,13 +163,13 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
         assertNoMoreEvents();
 
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of());
-        Assert.assertNull(cache.getCurrentData("/test/1"));
-        Assert.assertNull(cache.getCurrentChildren("/test/1"));
-        Assert.assertNull(cache.getCurrentData("/test/non_exist"));
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of());
+        assertNull(cache.getCurrentData("/test/1"));
+        assertNull(cache.getCurrentChildren("/test/1"));
+        assertNull(cache.getCurrentData("/test/non_exist"));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDepth1() throws Exception
     {
         client.create().forPath("/test");
@@ -181,15 +187,15 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
         assertNoMoreEvents();
 
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("1", "2", "3"));
-        Assert.assertEquals(cache.getCurrentChildren("/test/1").keySet(), ImmutableSet.of());
-        Assert.assertEquals(cache.getCurrentChildren("/test/2").keySet(), ImmutableSet.of());
-        Assert.assertNull(cache.getCurrentData("/test/2/sub"));
-        Assert.assertNull(cache.getCurrentChildren("/test/2/sub"));
-        Assert.assertNull(cache.getCurrentChildren("/test/non_exist"));
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("1", "2", "3"));
+        assertEquals(cache.getCurrentChildren("/test/1").keySet(), ImmutableSet.of());
+        assertEquals(cache.getCurrentChildren("/test/2").keySet(), ImmutableSet.of());
+        assertNull(cache.getCurrentData("/test/2/sub"));
+        assertNull(cache.getCurrentChildren("/test/2/sub"));
+        assertNull(cache.getCurrentChildren("/test/non_exist"));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDepth1Deeper() throws Exception
     {
         client.create().forPath("/test");
@@ -210,7 +216,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testAsyncInitialPopulation() throws Exception
     {
         client.create().forPath("/test");
@@ -224,7 +230,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testFromRoot() throws Exception
     {
         client.create().forPath("/test");
@@ -238,13 +244,13 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
         assertNoMoreEvents();
 
-        Assert.assertTrue(cache.getCurrentChildren("/").keySet().contains("test"));
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
-        Assert.assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
-        Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
+        assertTrue(cache.getCurrentChildren("/").keySet().contains("test"));
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
+        assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
+        assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testFromRootWithDepth() throws Exception
     {
         client.create().forPath("/test");
@@ -257,13 +263,13 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
         assertNoMoreEvents();
 
-        Assert.assertTrue(cache.getCurrentChildren("/").keySet().contains("test"));
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of());
-        Assert.assertNull(cache.getCurrentData("/test/one"));
-        Assert.assertNull(cache.getCurrentChildren("/test/one"));
+        assertTrue(cache.getCurrentChildren("/").keySet().contains("test"));
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of());
+        assertNull(cache.getCurrentData("/test/one"));
+        assertNull(cache.getCurrentChildren("/test/one"));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWithNamespace() throws Exception
     {
         client.create().forPath("/outer");
@@ -278,12 +284,12 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
         assertNoMoreEvents();
 
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
-        Assert.assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
-        Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
+        assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
+        assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWithNamespaceAtRoot() throws Exception
     {
         client.create().forPath("/outer");
@@ -299,14 +305,14 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEvent(TreeCacheEvent.Type.NODE_ADDED, "/test/one");
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
         assertNoMoreEvents();
-        Assert.assertEquals(cache.getCurrentChildren("/").keySet(), ImmutableSet.of("foo", "test"));
-        Assert.assertEquals(cache.getCurrentChildren("/foo").keySet(), ImmutableSet.of());
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
-        Assert.assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
-        Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
+        assertEquals(cache.getCurrentChildren("/").keySet(), ImmutableSet.of("foo", "test"));
+        assertEquals(cache.getCurrentChildren("/foo").keySet(), ImmutableSet.of());
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
+        assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
+        assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSyncInitialPopulation() throws Exception
     {
         cache = newTreeCacheWithListeners(client, "/test");
@@ -320,7 +326,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testChildrenInitialized() throws Exception
     {
         client.create().forPath("/test", "".getBytes());
@@ -338,7 +344,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testUpdateWhenNotCachingData() throws Exception
     {
         client.create().forPath("/test");
@@ -355,12 +361,12 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEvent(TreeCacheEvent.Type.NODE_UPDATED, "/test/foo");
         assertNoMoreEvents();
 
-        Assert.assertNotNull(cache.getCurrentData("/test/foo"));
+        assertNotNull(cache.getCurrentData("/test/foo"));
         // No byte data querying the tree because we're not caching data.
-        Assert.assertNull(cache.getCurrentData("/test/foo").getData());
+        assertNull(cache.getCurrentData("/test/foo").getData());
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDeleteThenCreate() throws Exception
     {
         client.create().forPath("/test");
@@ -385,7 +391,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDeleteThenCreateRoot() throws Exception
     {
         client.create().forPath("/test");
@@ -409,7 +415,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testKilledSession() throws Exception
     {
         client.create().forPath("/test");
@@ -431,7 +437,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasics() throws Exception
     {
         client.create().forPath("/test");
@@ -440,31 +446,31 @@ public class TestTreeCache extends BaseTestTreeCache
         cache.start();
         assertEvent(TreeCacheEvent.Type.NODE_ADDED, "/test");
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of());
-        Assert.assertNull(cache.getCurrentChildren("/t"));
-        Assert.assertNull(cache.getCurrentChildren("/testing"));
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of());
+        assertNull(cache.getCurrentChildren("/t"));
+        assertNull(cache.getCurrentChildren("/testing"));
 
         client.create().forPath("/test/one", "hey there".getBytes());
         assertEvent(TreeCacheEvent.Type.NODE_ADDED, "/test/one");
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
-        Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
-        Assert.assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
-        Assert.assertNull(cache.getCurrentChildren("/test/o"));
-        Assert.assertNull(cache.getCurrentChildren("/test/onely"));
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
+        assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
+        assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
+        assertNull(cache.getCurrentChildren("/test/o"));
+        assertNull(cache.getCurrentChildren("/test/onely"));
 
         client.setData().forPath("/test/one", "sup!".getBytes());
         assertEvent(TreeCacheEvent.Type.NODE_UPDATED, "/test/one");
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
-        Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "sup!");
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
+        assertEquals(new String(cache.getCurrentData("/test/one").getData()), "sup!");
 
         client.delete().forPath("/test/one");
         assertEvent(TreeCacheEvent.Type.NODE_REMOVED, "/test/one", "sup!".getBytes());
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of());
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of());
 
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasicsWithNoZkWatches() throws Exception
     {
         client.create().forPath("/test");
@@ -477,18 +483,18 @@ public class TestTreeCache extends BaseTestTreeCache
         assertEvent(TreeCacheEvent.Type.NODE_ADDED, "/test/one");
 
         assertEvent(TreeCacheEvent.Type.INITIALIZED);
-        Assert.assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
-        Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
-        Assert.assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
-        Assert.assertNull(cache.getCurrentChildren("/test/o"));
-        Assert.assertNull(cache.getCurrentChildren("/test/onely"));
-        Assert.assertNull(cache.getCurrentChildren("/t"));
-        Assert.assertNull(cache.getCurrentChildren("/testing"));
+        assertEquals(cache.getCurrentChildren("/test").keySet(), ImmutableSet.of("one"));
+        assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
+        assertEquals(cache.getCurrentChildren("/test/one").keySet(), ImmutableSet.of());
+        assertNull(cache.getCurrentChildren("/test/o"));
+        assertNull(cache.getCurrentChildren("/test/onely"));
+        assertNull(cache.getCurrentChildren("/t"));
+        assertNull(cache.getCurrentChildren("/testing"));
 
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasicsOnTwoCaches() throws Exception
     {
         TreeCache cache2 = newTreeCacheWithListeners(client, "/test");
@@ -519,24 +525,24 @@ public class TestTreeCache extends BaseTestTreeCache
 
             client.create().forPath("/test/one", "hey there".getBytes());
             assertEvent(TreeCacheEvent.Type.NODE_ADDED, "/test/one");
-            Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
+            assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
             semaphore.acquire();
-            Assert.assertEquals(new String(cache2.getCurrentData("/test/one").getData()), "hey there");
+            assertEquals(new String(cache2.getCurrentData("/test/one").getData()), "hey there");
 
             client.setData().forPath("/test/one", "sup!".getBytes());
             assertEvent(TreeCacheEvent.Type.NODE_UPDATED, "/test/one");
-            Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "sup!");
+            assertEquals(new String(cache.getCurrentData("/test/one").getData()), "sup!");
             semaphore.acquire();
-            Assert.assertEquals(new String(cache2.getCurrentData("/test/one").getData()), "sup!");
+            assertEquals(new String(cache2.getCurrentData("/test/one").getData()), "sup!");
 
             client.delete().forPath("/test/one");
             assertEvent(TreeCacheEvent.Type.NODE_REMOVED, "/test/one", "sup!".getBytes());
-            Assert.assertNull(cache.getCurrentData("/test/one"));
+            assertNull(cache.getCurrentData("/test/one"));
             semaphore.acquire();
-            Assert.assertNull(cache2.getCurrentData("/test/one"));
+            assertNull(cache2.getCurrentData("/test/one"));
 
             assertNoMoreEvents();
-            Assert.assertEquals(semaphore.availablePermits(), 0);
+            assertEquals(semaphore.availablePermits(), 0);
         }
         finally
         {
@@ -544,7 +550,7 @@ public class TestTreeCache extends BaseTestTreeCache
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDeleteNodeAfterCloseDoesntCallExecutor() throws Exception
     {
         client.create().forPath("/test");
@@ -556,7 +562,7 @@ public class TestTreeCache extends BaseTestTreeCache
 
         client.create().forPath("/test/one", "hey there".getBytes());
         assertEvent(TreeCacheEvent.Type.NODE_ADDED, "/test/one");
-        Assert.assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
+        assertEquals(new String(cache.getCurrentData("/test/one").getData()), "hey there");
 
         cache.close();
         assertNoMoreEvents();
@@ -568,7 +574,7 @@ public class TestTreeCache extends BaseTestTreeCache
     /**
      * Make sure TreeCache gets to a sane state when we can't initially connect to server.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testServerNotStartedYet() throws Exception
     {
         // Stop the existing server.
@@ -593,7 +599,7 @@ public class TestTreeCache extends BaseTestTreeCache
         assertNoMoreEvents();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testErrorListener() throws Exception
     {
         client.create().forPath("/test");
@@ -620,7 +626,7 @@ public class TestTreeCache extends BaseTestTreeCache
             @Override
             public void unhandledError(String message, Throwable e)
             {
-                Assert.assertFalse(isProcessed.compareAndSet(false, true));
+                assertFalse(isProcessed.compareAndSet(false, true));
             }
         });
 

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCacheIteratorAndSize.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCacheIteratorAndSize.java
@@ -18,13 +18,17 @@
  */
 package org.apache.curator.framework.recipes.cache;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Sets;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -34,7 +38,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class TestTreeCacheIteratorAndSize extends CuratorTestBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         final String[] nodes = {
@@ -79,18 +83,18 @@ public class TestTreeCacheIteratorAndSize extends CuratorTestBase
                     iteratorValues.put(next.getPath(), next.getData());
                 }
 
-                Assert.assertEquals(iteratorValues.size(), nodes.length);
+                assertEquals(iteratorValues.size(), nodes.length);
                 for ( String node : nodes )
                 {
-                    Assert.assertEquals(iteratorValues.get(node), node.getBytes());
+                    assertArrayEquals(iteratorValues.get(node), node.getBytes());
                 }
 
-                Assert.assertEquals(treeCache.size(), nodes.length);
+                assertEquals(treeCache.size(), nodes.length);
             }
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testIteratorWithRandomGraph() throws Exception
     {
         Map<String, String> pathAndData = new HashMap<>();
@@ -125,24 +129,24 @@ public class TestTreeCacheIteratorAndSize extends CuratorTestBase
 
                 timing.sleepABit(); // let the cache settle
 
-                Assert.assertEquals(treeCache.size(), pathAndData.size());
+                assertEquals(treeCache.size(), pathAndData.size());
 
                 // at this point we have a cached graph of random nodes with random values
                 Iterator<ChildData> iterator = treeCache.iterator();
                 while ( iterator.hasNext() )
                 {
                     ChildData next = iterator.next();
-                    Assert.assertTrue(pathAndData.containsKey(next.getPath()));
-                    Assert.assertEquals(pathAndData.get(next.getPath()).getBytes(), next.getData());
+                    assertTrue(pathAndData.containsKey(next.getPath()));
+                    assertArrayEquals(pathAndData.get(next.getPath()).getBytes(), next.getData());
                     pathAndData.remove(next.getPath());
                 }
 
-                Assert.assertEquals(pathAndData.size(), 0); // above loop should have removed all nodes
+                assertEquals(pathAndData.size(), 0); // above loop should have removed all nodes
             }
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testEmptyTree() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -154,13 +158,13 @@ public class TestTreeCacheIteratorAndSize extends CuratorTestBase
                 treeCache.start();
 
                 Iterator<ChildData> iterator = treeCache.iterator();
-                Assert.assertFalse(iterator.hasNext());
-                Assert.assertEquals(treeCache.size(), 0);
+                assertFalse(iterator.hasNext());
+                assertEquals(treeCache.size(), 0);
             }
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWithDeletedNodes() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -193,8 +197,8 @@ public class TestTreeCacheIteratorAndSize extends CuratorTestBase
                     paths.add(next.getPath());
                 }
 
-                Assert.assertEquals(paths, Sets.newHashSet("/foo", "/foo/a1", "/foo/a2", "/foo/a2/a2.1", "/foo/a3", "/foo/a3/a3.2"));
-                Assert.assertEquals(treeCache.size(), 6);
+                assertEquals(paths, Sets.newHashSet("/foo", "/foo/a1", "/foo/a2", "/foo/a2/a2.1", "/foo/a3", "/foo/a3/a3.2"));
+                assertEquals(treeCache.size(), 6);
             }
         }
     }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCacheIteratorAndSize.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCacheIteratorAndSize.java
@@ -23,12 +23,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Sets;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
+import org.junit.jupiter.api.Test;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -38,7 +38,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class TestTreeCacheIteratorAndSize extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         final String[] nodes = {
@@ -94,7 +94,7 @@ public class TestTreeCacheIteratorAndSize extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testIteratorWithRandomGraph() throws Exception
     {
         Map<String, String> pathAndData = new HashMap<>();
@@ -146,7 +146,7 @@ public class TestTreeCacheIteratorAndSize extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testEmptyTree() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -164,7 +164,7 @@ public class TestTreeCacheIteratorAndSize extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWithDeletedNodes() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCacheRandomTree.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCacheRandomTree.java
@@ -24,10 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import com.google.common.collect.Iterables;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.ZKPaths;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -59,12 +59,12 @@ public class TestTreeCacheRandomTree extends BaseTestTreeCache
     private final Random random = new Random();
     private boolean withDepth = false;
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGiantRandomDeepTree() throws Exception {
         doTestGiantRandomDeepTree();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGiantRandomDeepTreeWithDepth() throws Exception {
         withDepth = true;
         doTestGiantRandomDeepTree();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCacheRandomTree.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestTreeCacheRandomTree.java
@@ -19,17 +19,19 @@
 
 package org.apache.curator.framework.recipes.cache;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import com.google.common.collect.Iterables;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.ZKPaths;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-
-import static org.testng.Assert.assertNotNull;
 
 public class TestTreeCacheRandomTree extends BaseTestTreeCache
 {
@@ -57,12 +59,12 @@ public class TestTreeCacheRandomTree extends BaseTestTreeCache
     private final Random random = new Random();
     private boolean withDepth = false;
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testGiantRandomDeepTree() throws Exception {
         doTestGiantRandomDeepTree();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testGiantRandomDeepTreeWithDepth() throws Exception {
         withDepth = true;
         doTestGiantRandomDeepTree();
@@ -119,7 +121,7 @@ public class TestTreeCacheRandomTree extends BaseTestTreeCache
                 {
                     // Delete myself from parent.
                     TestNode removed = last.children.remove(ZKPaths.getNodeFromPath(node.fullPath));
-                    Assert.assertSame(node, removed);
+                    assertSame(node, removed);
 
                     // Delete from ZK
                     cl.delete().forPath(node.fullPath);
@@ -217,7 +219,7 @@ public class TestTreeCacheRandomTree extends BaseTestTreeCache
             return;
         }
 
-        Assert.assertEquals(cacheChildren.keySet(), expectedNode.children.keySet(), path);
+        assertEquals(cacheChildren.keySet(), expectedNode.children.keySet(), path);
 
         for ( Map.Entry<String, TestNode> entry : expectedNode.children.entrySet() )
         {
@@ -236,6 +238,6 @@ public class TestTreeCacheRandomTree extends BaseTestTreeCache
     {
         String path = expectedNode.fullPath;
         assertNotNull(actualChild, path);
-        Assert.assertEquals(actualChild.getData(), expectedNode.data, path);
+        assertArrayEquals(actualChild.getData(), expectedNode.data, path);
     }
 }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestWrappedNodeCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestWrappedNodeCache.java
@@ -23,16 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
@@ -43,7 +43,7 @@ import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.bu
 @Tag(CuratorTestBase.zk36Group)
 public class TestWrappedNodeCache extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeleteThenCreate() throws Exception
     {
         CuratorCache cache = null;
@@ -81,7 +81,7 @@ public class TestWrappedNodeCache extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testKilledSession() throws Exception
     {
         CuratorCache cache = null;
@@ -130,7 +130,7 @@ public class TestWrappedNodeCache extends CuratorTestBase
     }
 
     @SuppressWarnings("ConstantConditions")
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasics() throws Exception
     {
         CuratorCache cache = null;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderAcls.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderAcls.java
@@ -21,7 +21,6 @@ package org.apache.curator.framework.recipes.leader;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -37,6 +36,8 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.auth.DigestAuthenticationProvider;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +48,7 @@ public class TestLeaderAcls extends BaseClassForTests
 {
     private final Timing timing = new Timing();
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @DisplayName("Validation test for CURATOR-365")
     public void testAclErrorWithLeader() throws Exception
     {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderAcls.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderAcls.java
@@ -19,6 +19,9 @@
 
 package org.apache.curator.framework.recipes.leader;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -33,8 +36,7 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.server.auth.DigestAuthenticationProvider;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.DisplayName;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +47,8 @@ public class TestLeaderAcls extends BaseClassForTests
 {
     private final Timing timing = new Timing();
 
-    @Test(description = "Validation test for CURATOR-365")
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @DisplayName("Validation test for CURATOR-365")
     public void testAclErrorWithLeader() throws Exception
     {
         ACLProvider provider = new ACLProvider()
@@ -90,7 +93,7 @@ public class TestLeaderAcls extends BaseClassForTests
 
             latch = new LeaderLatch(client, "/base");
             latch.start();
-            Assert.assertTrue(latch.await(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+            assertTrue(latch.await(timing.forWaiting().seconds(), TimeUnit.SECONDS));
             latch.close();
             latch = null;
 
@@ -117,7 +120,7 @@ public class TestLeaderAcls extends BaseClassForTests
                 // but also making sure that the code goes through the backgroundCreateParentsThenNode() codepath
                 latch = new LeaderLatch(noAuthClient, "/base/second");
                 latch.start();
-                Assert.assertTrue(timing.awaitLatch(noAuthLatch));
+                assertTrue(timing.awaitLatch(noAuthLatch));
             }
             finally
             {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatch.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatch.java
@@ -29,7 +29,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.TestCleanState;
@@ -48,6 +47,8 @@ import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -80,7 +81,7 @@ public class TestLeaderLatch extends BaseClassForTests
         volatile LeaderLatch latch;
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWithCircuitBreaker() throws Exception
     {
         final int threadQty = 5;
@@ -170,7 +171,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testUncreatedPathGetLeader() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -181,7 +182,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWatchedNodeDeletedOnReconnect() throws Exception
     {
         final String latchPath = "/foo/bar";
@@ -217,7 +218,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSessionErrorPolicy() throws Exception
     {
         Timing timing = new Timing();
@@ -293,7 +294,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testErrorPolicies() throws Exception
     {
         Timing2 timing = new Timing2();
@@ -378,7 +379,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testProperCloseWithoutConnectionEstablished() throws Exception
     {
         server.stop();
@@ -427,7 +428,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testResetRace() throws Exception
     {
         Timing timing = new Timing();
@@ -457,7 +458,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateDeleteRace() throws Exception
     {
         Timing timing = new Timing();
@@ -489,7 +490,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testLostConnection() throws Exception
     {
         final int PARTICIPANT_QTY = 10;
@@ -544,7 +545,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCorrectWatching() throws Exception
     {
         final int PARTICIPANT_QTY = 10;
@@ -586,7 +587,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWaiting() throws Exception
     {
         final int LOOPS = 10;
@@ -649,19 +650,19 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         basic(Mode.START_IMMEDIATELY);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasicAlt() throws Exception
     {
         basic(Mode.START_IN_THREADS);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCallbackSanity() throws Exception
     {
         final int PARTICIPANT_QTY = 10;
@@ -745,7 +746,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCallbackNotifyLeader() throws Exception
     {
         final int PARTICIPANT_QTY = 10;
@@ -833,7 +834,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCallbackDontNotify() throws Exception
     {
         final AtomicLong masterCounter = new AtomicLong(0);
@@ -912,7 +913,7 @@ public class TestLeaderLatch extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNoServerAtStart()
     {
         CloseableUtils.closeQuietly(server);
@@ -1065,7 +1066,7 @@ public class TestLeaderLatch extends BaseClassForTests
         return leaders;
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRelativePath()
     {
         assertThrows(IllegalArgumentException.class, ()->{

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatchCluster.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatchCluster.java
@@ -21,16 +21,16 @@ package org.apache.curator.framework.recipes.leader;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collection;
 import java.util.List;
 
@@ -52,7 +52,7 @@ public class TestLeaderLatchCluster extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInCluster() throws Exception
     {
         final int PARTICIPANT_QTY = 3;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatchCluster.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatchCluster.java
@@ -18,17 +18,19 @@
  */
 package org.apache.curator.framework.recipes.leader;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Collection;
 import java.util.List;
 
@@ -50,7 +52,7 @@ public class TestLeaderLatchCluster extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testInCluster() throws Exception
     {
         final int PARTICIPANT_QTY = 3;
@@ -72,16 +74,16 @@ public class TestLeaderLatchCluster extends CuratorTestBase
             }
 
             ClientAndLatch leader = waitForALeader(clients, timing);
-            Assert.assertNotNull(leader);
+            assertNotNull(leader);
 
             cluster.killServer(instances.get(leader.index));
 
             Thread.sleep(sessionLength * 2);
 
             leader = waitForALeader(clients, timing);
-            Assert.assertNotNull(leader);
+            assertNotNull(leader);
 
-            Assert.assertEquals(getLeaders(clients).size(), 1);
+            assertEquals(getLeaders(clients).size(), 1);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelector.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelector.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -41,6 +40,8 @@ import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -56,7 +57,7 @@ public class TestLeaderSelector extends BaseClassForTests
 {
     private static final String PATH_NAME = "/one/two/me";
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInterruption() throws Exception
     {
         Timing2 timing = new Timing2();
@@ -100,7 +101,7 @@ public class TestLeaderSelector extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testErrorPolicies() throws Exception
     {
         Timing2 timing = new Timing2();
@@ -191,7 +192,7 @@ public class TestLeaderSelector extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testLeaderNodeDeleteOnInterrupt() throws Exception
     {
         Timing2 timing = new Timing2();
@@ -256,7 +257,7 @@ public class TestLeaderSelector extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInterruptLeadershipWithRequeue() throws Exception
     {
         Timing timing = new Timing();
@@ -293,7 +294,7 @@ public class TestLeaderSelector extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInterruptLeadership() throws Exception
     {
         LeaderSelector selector = null;
@@ -341,7 +342,7 @@ public class TestLeaderSelector extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRaceAtStateChanged() throws Exception
     {
         LeaderSelector selector = null;
@@ -403,7 +404,7 @@ public class TestLeaderSelector extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAutoRequeue() throws Exception
     {
         Timing timing = new Timing();
@@ -441,7 +442,7 @@ public class TestLeaderSelector extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testServerDying() throws Exception
     {
         Timing timing = new Timing();
@@ -485,7 +486,7 @@ public class TestLeaderSelector extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testKillSessionThenCloseShouldElectNewLeader() throws Exception
     {
         final Timing timing = new Timing();
@@ -586,7 +587,7 @@ public class TestLeaderSelector extends BaseClassForTests
      * it restarts the TestingServer instead of killing the session
      * it uses autoRequeue instead of explicitly calling requeue
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testKillServerThenCloseShouldElectNewLeader() throws Exception
     {
         final Timing timing = new Timing();
@@ -681,7 +682,7 @@ public class TestLeaderSelector extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testClosing() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -756,7 +757,7 @@ public class TestLeaderSelector extends BaseClassForTests
     }
 
     @SuppressWarnings({"ForLoopReplaceableByForEach"})
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRotatingLeadership() throws Exception
     {
         final int LEADER_QTY = 5;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorCluster.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorCluster.java
@@ -22,8 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -34,6 +32,8 @@ import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.ZKPaths;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
 public class TestLeaderSelectorCluster extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testRestart() throws Exception
     {
         final Timing        timing = new Timing();
@@ -88,7 +88,7 @@ public class TestLeaderSelectorCluster extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testLostRestart() throws Exception
     {
         final Timing        timing = new Timing();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorEdges.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorEdges.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -36,6 +35,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.concurrent.CountDownLatch;
@@ -66,7 +66,7 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
      *
      * @throws Exception
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void flappingTest() throws Exception
     {
         final CuratorFramework client =
@@ -155,7 +155,7 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
     /**
      * Create a protected node in background with a retry policy
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void createProtectedNodeInBackgroundTest() throws Exception
     {
         final CuratorFramework client =
@@ -207,7 +207,7 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
     /**
      * Same test as above but without a retry policy
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void createProtectedNodeInBackgroundTestNoRetry() throws Exception
     {
         final CuratorFramework client =

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorEdges.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorEdges.java
@@ -19,6 +19,11 @@
 
 package org.apache.curator.framework.recipes.leader;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -26,16 +31,13 @@ import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.BaseClassForTests;
-import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -46,13 +48,13 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @BeforeClass
+    @BeforeAll
     public static void setCNXFactory()
     {
         System.setProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY, ChaosMonkeyCnxnFactory.class.getName());
     }
 
-    @AfterClass
+    @AfterAll
     public static void resetCNXFactory()
     {
         System.clearProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY);
@@ -64,7 +66,7 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
      *
      * @throws Exception
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void flappingTest() throws Exception
     {
         final CuratorFramework client =
@@ -86,20 +88,20 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
             leaderSelector1.start();
             // At this point the ChaosMonkeyZookeeperServer must close the connection
             // right after the lock znode is created.
-            Assert.assertTrue(listener.reconnected.await(10, TimeUnit.SECONDS), "Connection has not been lost");
+            assertTrue(listener.reconnected.await(10, TimeUnit.SECONDS), "Connection has not been lost");
             // Check that leader ship has failed
-            Assert.assertEquals(listener.takeLeadership.getCount(), 1);
+            assertEquals(listener.takeLeadership.getCount(), 1);
             // Wait FailedDelete
             Thread.sleep(ChaosMonkeyCnxnFactory.LOCKOUT_DURATION_MS * 2);
             // Check that there is no znode
             final int children = client.getChildren().forPath(ChaosMonkeyCnxnFactory.CHAOS_ZNODE).size();
-            Assert.assertEquals(children, 0,
+            assertEquals(children, 0,
                 "Still " + children + " znodes under " + ChaosMonkeyCnxnFactory.CHAOS_ZNODE + " lock");
             // Check that a new LeaderSelector can be started
             leaderSelector2 = new LeaderSelector(client, ChaosMonkeyCnxnFactory.CHAOS_ZNODE,
                 listener);
             leaderSelector2.start();
-            Assert.assertTrue(listener.takeLeadership.await(1, TimeUnit.SECONDS));
+            assertTrue(listener.takeLeadership.await(1, TimeUnit.SECONDS));
         }
         finally
         {
@@ -109,7 +111,7 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
             }
             catch ( IllegalStateException e )
             {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
             try
             {
@@ -120,7 +122,7 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
             }
             catch ( IllegalStateException e )
             {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
             client.close();
         }
@@ -153,7 +155,7 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
     /**
      * Create a protected node in background with a retry policy
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void createProtectedNodeInBackgroundTest() throws Exception
     {
         final CuratorFramework client =
@@ -187,12 +189,12 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
                              )
                 .forPath(ChaosMonkeyCnxnFactory.CHAOS_ZNODE_PREFIX + "foo-");
 
-            Assert.assertTrue(latch.await(30, TimeUnit.SECONDS), "Callback has not been called");
+            assertTrue(latch.await(30, TimeUnit.SECONDS), "Callback has not been called");
             // Wait for the znode to be deleted
             Thread.sleep(ChaosMonkeyCnxnFactory.LOCKOUT_DURATION_MS * 2);
             // Check that there is no znode
             final int children = client.getChildren().forPath(ChaosMonkeyCnxnFactory.CHAOS_ZNODE).size();
-            Assert.assertEquals(children, 0,
+            assertEquals(children, 0,
                 "Still " + children + " znodes under " + ChaosMonkeyCnxnFactory.CHAOS_ZNODE + " lock");
         }
         finally
@@ -205,7 +207,7 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
     /**
      * Same test as above but without a retry policy
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void createProtectedNodeInBackgroundTestNoRetry() throws Exception
     {
         final CuratorFramework client =
@@ -239,12 +241,12 @@ public class TestLeaderSelectorEdges extends BaseClassForTests
                              )
                 .forPath(ChaosMonkeyCnxnFactory.CHAOS_ZNODE_PREFIX + "foo-");
 
-            Assert.assertTrue(latch.await(30, TimeUnit.SECONDS), "Callback has not been called");
+            assertTrue(latch.await(30, TimeUnit.SECONDS), "Callback has not been called");
             // Wait for the znode to be deleted
             Thread.sleep(ChaosMonkeyCnxnFactory.LOCKOUT_DURATION_MS * 2);
             // Check that there is no znode
             final int children = client.getChildren().forPath(ChaosMonkeyCnxnFactory.CHAOS_ZNODE).size();
-            Assert.assertEquals(children, 0,
+            assertEquals(children, 0,
                 "Still " + children + " znodes under " + ChaosMonkeyCnxnFactory.CHAOS_ZNODE + " lock");
         }
         finally

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorParticipants.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorParticipants.java
@@ -23,13 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryOneTime;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -38,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestLeaderSelectorParticipants extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testId() throws Exception
     {
         LeaderSelector          selector = null;
@@ -84,7 +85,7 @@ public class TestLeaderSelectorParticipants extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasic() throws Exception
     {
         final int           SELECTOR_QTY = 10;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorParticipants.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorParticipants.java
@@ -18,16 +18,18 @@
  */
 package org.apache.curator.framework.recipes.leader;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryOneTime;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -36,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestLeaderSelectorParticipants extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testId() throws Exception
     {
         LeaderSelector          selector = null;
@@ -64,16 +66,16 @@ public class TestLeaderSelectorParticipants extends BaseClassForTests
             selector.setId("A is A");
             selector.start();
 
-            Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
 
             Participant leader = selector.getLeader();
-            Assert.assertTrue(leader.isLeader());
-            Assert.assertEquals(leader.getId(), "A is A");
+            assertTrue(leader.isLeader());
+            assertEquals(leader.getId(), "A is A");
 
             Collection<Participant>     participants = selector.getParticipants();
-            Assert.assertEquals(participants.size(), 1);
-            Assert.assertEquals(participants.iterator().next().getId(), "A is A");
-            Assert.assertEquals(participants.iterator().next().getId(), selector.getId());
+            assertEquals(participants.size(), 1);
+            assertEquals(participants.iterator().next().getId(), "A is A");
+            assertEquals(participants.iterator().next().getId(), selector.getId());
         }
         finally
         {
@@ -82,7 +84,7 @@ public class TestLeaderSelectorParticipants extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasic() throws Exception
     {
         final int           SELECTOR_QTY = 10;
@@ -130,15 +132,15 @@ public class TestLeaderSelectorParticipants extends BaseClassForTests
                 selector.start();
             }
 
-            Assert.assertTrue(leaderLatch.await(10, TimeUnit.SECONDS));
-            Assert.assertTrue(workingLatch.await(10, TimeUnit.SECONDS));
+            assertTrue(leaderLatch.await(10, TimeUnit.SECONDS));
+            assertTrue(workingLatch.await(10, TimeUnit.SECONDS));
             
             Thread.sleep(1000); // some time for locks to acquire
 
             Collection<Participant>     participants = selectors.get(0).getParticipants();
             for ( int i = 1; i < selectors.size(); ++i )
             {
-                Assert.assertEquals(participants, selectors.get(i).getParticipants());
+                assertEquals(participants, selectors.get(i).getParticipants());
             }
 
             Set<String>                 ids = Sets.newHashSet();
@@ -149,17 +151,17 @@ public class TestLeaderSelectorParticipants extends BaseClassForTests
                 {
                     ++leaderCount;
                 }
-                Assert.assertFalse(ids.contains(participant.getId()));
+                assertFalse(ids.contains(participant.getId()));
                 ids.add(participant.getId());
             }
-            Assert.assertEquals(leaderCount, 1);
+            assertEquals(leaderCount, 1);
 
             Set<String>                 expectedIds = Sets.newHashSet();
             for ( int i = 0; i < SELECTOR_QTY; ++i )
             {
                 expectedIds.add(Integer.toString(i));
             }
-            Assert.assertEquals(expectedIds, ids);
+            assertEquals(expectedIds, ids);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorWithExecutor.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorWithExecutor.java
@@ -20,7 +20,6 @@ package org.apache.curator.framework.recipes.leader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -29,6 +28,8 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.ThreadUtils;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -38,7 +39,7 @@ public class TestLeaderSelectorWithExecutor extends BaseClassForTests
 {
     private static final ThreadFactory threadFactory = ThreadUtils.newThreadFactory("FeedGenerator");
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void test() throws Exception
     {
         Timing timing = new Timing();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorWithExecutor.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorWithExecutor.java
@@ -18,6 +18,9 @@
  */
 package org.apache.curator.framework.recipes.leader;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -26,8 +29,6 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.ThreadUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -37,7 +38,7 @@ public class TestLeaderSelectorWithExecutor extends BaseClassForTests
 {
     private static final ThreadFactory threadFactory = ThreadUtils.newThreadFactory("FeedGenerator");
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void test() throws Exception
     {
         Timing timing = new Timing();
@@ -61,7 +62,7 @@ public class TestLeaderSelectorWithExecutor extends BaseClassForTests
 
             timing.sleepABit();
 
-            Assert.assertEquals(listener.getLeaderCount(), 1);
+            assertEquals(listener.getLeaderCount(), 1);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMultiMutex.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMultiMutex.java
@@ -18,12 +18,16 @@
  */
 package org.apache.curator.framework.recipes.locks;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.retry.RetryOneTime;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.apache.curator.test.BaseClassForTests;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -40,7 +44,7 @@ public class TestInterProcessMultiMutex extends TestInterProcessMutexBase
         return new InterProcessMultiLock(client, Arrays.asList(LOCK_PATH_1, LOCK_PATH_2));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSomeReleasesFail() throws IOException
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -81,14 +85,14 @@ public class TestInterProcessMultiMutex extends TestInterProcessMutexBase
             {
                 lock.acquire();
                 lock.release();
-                Assert.fail();
+                fail();
             }
             catch ( Exception e )
             {
                 // ignore
             }
-            Assert.assertFalse(goodLock.isAcquiredInThisProcess());
-            Assert.assertTrue(otherGoodLock.isAcquiredInThisProcess());
+            assertFalse(goodLock.isAcquiredInThisProcess());
+            assertTrue(otherGoodLock.isAcquiredInThisProcess());
         }
         finally
         {
@@ -96,7 +100,7 @@ public class TestInterProcessMultiMutex extends TestInterProcessMutexBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSomeLocksFailToLock() throws IOException
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -140,14 +144,14 @@ public class TestInterProcessMultiMutex extends TestInterProcessMutexBase
             try
             {
                 lock.acquire();
-                Assert.fail();
+                fail();
             }
             catch ( Exception e )
             {
                 // ignore
             }
-            Assert.assertFalse(goodLock.isAcquiredInThisProcess());
-            Assert.assertTrue(goodLockWasLocked.get());
+            assertFalse(goodLock.isAcquiredInThisProcess());
+            assertTrue(goodLockWasLocked.get());
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMultiMutex.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMultiMutex.java
@@ -22,12 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +44,7 @@ public class TestInterProcessMultiMutex extends TestInterProcessMutexBase
         return new InterProcessMultiLock(client, Arrays.asList(LOCK_PATH_1, LOCK_PATH_2));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSomeReleasesFail() throws IOException
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -100,7 +100,7 @@ public class TestInterProcessMultiMutex extends TestInterProcessMutexBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSomeLocksFailToLock() throws IOException
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMutex.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMutex.java
@@ -19,17 +19,21 @@
 
 package org.apache.curator.framework.recipes.locks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.framework.schema.Schema;
 import org.apache.curator.framework.schema.SchemaSet;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -48,7 +52,7 @@ public class TestInterProcessMutex extends TestInterProcessMutexBase
         return new InterProcessMutex(client, LOCK_PATH);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWithSchema() throws Exception
     {
         Schema schemaRoot = Schema.builderForRecipeParent("/foo").name("root").build();
@@ -73,7 +77,7 @@ public class TestInterProcessMutex extends TestInterProcessMutexBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRevoking() throws Exception
     {
         final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -118,13 +122,13 @@ public class TestInterProcessMutex extends TestInterProcessMutexBase
                         @Override
                         public Void call() throws Exception
                         {
-                            Assert.assertTrue(lockLatch.await(10, TimeUnit.SECONDS));
+                            assertTrue(lockLatch.await(10, TimeUnit.SECONDS));
                             Collection<String> nodes = lock.getParticipantNodes();
-                            Assert.assertEquals(nodes.size(), 1);
+                            assertEquals(nodes.size(), 1);
                             Revoker.attemptRevoke(client, nodes.iterator().next());
 
                             InterProcessMutex l2 = new InterProcessMutex(client, LOCK_PATH);
-                            Assert.assertTrue(l2.acquire(5, TimeUnit.SECONDS));
+                            assertTrue(l2.acquire(5, TimeUnit.SECONDS));
                             l2.release();
                             return null;
                         }
@@ -140,7 +144,7 @@ public class TestInterProcessMutex extends TestInterProcessMutexBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testPersistentLock() throws Exception
     {
         final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -168,16 +172,16 @@ public class TestInterProcessMutex extends TestInterProcessMutexBase
 
             // Get a persistent lock
             lock.acquire(10, TimeUnit.SECONDS);
-            Assert.assertTrue(lock.isAcquiredInThisProcess());
+            assertTrue(lock.isAcquiredInThisProcess());
 
             // Kill the session, check that lock node still exists
             client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
-            Assert.assertNotNull(client.checkExists().forPath(LOCK_PATH));
+            assertNotNull(client.checkExists().forPath(LOCK_PATH));
 
             // Release the lock and verify that the actual lock node created no longer exists
             String actualLockPath = lock.getLockPath();
             lock.release();
-            Assert.assertNull(client.checkExists().forPath(actualLockPath));
+            assertNull(client.checkExists().forPath(actualLockPath));
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMutex.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMutex.java
@@ -24,16 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.framework.schema.Schema;
 import org.apache.curator.framework.schema.SchemaSet;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -52,7 +52,7 @@ public class TestInterProcessMutex extends TestInterProcessMutexBase
         return new InterProcessMutex(client, LOCK_PATH);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWithSchema() throws Exception
     {
         Schema schemaRoot = Schema.builderForRecipeParent("/foo").name("root").build();
@@ -77,7 +77,7 @@ public class TestInterProcessMutex extends TestInterProcessMutexBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRevoking() throws Exception
     {
         final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -144,7 +144,7 @@ public class TestInterProcessMutex extends TestInterProcessMutexBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPersistentLock() throws Exception
     {
         final CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMutexBase.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMutexBase.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -38,6 +37,8 @@ import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.KeeperException;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -59,7 +60,7 @@ public abstract class TestInterProcessMutexBase extends BaseClassForTests
 
     protected abstract InterProcessLock makeLock(CuratorFramework client);
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testLocker() throws Exception
     {
         final Timing timing = new Timing();
@@ -81,7 +82,7 @@ public abstract class TestInterProcessMutexBase extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWaitingProcessKilledServer() throws Exception
     {
         final Timing timing = new Timing();
@@ -157,7 +158,7 @@ public abstract class TestInterProcessMutexBase extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testKilledSession() throws Exception
     {
         final Timing2 timing = new Timing2();
@@ -211,7 +212,7 @@ public abstract class TestInterProcessMutexBase extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testContainerCleanup() throws Exception
     {
         if ( !ZKPaths.hasContainerSupport() )
@@ -287,7 +288,7 @@ public abstract class TestInterProcessMutexBase extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWithNamespace() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.builder().
@@ -309,7 +310,7 @@ public abstract class TestInterProcessMutexBase extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testReentrantSingleLock() throws Exception
     {
         final int THREAD_QTY = 10;
@@ -375,7 +376,7 @@ public abstract class TestInterProcessMutexBase extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testReentrant2Threads() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new ExponentialBackoffRetry(100, 3));
@@ -421,7 +422,7 @@ public abstract class TestInterProcessMutexBase extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testReentrant() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new ExponentialBackoffRetry(100, 3));
@@ -469,7 +470,7 @@ public abstract class TestInterProcessMutexBase extends BaseClassForTests
         assertTrue(mutex.isAcquiredInThisProcess());
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void test2Clients() throws Exception
     {
         CuratorFramework client1 = null;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessReadWriteLock.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessReadWriteLock.java
@@ -25,12 +25,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -45,7 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestInterProcessReadWriteLock extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGetParticipantNodes() throws Exception
     {
         final int READERS = 20;
@@ -133,7 +134,7 @@ public class TestInterProcessReadWriteLock extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testThatUpgradingIsDisallowed() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -153,7 +154,7 @@ public class TestInterProcessReadWriteLock extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testThatDowngradingRespectsThreads() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -214,7 +215,7 @@ public class TestInterProcessReadWriteLock extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDowngrading() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -235,7 +236,7 @@ public class TestInterProcessReadWriteLock extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         final int CONCURRENCY = 8;
@@ -300,7 +301,7 @@ public class TestInterProcessReadWriteLock extends BaseClassForTests
         assertTrue(maxConcurrentCount.get() > 1);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetNodeData() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphore.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphore.java
@@ -19,8 +19,14 @@
 
 package org.apache.curator.framework.recipes.locks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.CuratorWatcher;
@@ -28,7 +34,6 @@ import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.framework.recipes.shared.SharedCount;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
-import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
@@ -36,8 +41,6 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -55,7 +58,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @SuppressWarnings({"SynchronizationOnLocalVariableOrMethodParameter"})
 public class TestInterProcessSemaphore extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testAcquireAfterLostServer() throws Exception
     {
         // CURATOR-335
@@ -128,7 +131,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
             {
                 executor.execute(runner);
             }
-            Assert.assertTrue(timing.awaitLatch(isReadyLatch));
+            assertTrue(timing.awaitLatch(isReadyLatch));
             timing.sleepABit();
 
             final CountDownLatch lostLatch = new CountDownLatch(1);
@@ -150,20 +153,20 @@ public class TestInterProcessSemaphore extends BaseClassForTests
             });
       
             server.stop();
-            Assert.assertTrue(timing.multiple(1.25).awaitLatch(lostLatch));
+            assertTrue(timing.multiple(1.25).awaitLatch(lostLatch));
             InterProcessSemaphoreV2.debugAcquireLatch.countDown();  // the waiting semaphore proceeds to getChildren - which should fail
-            Assert.assertTrue(timing.awaitLatch(InterProcessSemaphoreV2.debugFailedGetChildrenLatch));  // wait until getChildren fails
+            assertTrue(timing.awaitLatch(InterProcessSemaphoreV2.debugFailedGetChildrenLatch));  // wait until getChildren fails
 
             server.restart();
 
-            Assert.assertTrue(timing.awaitLatch(restartedLatch));
+            assertTrue(timing.awaitLatch(restartedLatch));
             for ( int i = 0; i < NUM_CLIENTS; ++i )
             {
                 // acquires should continue as normal after server restart
                 Boolean polled = acquiredQueue.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS);
                 if ( (polled == null) || !polled )
                 {
-                    Assert.fail("Semaphores not reacquired after restart");
+                    fail("Semaphores not reacquired after restart");
                 }
             }
         }
@@ -174,7 +177,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testThreadedLeaseIncrease() throws Exception
     {
         final Timing timing = new Timing();
@@ -200,10 +203,10 @@ public class TestInterProcessSemaphore extends BaseClassForTests
                         public Object call() throws Exception
                         {
                             Lease lease = semaphore.acquire(timing.seconds(), TimeUnit.SECONDS);
-                            Assert.assertNotNull(lease);
+                            assertNotNull(lease);
                             latch1.countDown();
                             lease = semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-                            Assert.assertNotNull(lease);
+                            assertNotNull(lease);
                             latch2.countDown();
                             return null;
                         }
@@ -216,12 +219,12 @@ public class TestInterProcessSemaphore extends BaseClassForTests
                         @Override
                         public Object call() throws Exception
                         {
-                            Assert.assertTrue(latch1.await(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+                            assertTrue(latch1.await(timing.forWaiting().seconds(), TimeUnit.SECONDS));
                             timing.sleepABit(); // make sure second acquire is waiting
-                            Assert.assertTrue(count.trySetCount(2));
+                            assertTrue(count.trySetCount(2));
                             //Make sure second acquire takes less than full waiting time:
                             timing.sleepABit();
-                            Assert.assertTrue(latch2.await(0, TimeUnit.SECONDS));
+                            assertTrue(latch2.await(0, TimeUnit.SECONDS));
                             return null;
                         }
                     }
@@ -238,7 +241,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testClientClose() throws Exception
     {
         final Timing timing = new Timing();
@@ -258,16 +261,16 @@ public class TestInterProcessSemaphore extends BaseClassForTests
             semaphore2 = new InterProcessSemaphoreV2(client2, "/test", 1);
 
             Lease lease = semaphore2.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-            Assert.assertNotNull(lease);
+            assertNotNull(lease);
             lease.close();
 
             lease = semaphore1.acquire(10, TimeUnit.SECONDS);
-            Assert.assertNotNull(lease);
+            assertNotNull(lease);
 
             client1.close();    // should release any held leases
             client1 = null;
 
-            Assert.assertNotNull(semaphore2.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+            assertNotNull(semaphore2.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
         }
         finally
         {
@@ -276,7 +279,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testMaxPerSession() throws Exception
     {
         final int CLIENT_QTY = 10;
@@ -324,10 +327,10 @@ public class TestInterProcessSemaphore extends BaseClassForTests
                                                 thisQty = (available.get() > 1) ? (random.nextInt(available.get()) + 1) : 1;
 
                                                 available.addAndGet(-1 * thisQty);
-                                                Assert.assertTrue(available.get() >= 0);
+                                                assertTrue(available.get() >= 0);
                                             }
                                             Collection<Lease> leases = semaphore.acquire(thisQty, timing.forWaiting().seconds(), TimeUnit.SECONDS);
-                                            Assert.assertNotNull(leases);
+                                            assertNotNull(leases);
                                             try
                                             {
                                                 synchronized(counter)
@@ -373,14 +376,14 @@ public class TestInterProcessSemaphore extends BaseClassForTests
 
         synchronized(counter)
         {
-            Assert.assertTrue(counter.currentCount == 0);
-            Assert.assertTrue(counter.maxCount > 0);
-            Assert.assertTrue(counter.maxCount <= SESSION_MAX);
+            assertTrue(counter.currentCount == 0);
+            assertTrue(counter.maxCount > 0);
+            assertTrue(counter.maxCount <= SESSION_MAX);
             System.out.println(counter.maxCount);
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRelease1AtATime() throws Exception
     {
         final Timing timing = new Timing();
@@ -407,7 +410,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
                             {
                                 InterProcessSemaphoreV2 semaphore = new InterProcessSemaphoreV2(client, "/test", MAX);
                                 Lease lease = semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-                                Assert.assertNotNull(lease);
+                                assertNotNull(lease);
                                 uses.incrementAndGet();
                                 try
                                 {
@@ -444,11 +447,11 @@ public class TestInterProcessSemaphore extends BaseClassForTests
             f.get();
         }
 
-        Assert.assertEquals(uses.get(), CLIENT_QTY);
-        Assert.assertEquals(maxLeases.get(), MAX);
+        assertEquals(uses.get(), CLIENT_QTY);
+        assertEquals(maxLeases.get(), MAX);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testReleaseInChunks() throws Exception
     {
         final Timing timing = new Timing();
@@ -524,9 +527,9 @@ public class TestInterProcessSemaphore extends BaseClassForTests
             timing.sleepABit();
             synchronized(counter)
             {
-                Assert.assertTrue(counter.currentCount == 0);
-                Assert.assertTrue(counter.maxCount > 0);
-                Assert.assertTrue(counter.maxCount <= MAX_LEASES);
+                assertTrue(counter.currentCount == 0);
+                assertTrue(counter.maxCount > 0);
+                assertTrue(counter.maxCount <= MAX_LEASES);
                 System.out.println(counter.maxCount);
             }
         }
@@ -536,7 +539,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testThreads() throws Exception
     {
         final int THREAD_QTY = 10;
@@ -572,7 +575,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
                     );
             }
             service.shutdown();
-            Assert.assertTrue(service.awaitTermination(10, TimeUnit.SECONDS));
+            assertTrue(service.awaitTermination(10, TimeUnit.SECONDS));
         }
         finally
         {
@@ -580,7 +583,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSimple() throws Exception
     {
         Timing timing = new Timing();
@@ -589,8 +592,8 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         try
         {
             InterProcessSemaphoreV2 semaphore = new InterProcessSemaphoreV2(client, "/test", 1);
-            Assert.assertNotNull(semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
-            Assert.assertNull(semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+            assertNotNull(semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+            assertNull(semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
         }
         finally
         {
@@ -598,7 +601,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSimple2() throws Exception
     {
         final int MAX_LEASES = 3;
@@ -613,16 +616,16 @@ public class TestInterProcessSemaphore extends BaseClassForTests
             {
                 InterProcessSemaphoreV2 semaphore = new InterProcessSemaphoreV2(client, "/test", MAX_LEASES);
                 Lease lease = semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-                Assert.assertNotNull(lease);
+                assertNotNull(lease);
                 leases.add(lease);
             }
 
             InterProcessSemaphoreV2 semaphore = new InterProcessSemaphoreV2(client, "/test", MAX_LEASES);
             Lease lease = semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-            Assert.assertNull(lease);
+            assertNull(lease);
 
             leases.remove(0).close();
-            Assert.assertNotNull(semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+            assertNotNull(semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
         }
         finally
         {
@@ -634,7 +637,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testGetParticipantNodes() throws Exception
     {
         final int LEASES = 3;
@@ -651,7 +654,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
                 leases.add(semaphore.acquire());
             }
 
-            Assert.assertEquals(semaphore.getParticipantNodes().size(), LEASES);
+            assertEquals(semaphore.getParticipantNodes().size(), LEASES);
         }
         finally
         {
@@ -663,7 +666,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testNoOrphanedNodes() throws Exception
     {
         final Timing timing = new Timing();
@@ -674,9 +677,9 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         {
             final InterProcessSemaphoreV2 semaphore = new InterProcessSemaphoreV2(client, "/test", 1);
             Lease lease = semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-            Assert.assertNotNull(lease);
+            assertNotNull(lease);
             final List<String> childNodes = client.getChildren().forPath("/test/leases");
-            Assert.assertEquals(childNodes.size(), 1);
+            assertEquals(childNodes.size(), 1);
 
             final CountDownLatch nodeCreatedLatch = new CountDownLatch(1);
             client.getChildren().usingWatcher(new CuratorWatcher()
@@ -710,7 +713,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
                     newNode = c;
                 }
             }
-            Assert.assertNotNull(newNode);
+            assertNotNull(newNode);
 
             // delete the ephemeral node to trigger a retry
             client.delete().forPath("/test/leases/" + newNode);
@@ -718,12 +721,12 @@ public class TestInterProcessSemaphore extends BaseClassForTests
             // release first lease so second one can be acquired
             lease.close();
             lease = leaseFuture.get();
-            Assert.assertNotNull(lease);
+            assertNotNull(lease);
             lease.close();
-            Assert.assertEquals(client.getChildren().forPath("/test/leases").size(), 0);
+            assertEquals(client.getChildren().forPath("/test/leases").size(), 0);
 
             // no more lease exist. must be possible to acquire a new one
-            Assert.assertNotNull(semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+            assertNotNull(semaphore.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
         }
         finally
         {
@@ -732,7 +735,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testInterruptAcquire() throws Exception
     {
         // CURATOR-462
@@ -749,7 +752,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
             
             // Acquire exclusive semaphore
             Lease lease = s1.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-            Assert.assertNotNull(lease);
+            assertNotNull(lease);
             
             // Queue up another semaphore on the same path
             Future<Object> handle = Executors.newSingleThreadExecutor().submit(new Callable<Object>() {
@@ -762,18 +765,18 @@ public class TestInterProcessSemaphore extends BaseClassForTests
             });
 
             // Wait until second lease is created and the wait is started for it to become active
-            Assert.assertTrue(timing.awaitLatch(debugWaitLatch));
+            assertTrue(timing.awaitLatch(debugWaitLatch));
             
             // Interrupt the wait
             handle.cancel(true);
             
             // Assert that the second lease is gone
             timing.sleepABit();
-            Assert.assertEquals(client.getChildren().forPath("/test/leases").size(), 1);
+            assertEquals(client.getChildren().forPath("/test/leases").size(), 1);
             
             // Assert that after closing the first (current) semaphore, we can acquire a new one
             s1.returnLease(lease);
-            Assert.assertNotNull(s3.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+            assertNotNull(s3.acquire(timing.forWaiting().seconds(), TimeUnit.SECONDS));
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphore.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphore.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.CuratorWatcher;
@@ -41,6 +40,8 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -58,7 +59,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @SuppressWarnings({"SynchronizationOnLocalVariableOrMethodParameter"})
 public class TestInterProcessSemaphore extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAcquireAfterLostServer() throws Exception
     {
         // CURATOR-335
@@ -177,7 +178,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testThreadedLeaseIncrease() throws Exception
     {
         final Timing timing = new Timing();
@@ -241,7 +242,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testClientClose() throws Exception
     {
         final Timing timing = new Timing();
@@ -279,7 +280,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMaxPerSession() throws Exception
     {
         final int CLIENT_QTY = 10;
@@ -383,7 +384,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRelease1AtATime() throws Exception
     {
         final Timing timing = new Timing();
@@ -451,7 +452,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         assertEquals(maxLeases.get(), MAX);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testReleaseInChunks() throws Exception
     {
         final Timing timing = new Timing();
@@ -539,7 +540,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testThreads() throws Exception
     {
         final int THREAD_QTY = 10;
@@ -583,7 +584,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSimple() throws Exception
     {
         Timing timing = new Timing();
@@ -601,7 +602,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSimple2() throws Exception
     {
         final int MAX_LEASES = 3;
@@ -637,7 +638,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGetParticipantNodes() throws Exception
     {
         final int LEASES = 3;
@@ -666,7 +667,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNoOrphanedNodes() throws Exception
     {
         final Timing timing = new Timing();
@@ -735,7 +736,7 @@ public class TestInterProcessSemaphore extends BaseClassForTests
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInterruptAcquire() throws Exception
     {
         // CURATOR-462

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphoreCluster.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphoreCluster.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -37,6 +36,8 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -53,7 +54,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestInterProcessSemaphoreCluster extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testKilledServerWithEnsembleProvider() throws Exception
     {
         final int           CLIENT_QTY = 10;
@@ -197,7 +198,7 @@ public class TestInterProcessSemaphoreCluster extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testCluster() throws Exception
     {
         final int           QTY = 20;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphoreCluster.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphoreCluster.java
@@ -18,7 +18,11 @@
  */
 package org.apache.curator.framework.recipes.locks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -32,8 +36,7 @@ import org.apache.curator.test.TestingCluster;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -47,10 +50,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestInterProcessSemaphoreCluster extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testKilledServerWithEnsembleProvider() throws Exception
     {
         final int           CLIENT_QTY = 10;
@@ -168,22 +171,22 @@ public class TestInterProcessSemaphoreCluster extends BaseClassForTests
                 );
             }
 
-            Assert.assertTrue(timing.acquireSemaphore(acquiredSemaphore));
-            Assert.assertEquals(1, acquireCount.get());
+            assertTrue(timing.acquireSemaphore(acquiredSemaphore));
+            assertEquals(1, acquireCount.get());
 
             cluster.close();
             timing.awaitLatch(suspendedLatch);
             timing.forWaiting().sleepABit();
-            Assert.assertEquals(0, acquireCount.get());
+            assertEquals(0, acquireCount.get());
 
             cluster = createAndStartCluster(3);
 
             connectionString.set(cluster.getConnectString());
             timing.forWaiting().sleepABit();
 
-            Assert.assertTrue(timing.acquireSemaphore(acquiredSemaphore));
+            assertTrue(timing.acquireSemaphore(acquiredSemaphore));
             timing.forWaiting().sleepABit();
-            Assert.assertEquals(1, acquireCount.get());
+            assertEquals(1, acquireCount.get());
         }
         finally
         {
@@ -194,7 +197,7 @@ public class TestInterProcessSemaphoreCluster extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testCluster() throws Exception
     {
         final int           QTY = 20;
@@ -232,7 +235,7 @@ public class TestInterProcessSemaphoreCluster extends BaseClassForTests
 
             timing.forWaiting().sleepABit();
 
-            Assert.assertNotNull(SemaphoreClient.getActiveClient());
+            assertNotNull(SemaphoreClient.getActiveClient());
 
             final CountDownLatch    latch = new CountDownLatch(1);
             CuratorFramework        client = CuratorFrameworkFactory.newClient(cluster.getConnectString(), timing.session(), timing.connection(), new ExponentialBackoffRetry(100, 3));
@@ -271,7 +274,7 @@ public class TestInterProcessSemaphoreCluster extends BaseClassForTests
                 {
                     break;  // checking that the op count isn't increasing
                 }
-                Assert.assertTrue((System.currentTimeMillis() - startTicks) < timing.forWaiting().milliseconds());
+                assertTrue((System.currentTimeMillis() - startTicks) < timing.forWaiting().milliseconds());
             }
 
             int     thisOpCount = opCount.get();
@@ -289,7 +292,7 @@ public class TestInterProcessSemaphoreCluster extends BaseClassForTests
                 {
                     break;  // checking that semaphore has started working again
                 }
-                Assert.assertTrue((System.currentTimeMillis() - startTicks) < timing.forWaiting().milliseconds());
+                assertTrue((System.currentTimeMillis() - startTicks) < timing.forWaiting().milliseconds());
             }
         }
         finally

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphoreMutex.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphoreMutex.java
@@ -18,27 +18,32 @@
  */
 package org.apache.curator.framework.recipes.locks;
 
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
-import org.testng.annotations.Test;
+import org.apache.curator.test.BaseClassForTests;
+import org.junit.jupiter.api.Disabled;
 
 public class TestInterProcessSemaphoreMutex extends TestInterProcessMutexBase
 {
     private static final String LOCK_PATH = LOCK_BASE_PATH + "/our-lock";
 
     @Override
-    @Test(enabled = false)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Disabled
     public void testReentrant()
     {
     }
 
     @Override
-    @Test(enabled = false)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Disabled
     public void testReentrant2Threads()
     {
     }
 
     @Override
-    @Test(enabled = false)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Disabled
     public void testReentrantSingleLock()
     {
     }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphoreMutex.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessSemaphoreMutex.java
@@ -18,31 +18,30 @@
  */
 package org.apache.curator.framework.recipes.locks;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.test.BaseClassForTests;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestInterProcessSemaphoreMutex extends TestInterProcessMutexBase
 {
     private static final String LOCK_PATH = LOCK_BASE_PATH + "/our-lock";
 
     @Override
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Disabled
     public void testReentrant()
     {
     }
 
     @Override
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Disabled
     public void testReentrant2Threads()
     {
     }
 
     @Override
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     @Disabled
     public void testReentrantSingleLock()
     {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestLockACLs.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestLockACLs.java
@@ -22,7 +22,6 @@ package org.apache.curator.framework.recipes.locks;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
@@ -34,6 +33,7 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -56,7 +56,7 @@ public class TestLockACLs extends BaseClassForTests
         return client;
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testLockACLs() throws Exception
     {
         CuratorFramework client = createClient(new TestLockACLsProvider());
@@ -82,7 +82,7 @@ public class TestLockACLs extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testACLsCreatingParents() throws Exception
     {
         CuratorFramework client = createClient(new TestACLsCreatingParentsProvider());

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestLockACLs.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestLockACLs.java
@@ -19,6 +19,10 @@
 
 package org.apache.curator.framework.recipes.locks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
@@ -30,8 +34,7 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -53,25 +56,25 @@ public class TestLockACLs extends BaseClassForTests
         return client;
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testLockACLs() throws Exception
     {
         CuratorFramework client = createClient(new TestLockACLsProvider());
         try
         {
             client.create().forPath("/foo");
-            Assert.assertNotNull(client.checkExists().forPath("/foo"));
-            Assert.assertEquals(ZooDefs.Perms.ALL, client.getACL().forPath("/foo").get(0).getPerms());
-            Assert.assertEquals("ip", client.getACL().forPath("/foo").get(0).getId().getScheme());
-            Assert.assertEquals("127.0.0.1", client.getACL().forPath("/foo").get(0).getId().getId());
+            assertNotNull(client.checkExists().forPath("/foo"));
+            assertEquals(ZooDefs.Perms.ALL, client.getACL().forPath("/foo").get(0).getPerms());
+            assertEquals("ip", client.getACL().forPath("/foo").get(0).getId().getScheme());
+            assertEquals("127.0.0.1", client.getACL().forPath("/foo").get(0).getId().getId());
 
             InterProcessReadWriteLock lock = new InterProcessReadWriteLock(client, "/bar");
             InterProcessMutex writeLock = lock.writeLock();
             writeLock.acquire();
-            Assert.assertNotNull(client.checkExists().forPath("/bar"));
-            Assert.assertEquals(ZooDefs.Perms.ALL, client.getACL().forPath("/bar").get(0).getPerms());
-            Assert.assertEquals("ip", client.getACL().forPath("/bar").get(0).getId().getScheme());
-            Assert.assertEquals("127.0.0.1", client.getACL().forPath("/bar").get(0).getId().getId());
+            assertNotNull(client.checkExists().forPath("/bar"));
+            assertEquals(ZooDefs.Perms.ALL, client.getACL().forPath("/bar").get(0).getPerms());
+            assertEquals("ip", client.getACL().forPath("/bar").get(0).getId().getScheme());
+            assertEquals("127.0.0.1", client.getACL().forPath("/bar").get(0).getId().getId());
         }
         finally
         {
@@ -79,15 +82,15 @@ public class TestLockACLs extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testACLsCreatingParents() throws Exception
     {
         CuratorFramework client = createClient(new TestACLsCreatingParentsProvider());
         try
         {
             client.create().creatingParentsIfNeeded().forPath("/parent/foo");
-            Assert.assertEquals(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, client.getACL().forPath("/parent").get(0).getPerms());
-            Assert.assertEquals(ZooDefs.Perms.ALL, client.getACL().forPath("/parent/foo").get(0).getPerms());
+            assertEquals(ZooDefs.Perms.CREATE | ZooDefs.Perms.READ, client.getACL().forPath("/parent").get(0).getPerms());
+            assertEquals(ZooDefs.Perms.ALL, client.getACL().forPath("/parent/foo").get(0).getPerms());
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestLockCleanlinessWithFaults.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestLockCleanlinessWithFaults.java
@@ -18,20 +18,21 @@
  */
 package org.apache.curator.framework.recipes.locks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.BaseClassForTests;
-import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.List;
 
 public class TestLockCleanlinessWithFaults extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testNodeDeleted() throws Exception
     {
         final String PATH = "/foo/bar";
@@ -43,7 +44,7 @@ public class TestLockCleanlinessWithFaults extends BaseClassForTests
             client.start();
 
             client.create().creatingParentsIfNeeded().forPath(PATH);
-            Assert.assertEquals(client.checkExists().forPath(PATH).getNumChildren(), 0);
+            assertEquals(client.checkExists().forPath(PATH).getNumChildren(), 0);
 
             LockInternals       internals = new LockInternals(client, new StandardLockInternalsDriver(), PATH, "lock-", 1)
             {
@@ -56,7 +57,7 @@ public class TestLockCleanlinessWithFaults extends BaseClassForTests
             try
             {
                 internals.attemptLock(0, null, null);
-                Assert.fail();
+                fail();
             }
             catch ( KeeperException.NoNodeException dummy )
             {
@@ -64,7 +65,7 @@ public class TestLockCleanlinessWithFaults extends BaseClassForTests
             }
 
             // make sure no nodes are left lying around
-            Assert.assertEquals(client.checkExists().forPath(PATH).getNumChildren(), 0);
+            assertEquals(client.checkExists().forPath(PATH).getNumChildren(), 0);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestLockCleanlinessWithFaults.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestLockCleanlinessWithFaults.java
@@ -21,18 +21,19 @@ package org.apache.curator.framework.recipes.locks;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.TestCleanState;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.zookeeper.KeeperException;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 
 public class TestLockCleanlinessWithFaults extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testNodeDeleted() throws Exception
     {
         final String PATH = "/foo/bar";

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestGroupMember.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestGroupMember.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.base.Function;
 import com.google.common.collect.Maps;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -33,6 +32,8 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.Map;
 
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
@@ -40,7 +41,7 @@ public class TestGroupMember extends BaseClassForTests
 {
     // NOTE - don't need many tests as this class is just a wrapper around two existing recipes
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         Timing timing = new Timing();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestGroupMember.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestGroupMember.java
@@ -18,8 +18,13 @@
  */
 package org.apache.curator.framework.recipes.nodes;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.base.Function;
 import com.google.common.collect.Maps;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -27,16 +32,15 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.Map;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestGroupMember extends BaseClassForTests
 {
     // NOTE - don't need many tests as this class is just a wrapper around two existing recipes
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         Timing timing = new Timing();
@@ -48,7 +52,7 @@ public class TestGroupMember extends BaseClassForTests
             client.start();
 
             groupMember1 = new GroupMember(client, "/member", "1");
-            Assert.assertTrue(groupMember1.getCurrentMembers().containsKey("1"));
+            assertTrue(groupMember1.getCurrentMembers().containsKey("1"));
             groupMember1.start();
 
             groupMember2 = new GroupMember(client, "/member", "2");
@@ -74,27 +78,27 @@ public class TestGroupMember extends BaseClassForTests
                     return new String(input);
                 }
             });
-            Assert.assertEquals(convertMembers1.size(), 2);
-            Assert.assertEquals(convertMembers2.size(), 2);
-            Assert.assertEquals(convertMembers1, convertMembers2);
-            Assert.assertTrue(convertMembers1.containsKey("1"));
-            Assert.assertTrue(convertMembers1.containsKey("2"));
+            assertEquals(convertMembers1.size(), 2);
+            assertEquals(convertMembers2.size(), 2);
+            assertEquals(convertMembers1, convertMembers2);
+            assertTrue(convertMembers1.containsKey("1"));
+            assertTrue(convertMembers1.containsKey("2"));
 
             groupMember2.close();
 
             timing.sleepABit();
 
             currentMembers1 = groupMember1.getCurrentMembers();
-            Assert.assertEquals(currentMembers1.size(), 1);
-            Assert.assertTrue(currentMembers1.containsKey("1"));
-            Assert.assertFalse(currentMembers1.containsKey("2"));
+            assertEquals(currentMembers1.size(), 1);
+            assertTrue(currentMembers1.containsKey("1"));
+            assertFalse(currentMembers1.containsKey("2"));
 
             groupMember1.setThisData("something".getBytes());
 
             timing.sleepABit();
             currentMembers1 = groupMember1.getCurrentMembers();
-            Assert.assertTrue(currentMembers1.containsKey("1"));
-            Assert.assertEquals(currentMembers1.get("1"), "something".getBytes());
+            assertTrue(currentMembers1.containsKey("1"));
+            assertArrayEquals(currentMembers1.get("1"), "something".getBytes());
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentEphemeralNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentEphemeralNode.java
@@ -18,9 +18,17 @@
  */
 package org.apache.curator.framework.recipes.nodes;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
@@ -41,11 +49,9 @@ import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.AfterEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,8 +61,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-
-import static org.testng.Assert.*;
 
 @SuppressWarnings("deprecation")
 public class TestPersistentEphemeralNode extends BaseClassForTests
@@ -70,7 +74,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
 
     private final Timing2 timing = new Timing2();
 
-    @AfterMethod
+    @AfterEach
     @Override
     public void teardown() throws Exception
     {
@@ -92,7 +96,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testListenersReconnectedIsFast() throws Exception
     {
         server.stop();
@@ -126,14 +130,14 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
                 client.getConnectionStateListenable().addListener(listener);
                 timing.sleepABit();
                 server.restart();
-                Assert.assertTrue(timing.awaitLatch(connectedLatch));
+                assertTrue(timing.awaitLatch(connectedLatch));
                 timing.sleepABit();
-                Assert.assertTrue(node.waitForInitialCreate(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS));
+                assertTrue(node.waitForInitialCreate(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS));
                 server.stop();
                 timing.sleepABit();
                 server.restart();
                 timing.sleepABit();
-                Assert.assertTrue(timing.awaitLatch(reconnectedLatch));
+                assertTrue(timing.awaitLatch(reconnectedLatch));
             }
         }
         finally
@@ -142,7 +146,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testNoServerAtStart() throws Exception
     {
         server.stop();
@@ -174,11 +178,11 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
 
             server.restart();
 
-            Assert.assertTrue(timing.awaitLatch(connectedLatch));
+            assertTrue(timing.awaitLatch(connectedLatch));
 
             timing.sleepABit();
 
-            Assert.assertTrue(node.waitForInitialCreate(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS));
+            assertTrue(node.waitForInitialCreate(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS));
         }
         finally
         {
@@ -187,40 +191,48 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullCurator() throws Exception
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    public void testNullCurator()
     {
-        new PersistentEphemeralNode(null, PersistentEphemeralNode.Mode.EPHEMERAL, PATH, new byte[0]);
+        assertThrows(NullPointerException.class, ()-> {
+            new PersistentEphemeralNode(null, PersistentEphemeralNode.Mode.EPHEMERAL, PATH, new byte[0]);
+        });
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testNullPath() throws Exception
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    public void testNullPath()
     {
-        CuratorFramework curator = newCurator();
-        new PersistentEphemeralNode(curator, PersistentEphemeralNode.Mode.EPHEMERAL, null, new byte[0]);
+        assertThrows(IllegalArgumentException.class, ()-> {
+            CuratorFramework curator = newCurator();
+            new PersistentEphemeralNode(curator, PersistentEphemeralNode.Mode.EPHEMERAL, null, new byte[0]);
+        });
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullData() throws Exception
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    public void testNullData()
     {
-        CuratorFramework curator = newCurator();
-        new PersistentEphemeralNode(curator, PersistentEphemeralNode.Mode.EPHEMERAL, PATH, null);
+        assertThrows(NullPointerException.class, ()-> {
+            CuratorFramework curator = newCurator();
+            new PersistentEphemeralNode(curator, PersistentEphemeralNode.Mode.EPHEMERAL, PATH, null);
+        });
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullMode() throws Exception
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    public void testNullMode()
     {
-        CuratorFramework curator = newCurator();
-        new PersistentEphemeralNode(curator, null, PATH, new byte[0]);
+        assertThrows(NullPointerException.class, ()->{
+            CuratorFramework curator = newCurator();
+            new PersistentEphemeralNode(curator, null, PATH, new byte[0]);
+            });
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSettingDataSequential() throws Exception
     {
         setDataTest(PersistentEphemeralNode.Mode.EPHEMERAL_SEQUENTIAL);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSettingData() throws Exception
     {
         setDataTest(PersistentEphemeralNode.Mode.EPHEMERAL);
@@ -236,9 +248,9 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
             node = new PersistentEphemeralNode(client, mode, PATH, "a".getBytes());
             node.debugWaitMsForBackgroundBeforeClose.set(timing.forSleepingABit().milliseconds());
             node.start();
-            Assert.assertTrue(node.waitForInitialCreate(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+            assertTrue(node.waitForInitialCreate(timing.forWaiting().seconds(), TimeUnit.SECONDS));
 
-            Assert.assertEquals(client.getData().forPath(node.getActualPath()), "a".getBytes());
+            assertArrayEquals(client.getData().forPath(node.getActualPath()), "a".getBytes());
 
             final Semaphore semaphore = new Semaphore(0);
             Watcher watcher = new Watcher()
@@ -251,15 +263,15 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
             };
             client.checkExists().usingWatcher(watcher).forPath(node.getActualPath());
             node.setData("b".getBytes());
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
-            Assert.assertEquals(node.getActualPath(), node.getActualPath());
-            Assert.assertEquals(client.getData().usingWatcher(watcher).forPath(node.getActualPath()), "b".getBytes());
+            assertTrue(timing.acquireSemaphore(semaphore));
+            assertEquals(node.getActualPath(), node.getActualPath());
+            assertArrayEquals(client.getData().usingWatcher(watcher).forPath(node.getActualPath()), "b".getBytes());
             node.setData("c".getBytes());
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
-            Assert.assertEquals(node.getActualPath(), node.getActualPath());
-            Assert.assertEquals(client.getData().usingWatcher(watcher).forPath(node.getActualPath()), "c".getBytes());
+            assertTrue(timing.acquireSemaphore(semaphore));
+            assertEquals(node.getActualPath(), node.getActualPath());
+            assertArrayEquals(client.getData().usingWatcher(watcher).forPath(node.getActualPath()), "c".getBytes());
             node.close();
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
+            assertTrue(timing.acquireSemaphore(semaphore));
         }
         finally
         {
@@ -268,7 +280,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDeletesNodeWhenClosed() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -291,7 +303,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         assertNodeDoesNotExist(curator, path);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testClosingMultipleTimes() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -309,7 +321,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         assertNodeDoesNotExist(curator, path);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDeletesNodeWhenSessionDisconnects() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -340,7 +352,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRecreatesNodeWhenSessionReconnects() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -375,7 +387,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRecreatesNodeWhenSessionReconnectsMultipleTimes() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -395,7 +407,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
             {
                 Trigger deletionTrigger = Trigger.deletedOrSetData();
                 Stat stat = observer.checkExists().usingWatcher(deletionTrigger).forPath(path);
-                Assert.assertNotNull(stat, "node should exist: " + path);
+                assertNotNull(stat, "node should exist: " + path);
 
                 node.debugCreateNodeLatch = new CountDownLatch(1);
                 // Kill the session, thus cleaning up the node...
@@ -417,7 +429,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRecreatesNodeWhenEphemeralOwnerSessionExpires() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -458,7 +470,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRecreatesNodeWhenItGetsDeleted() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -487,7 +499,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testNodesCreateUniquePaths() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -516,7 +528,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testData() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -541,7 +553,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
      * that if data is present in the PersistentEphermalNode that it is still set.
      * @throws Exception
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSetDataWhenNodeExists() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -563,7 +575,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSetDataWhenDisconnected() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -610,7 +622,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSetUpdatedDataWhenReconnected() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -656,7 +668,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
      * appended to the new protected node name. This meant that a new node got created on each reconnect.
      * @throws Exception
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testProtected() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -687,7 +699,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testNoCreatePermission() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -723,7 +735,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testNoWritePermission() throws Exception
     {
         final ACLProvider aclProvider = new ACLProvider() {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentEphemeralNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentEphemeralNode.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
@@ -50,6 +49,7 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.IOException;
@@ -96,7 +96,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testListenersReconnectedIsFast() throws Exception
     {
         server.stop();
@@ -146,7 +146,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNoServerAtStart() throws Exception
     {
         server.stop();
@@ -191,7 +191,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNullCurator()
     {
         assertThrows(NullPointerException.class, ()-> {
@@ -199,7 +199,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         });
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNullPath()
     {
         assertThrows(IllegalArgumentException.class, ()-> {
@@ -208,7 +208,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         });
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNullData()
     {
         assertThrows(NullPointerException.class, ()-> {
@@ -217,7 +217,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         });
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNullMode()
     {
         assertThrows(NullPointerException.class, ()->{
@@ -226,13 +226,13 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
             });
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSettingDataSequential() throws Exception
     {
         setDataTest(PersistentEphemeralNode.Mode.EPHEMERAL_SEQUENTIAL);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSettingData() throws Exception
     {
         setDataTest(PersistentEphemeralNode.Mode.EPHEMERAL);
@@ -280,7 +280,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeletesNodeWhenClosed() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -303,7 +303,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         assertNodeDoesNotExist(curator, path);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testClosingMultipleTimes() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -321,7 +321,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         assertNodeDoesNotExist(curator, path);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeletesNodeWhenSessionDisconnects() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -352,7 +352,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRecreatesNodeWhenSessionReconnects() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -387,7 +387,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRecreatesNodeWhenSessionReconnectsMultipleTimes() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -429,7 +429,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRecreatesNodeWhenEphemeralOwnerSessionExpires() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -470,7 +470,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRecreatesNodeWhenItGetsDeleted() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -499,7 +499,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNodesCreateUniquePaths() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -528,7 +528,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testData() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -553,7 +553,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
      * that if data is present in the PersistentEphermalNode that it is still set.
      * @throws Exception
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetDataWhenNodeExists() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -575,7 +575,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetDataWhenDisconnected() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -622,7 +622,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetUpdatedDataWhenReconnected() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -668,7 +668,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
      * appended to the new protected node name. This meant that a new node got created on each reconnect.
      * @throws Exception
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testProtected() throws Exception
     {
         CuratorFramework curator = newCurator();
@@ -699,7 +699,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNoCreatePermission() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -735,7 +735,7 @@ public class TestPersistentEphemeralNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNoWritePermission() throws Exception
     {
         final ACLProvider aclProvider = new ACLProvider() {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentEphemeralNodeListener.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentEphemeralNodeListener.java
@@ -19,17 +19,18 @@
 
 package org.apache.curator.framework.recipes.nodes;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
-import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -37,7 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @SuppressWarnings("deprecation")
 public class TestPersistentEphemeralNodeListener extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testListenersReconnectedIsOK() throws Exception
     {
         server.stop();
@@ -72,14 +73,14 @@ public class TestPersistentEphemeralNodeListener extends BaseClassForTests
             client.getConnectionStateListenable().addListener(listener);
             timing.sleepABit();
             server.restart();
-            Assert.assertTrue(timing.awaitLatch(connectedLatch));
+            assertTrue(timing.awaitLatch(connectedLatch));
             timing.sleepABit();
-            Assert.assertTrue(node.waitForInitialCreate(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS));
+            assertTrue(node.waitForInitialCreate(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS));
             server.restart();
             timing.sleepABit();
-            Assert.assertTrue(timing.awaitLatch(reconnectedLatch));
+            assertTrue(timing.awaitLatch(reconnectedLatch));
             timing.sleepABit();
-            Assert.assertEquals(lastState.get(), ConnectionState.RECONNECTED);
+            assertEquals(lastState.get(), ConnectionState.RECONNECTED);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentEphemeralNodeListener.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentEphemeralNodeListener.java
@@ -22,7 +22,6 @@ package org.apache.curator.framework.recipes.nodes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -31,6 +30,8 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -38,7 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @SuppressWarnings("deprecation")
 public class TestPersistentEphemeralNodeListener extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testListenersReconnectedIsOK() throws Exception
     {
         server.stop();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentNode.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -33,12 +32,14 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class TestPersistentNode extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testQuickSetData() throws Exception
     {
         final byte[] TEST_DATA = "hey".getBytes();
@@ -69,7 +70,7 @@ public class TestPersistentNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         final byte[] TEST_DATA = "hey".getBytes();
@@ -99,7 +100,7 @@ public class TestPersistentNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testQuickClose() throws Exception
     {
         Timing timing = new Timing();
@@ -121,7 +122,7 @@ public class TestPersistentNode extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testQuickCloseNodeExists() throws Exception
     {
         Timing timing = new Timing();
@@ -145,7 +146,7 @@ public class TestPersistentNode extends BaseClassForTests
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testEphemeralSequentialWithProtectionReconnection() throws Exception
     {
         Timing timing = new Timing();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.framework.recipes.nodes;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -89,7 +90,7 @@ public class TestPersistentNode extends BaseClassForTests
             client.start();
 
             byte[] bytes = client.getData().forPath("/test");
-            assertEquals(bytes, TEST_DATA);
+            assertArrayEquals(bytes, TEST_DATA);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentNode.java
@@ -18,6 +18,12 @@
  */
 package org.apache.curator.framework.recipes.nodes;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -26,15 +32,12 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class TestPersistentNode extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testQuickSetData() throws Exception
     {
         final byte[] TEST_DATA = "hey".getBytes();
@@ -51,7 +54,7 @@ public class TestPersistentNode extends BaseClassForTests
             try
             {
                 pen.setData(ALT_TEST_DATA);
-                Assert.fail("IllegalStateException should have been thrown");
+                fail("IllegalStateException should have been thrown");
             }
             catch ( IllegalStateException dummy )
             {
@@ -65,7 +68,7 @@ public class TestPersistentNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         final byte[] TEST_DATA = "hey".getBytes();
@@ -79,14 +82,14 @@ public class TestPersistentNode extends BaseClassForTests
             pen = new PersistentNode(client, CreateMode.PERSISTENT, false, "/test", TEST_DATA);
             pen.debugWaitMsForBackgroundBeforeClose.set(timing.forSleepingABit().milliseconds());
             pen.start();
-            Assert.assertTrue(pen.waitForInitialCreate(timing.milliseconds(), TimeUnit.MILLISECONDS));
+            assertTrue(pen.waitForInitialCreate(timing.milliseconds(), TimeUnit.MILLISECONDS));
             client.close(); // cause session to end - force checks that node is persistent
 
             client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
             client.start();
 
             byte[] bytes = client.getData().forPath("/test");
-            Assert.assertEquals(bytes, TEST_DATA);
+            assertEquals(bytes, TEST_DATA);
         }
         finally
         {
@@ -95,7 +98,7 @@ public class TestPersistentNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testQuickClose() throws Exception
     {
         Timing timing = new Timing();
@@ -108,7 +111,7 @@ public class TestPersistentNode extends BaseClassForTests
             pen.start();
             pen.close();
             timing.sleepABit();
-            Assert.assertNull(client.checkExists().forPath("/test/one/two"));
+            assertNull(client.checkExists().forPath("/test/one/two"));
         }
         finally
         {
@@ -117,7 +120,7 @@ public class TestPersistentNode extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testQuickCloseNodeExists() throws Exception
     {
         Timing timing = new Timing();
@@ -132,7 +135,7 @@ public class TestPersistentNode extends BaseClassForTests
             pen.start();
             pen.close();
             timing.sleepABit();
-            Assert.assertNull(client.checkExists().forPath("/test/one/two"));
+            assertNull(client.checkExists().forPath("/test/one/two"));
         }
         finally
         {
@@ -141,7 +144,7 @@ public class TestPersistentNode extends BaseClassForTests
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testEphemeralSequentialWithProtectionReconnection() throws Exception
     {
         Timing timing = new Timing();
@@ -156,14 +159,14 @@ public class TestPersistentNode extends BaseClassForTests
             pen.start();
             List<String> children = client.getChildren().forPath("/test/one");
             System.out.println("children before restart: "+children);
-            Assert.assertEquals(1, children.size());
+            assertEquals(1, children.size());
             server.stop();
             timing.sleepABit();
             server.restart();
             timing.sleepABit();
             List<String> childrenAfter = client.getChildren().forPath("/test/one");
             System.out.println("children after restart: "+childrenAfter);
-            Assert.assertEquals(children, childrenAfter, "unexpected znodes: "+childrenAfter);
+            assertEquals(children, childrenAfter, "unexpected znodes: "+childrenAfter);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentTtlNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentTtlNode.java
@@ -18,20 +18,26 @@
  */
 package org.apache.curator.framework.recipes.nodes;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.ZKPaths;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
@@ -42,12 +48,12 @@ public class TestPersistentTtlNode extends CuratorTestBase
     private final Timing timing = new Timing();
     private final long ttlMs = timing.multiple(.10).milliseconds(); // a small number
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         System.setProperty("zookeeper.extendedTypesEnabled", "true");
     }
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setup() throws Exception
     {
@@ -55,7 +61,7 @@ public class TestPersistentTtlNode extends CuratorTestBase
         super.setup();
     }
 
-    @AfterMethod
+    @AfterEach
     @Override
     public void teardown() throws Exception
     {
@@ -63,7 +69,7 @@ public class TestPersistentTtlNode extends CuratorTestBase
         super.teardown();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -73,22 +79,22 @@ public class TestPersistentTtlNode extends CuratorTestBase
             try (PersistentTtlNode node = new PersistentTtlNode(client, "/test", ttlMs, new byte[0]))
             {
                 node.start();
-                Assert.assertTrue(node.waitForInitialCreate(timing.session(), TimeUnit.MILLISECONDS));
+                assertTrue(node.waitForInitialCreate(timing.session(), TimeUnit.MILLISECONDS));
 
                 for ( int i = 0; i < 5; ++i )
                 {
                     Thread.sleep(ttlMs + (ttlMs / 2));  // sleep a bit more than the TTL
-                    Assert.assertNotNull(client.checkExists().forPath("/test"));
+                    assertNotNull(client.checkExists().forPath("/test"));
                 }
             }
-            Assert.assertNotNull(client.checkExists().forPath("/test"));
+            assertNotNull(client.checkExists().forPath("/test"));
 
             timing.sleepABit();
-            Assert.assertNull(client.checkExists().forPath("/test"));
+            assertNull(client.checkExists().forPath("/test"));
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testForcedDeleteOfTouchNode() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -98,7 +104,7 @@ public class TestPersistentTtlNode extends CuratorTestBase
             try (PersistentTtlNode node = new PersistentTtlNode(client, "/test", ttlMs, new byte[0]))
             {
                 node.start();
-                Assert.assertTrue(node.waitForInitialCreate(timing.session(), TimeUnit.MILLISECONDS));
+                assertTrue(node.waitForInitialCreate(timing.session(), TimeUnit.MILLISECONDS));
 
                 for ( int i = 0; i < 5; ++i )
                 {
@@ -107,12 +113,12 @@ public class TestPersistentTtlNode extends CuratorTestBase
                 }
 
                 timing.sleepABit();
-                Assert.assertNotNull(client.checkExists().forPath("/test"));
+                assertNotNull(client.checkExists().forPath("/test"));
             }
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testEventsOnParent() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -138,23 +144,23 @@ public class TestPersistentTtlNode extends CuratorTestBase
                     cache.getListenable().addListener(listener);
 
                     node.start();
-                    Assert.assertTrue(node.waitForInitialCreate(timing.session(), TimeUnit.MILLISECONDS));
+                    assertTrue(node.waitForInitialCreate(timing.session(), TimeUnit.MILLISECONDS));
                     cache.start(BUILD_INITIAL_CACHE);
 
-                    Assert.assertEquals(changes.availablePermits(), 0);
+                    assertEquals(changes.availablePermits(), 0);
                     timing.sleepABit();
-                    Assert.assertEquals(changes.availablePermits(), 0);
+                    assertEquals(changes.availablePermits(), 0);
 
                     client.setData().forPath("/test", "changed".getBytes());
-                    Assert.assertTrue(timing.acquireSemaphore(changes));
+                    assertTrue(timing.acquireSemaphore(changes));
                     timing.sleepABit();
-                    Assert.assertEquals(changes.availablePermits(), 0);
+                    assertEquals(changes.availablePermits(), 0);
                 }
             }
 
             timing.sleepABit();
 
-            Assert.assertNull(client.checkExists().forPath("/test"));
+            assertNull(client.checkExists().forPath("/test"));
         }
     }
 }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentTtlNode.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/nodes/TestPersistentTtlNode.java
@@ -23,20 +23,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.ZKPaths;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -69,7 +68,7 @@ public class TestPersistentTtlNode extends CuratorTestBase
         super.teardown();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -94,7 +93,7 @@ public class TestPersistentTtlNode extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testForcedDeleteOfTouchNode() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))
@@ -118,7 +117,7 @@ public class TestPersistentTtlNode extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testEventsOnParent() throws Exception
     {
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)))

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestBoundedDistributedQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestBoundedDistributedQueue.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
@@ -33,6 +32,8 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -63,7 +64,7 @@ public class TestBoundedDistributedQueue extends BaseClassForTests
     };
 
     @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void         testMulti() throws Exception
     {
         final String        PATH = "/queue";
@@ -193,7 +194,7 @@ public class TestBoundedDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void         testSimple() throws Exception
     {
         Timing                      timing = new Timing();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestBoundedDistributedQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestBoundedDistributedQueue.java
@@ -18,6 +18,11 @@
  */
 package org.apache.curator.framework.recipes.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
@@ -28,8 +33,6 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -60,7 +63,7 @@ public class TestBoundedDistributedQueue extends BaseClassForTests
     };
 
     @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void         testMulti() throws Exception
     {
         final String        PATH = "/queue";
@@ -180,7 +183,7 @@ public class TestBoundedDistributedQueue extends BaseClassForTests
 
             for ( int count : counts )
             {
-                Assert.assertTrue(count <= (MAX_ITEMS * CLIENT_QTY), counts.toString());
+                assertTrue(count <= (MAX_ITEMS * CLIENT_QTY), counts.toString());
             }
         }
         finally
@@ -190,7 +193,7 @@ public class TestBoundedDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void         testSimple() throws Exception
     {
         Timing                      timing = new Timing();
@@ -235,16 +238,16 @@ public class TestBoundedDistributedQueue extends BaseClassForTests
             };
             queue.getPutListenerContainer().addListener(listener);
 
-            Assert.assertTrue(queue.put("1", timing.milliseconds(), TimeUnit.MILLISECONDS));   // should end up in consumer
-            Assert.assertTrue(queue.put("2", timing.milliseconds(), TimeUnit.MILLISECONDS));   // should sit blocking in DistributedQueue
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(queue.put("1", timing.milliseconds(), TimeUnit.MILLISECONDS));   // should end up in consumer
+            assertTrue(queue.put("2", timing.milliseconds(), TimeUnit.MILLISECONDS));   // should sit blocking in DistributedQueue
+            assertTrue(timing.awaitLatch(latch));
             timing.sleepABit();
-            Assert.assertFalse(queue.put("3", timing.multiple(.5).milliseconds(), TimeUnit.MILLISECONDS));
+            assertFalse(queue.put("3", timing.multiple(.5).milliseconds(), TimeUnit.MILLISECONDS));
 
             semaphore.release(100);
-            Assert.assertTrue(queue.put("3", timing.milliseconds(), TimeUnit.MILLISECONDS));
-            Assert.assertTrue(queue.put("4", timing.milliseconds(), TimeUnit.MILLISECONDS));
-            Assert.assertTrue(queue.put("5", timing.milliseconds(), TimeUnit.MILLISECONDS));
+            assertTrue(queue.put("3", timing.milliseconds(), TimeUnit.MILLISECONDS));
+            assertTrue(queue.put("4", timing.milliseconds(), TimeUnit.MILLISECONDS));
+            assertTrue(queue.put("5", timing.milliseconds(), TimeUnit.MILLISECONDS));
 
             for ( int i = 0; i < 5; ++i )
             {
@@ -256,7 +259,7 @@ public class TestBoundedDistributedQueue extends BaseClassForTests
             }
             timing.sleepABit();
 
-            Assert.assertEquals(messages, Arrays.asList("1", "2", "3", "4", "5"));
+            assertEquals(messages, Arrays.asList("1", "2", "3", "4", "5"));
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedDelayQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedDelayQueue.java
@@ -18,6 +18,12 @@
  */
 package org.apache.curator.framework.recipes.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -26,9 +32,6 @@ import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
 import org.mockito.Mockito;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestDistributedDelayQueue extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testLateAddition() throws Exception
     {
         Timing                          timing = new Timing();
@@ -54,14 +57,14 @@ public class TestDistributedDelayQueue extends BaseClassForTests
 
             queue.put(1L, System.currentTimeMillis() + Integer.MAX_VALUE);  // never come out
             Long        value = consumer.take(1, TimeUnit.SECONDS);
-            Assert.assertNull(value);
+            assertNull(value);
 
             queue.put(2L, System.currentTimeMillis());
             value = consumer.take(timing.seconds(), TimeUnit.SECONDS);
-            Assert.assertEquals(value, Long.valueOf(2));
+            assertEquals(value, Long.valueOf(2));
 
             value = consumer.take(1, TimeUnit.SECONDS);
-            Assert.assertNull(value);
+            assertNull(value);
         }
         finally
         {
@@ -70,7 +73,7 @@ public class TestDistributedDelayQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testBasic() throws Exception
     {
         Timing                          timing = new Timing();
@@ -85,10 +88,10 @@ public class TestDistributedDelayQueue extends BaseClassForTests
 
             queue.put(1L, System.currentTimeMillis() + 1000);
             Thread.sleep(100);
-            Assert.assertEquals(consumer.size(), 0);    // delay hasn't been reached
+            assertEquals(consumer.size(), 0);    // delay hasn't been reached
 
             Long        value = consumer.take(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-            Assert.assertEquals(value, Long.valueOf(1));
+            assertEquals(value, Long.valueOf(1));
         }
         finally
         {
@@ -97,7 +100,7 @@ public class TestDistributedDelayQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSimple() throws Exception
     {
         final int QTY = 10;
@@ -123,8 +126,8 @@ public class TestDistributedDelayQueue extends BaseClassForTests
             for ( int i = 0; i < QTY; ++i )
             {
                 Long        value = consumer.take(timing.forWaiting().seconds(), TimeUnit.SECONDS);
-                Assert.assertNotNull(value);
-                Assert.assertTrue(value >= lastValue);
+                assertNotNull(value);
+                assertTrue(value >= lastValue);
                 lastValue = value;
             }
         }
@@ -135,7 +138,7 @@ public class TestDistributedDelayQueue extends BaseClassForTests
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSorting() throws Exception
     {
         Timing                          timing = new Timing();
@@ -188,8 +191,8 @@ public class TestDistributedDelayQueue extends BaseClassForTests
             for ( int i = 0; i < QTY; ++i )
             {
                 Long value = consumer.take(DELAY_MS * 2, TimeUnit.MILLISECONDS);
-                Assert.assertNotNull(value);
-                Assert.assertEquals(value, new Long(lastValue + 1));
+                assertNotNull(value);
+                assertEquals(value, new Long(lastValue + 1));
                 lastValue = value;
             }
         }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedDelayQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedDelayQueue.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -31,6 +30,7 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestDistributedDelayQueue extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testLateAddition() throws Exception
     {
         Timing                          timing = new Timing();
@@ -73,7 +73,7 @@ public class TestDistributedDelayQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testBasic() throws Exception
     {
         Timing                          timing = new Timing();
@@ -100,7 +100,7 @@ public class TestDistributedDelayQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSimple() throws Exception
     {
         final int QTY = 10;
@@ -138,7 +138,7 @@ public class TestDistributedDelayQueue extends BaseClassForTests
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSorting() throws Exception
     {
         Timing                          timing = new Timing();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedIdQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedIdQueue.java
@@ -21,7 +21,6 @@ package org.apache.curator.framework.recipes.queue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -29,6 +28,7 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryOneTime;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -41,7 +41,7 @@ public class TestDistributedIdQueue extends BaseClassForTests
 
     private static final QueueSerializer<TestQueueItem>  serializer = new QueueItemSerializer();
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeletingWithLock() throws Exception
     {
         DistributedIdQueue<TestQueueItem>  queue = null;
@@ -83,7 +83,7 @@ public class TestDistributedIdQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testOrdering() throws Exception
     {
         final int                   ITEM_QTY = 100;
@@ -126,7 +126,7 @@ public class TestDistributedIdQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRequeuingWithLock() throws Exception
     {
         DistributedIdQueue<TestQueueItem>  queue = null;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedIdQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedIdQueue.java
@@ -18,7 +18,10 @@
  */
 package org.apache.curator.framework.recipes.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -27,8 +30,6 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.mockito.Mockito;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -40,7 +41,7 @@ public class TestDistributedIdQueue extends BaseClassForTests
 
     private static final QueueSerializer<TestQueueItem>  serializer = new QueueItemSerializer();
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDeletingWithLock() throws Exception
     {
         DistributedIdQueue<TestQueueItem>  queue = null;
@@ -70,8 +71,8 @@ public class TestDistributedIdQueue extends BaseClassForTests
 
             queue.put(new TestQueueItem("test"), "id");
             
-            Assert.assertTrue(consumingLatch.await(10, TimeUnit.SECONDS));  // wait until consumer has it
-            Assert.assertEquals(queue.remove("id"), 0);
+            assertTrue(consumingLatch.await(10, TimeUnit.SECONDS));  // wait until consumer has it
+            assertEquals(queue.remove("id"), 0);
 
             waitLatch.countDown();
         }
@@ -82,7 +83,7 @@ public class TestDistributedIdQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testOrdering() throws Exception
     {
         final int                   ITEM_QTY = 100;
@@ -108,14 +109,14 @@ public class TestDistributedIdQueue extends BaseClassForTests
             int                 iteration = 0;
             while ( consumer.size() < ITEM_QTY )
             {
-                Assert.assertTrue(++iteration < ITEM_QTY);
+                assertTrue(++iteration < ITEM_QTY);
                 Thread.sleep(1000);
             }
 
             int                 i = 0;
             for ( TestQueueItem item : consumer.getItems() )
             {
-                Assert.assertEquals(item.str, ids.get(i++));
+                assertEquals(item.str, ids.get(i++));
             }
         }
         finally
@@ -125,7 +126,7 @@ public class TestDistributedIdQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRequeuingWithLock() throws Exception
     {
         DistributedIdQueue<TestQueueItem>  queue = null;
@@ -156,13 +157,13 @@ public class TestDistributedIdQueue extends BaseClassForTests
 
             queue.put(new TestQueueItem("test"), "id");
 
-            Assert.assertTrue(consumingLatch.await(10, TimeUnit.SECONDS));  // wait until consumer has it
+            assertTrue(consumingLatch.await(10, TimeUnit.SECONDS));  // wait until consumer has it
 
             // Sleep one more second
 
             Thread.sleep(1000);
 
-            Assert.assertTrue(queue.debugIsQueued("id"));
+            assertTrue(queue.debugIsQueued("id"));
 
         }
         finally

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedPriorityQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedPriorityQueue.java
@@ -18,6 +18,12 @@
  */
 package org.apache.curator.framework.recipes.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -27,8 +33,6 @@ import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
 import org.mockito.Mockito;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -39,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestDistributedPriorityQueue extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testMinItemsBeforeRefresh() throws Exception
     {
         DistributedPriorityQueue<Integer>   queue = null;
@@ -58,7 +62,7 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
                 queue.put(i, 10 + i);
             }
 
-            Assert.assertEquals(consumer.take(1, TimeUnit.SECONDS), new Integer(0));
+            assertEquals(consumer.take(1, TimeUnit.SECONDS), new Integer(0));
             queue.put(1000, 1); // lower priority
 
             int         count = 0;
@@ -66,7 +70,7 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
             {
                 ++count;
             }
-            Assert.assertTrue(Math.abs(minItemsBeforeRefresh - count) < minItemsBeforeRefresh, String.format("Diff: %d - min: %d", Math.abs(minItemsBeforeRefresh - count), minItemsBeforeRefresh));     // allows for some slack - testing that within a slop value the newly inserted item with lower priority comes out
+            assertTrue(Math.abs(minItemsBeforeRefresh - count) < minItemsBeforeRefresh, String.format("Diff: %d - min: %d", Math.abs(minItemsBeforeRefresh - count), minItemsBeforeRefresh));     // allows for some slack - testing that within a slop value the newly inserted item with lower priority comes out
         }
         finally
         {
@@ -75,7 +79,7 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSortingWhileTaking() throws Exception
     {
         Timing           timing = new Timing();
@@ -106,12 +110,12 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
                 queue.put(i, 10);
             }
 
-            Assert.assertEquals(blockingQueue.poll(timing.seconds(), TimeUnit.SECONDS), new Integer(0));
+            assertEquals(blockingQueue.poll(timing.seconds(), TimeUnit.SECONDS), new Integer(0));
             timing.sleepABit();
             queue.put(1000, 1); // lower priority
             timing.sleepABit();
-            Assert.assertEquals(blockingQueue.poll(timing.seconds(), TimeUnit.SECONDS), new Integer(1)); // is in consumer already
-            Assert.assertEquals(blockingQueue.poll(timing.seconds(), TimeUnit.SECONDS), new Integer(1000));
+            assertEquals(blockingQueue.poll(timing.seconds(), TimeUnit.SECONDS), new Integer(1)); // is in consumer already
+            assertEquals(blockingQueue.poll(timing.seconds(), TimeUnit.SECONDS), new Integer(1000));
         }
         finally
         {
@@ -120,7 +124,7 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testAdditions() throws Exception
     {
         DistributedPriorityQueue<Integer>   queue = null;
@@ -169,7 +173,7 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSimple() throws Exception
     {
         List<Integer>                       nums = new ArrayList<Integer>();
@@ -197,7 +201,7 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
 
             nums.add(Integer.MIN_VALUE);
             queue.put(Integer.MIN_VALUE, Integer.MIN_VALUE);  // the queue background thread will be blocking with the first item - make sure it's the lowest value
-            Assert.assertTrue(timing.awaitLatch(hasConsumedLatch));
+            assertTrue(timing.awaitLatch(hasConsumedLatch));
 
             Random          random = new Random();
             for ( int i = 0; i < 100; ++i )
@@ -222,7 +226,7 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
             {
                 message.append(i).append("\t").append(DistributedPriorityQueue.priorityToString(i)).append("\n");
             }
-            Assert.fail(message.toString());
+            fail(message.toString());
         }
         finally
         {
@@ -237,10 +241,10 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
         for ( int i = 0; i < qty; ++i )
         {
             Integer     value = consumer.take(10, TimeUnit.SECONDS);
-            Assert.assertNotNull(value);
+            assertNotNull(value);
             if ( i > 0 )
             {
-                Assert.assertTrue(value >= previous, String.format("Value: (%d:%s) Previous: (%d:%s)", value, DistributedPriorityQueue.priorityToString(value), previous, DistributedPriorityQueue.priorityToString(previous)));
+                assertTrue(value >= previous, String.format("Value: (%d:%s) Previous: (%d:%s)", value, DistributedPriorityQueue.priorityToString(value), previous, DistributedPriorityQueue.priorityToString(previous)));
             }
             previous = value;
         }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedPriorityQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedPriorityQueue.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -32,6 +31,7 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestDistributedPriorityQueue extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testMinItemsBeforeRefresh() throws Exception
     {
         DistributedPriorityQueue<Integer>   queue = null;
@@ -79,7 +79,7 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSortingWhileTaking() throws Exception
     {
         Timing           timing = new Timing();
@@ -124,7 +124,7 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testAdditions() throws Exception
     {
         DistributedPriorityQueue<Integer>   queue = null;
@@ -173,7 +173,7 @@ public class TestDistributedPriorityQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSimple() throws Exception
     {
         List<Integer>                       nums = new ArrayList<Integer>();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedQueue.java
@@ -18,8 +18,13 @@
  */
 package org.apache.curator.framework.recipes.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -35,8 +40,6 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
 import org.apache.zookeeper.CreateMode;
 import org.mockito.Mockito;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -57,7 +60,7 @@ public class TestDistributedQueue extends BaseClassForTests
 
     private static final QueueSerializer<TestQueueItem>  serializer = new QueueItemSerializer();
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRetryAfterFailure_Curator56() throws Exception
     {
         /*
@@ -107,9 +110,9 @@ public class TestDistributedQueue extends BaseClassForTests
             queue.put(new TestQueueItem("test"));
 
             retryCounter.await(10, TimeUnit.SECONDS);
-            Assert.assertEquals(retryCounter.getCount(), 0, "Queue item was not consumed. Retry counter is " + retryCounter.getCount());
-            Assert.assertEquals(names.size(), 2);
-            Assert.assertEquals(names.get(0).length(), names.get(1).length(), "name1: " + names.get(0) + " - " + "name2: " + names.get(1));
+            assertEquals(retryCounter.getCount(), 0, "Queue item was not consumed. Retry counter is " + retryCounter.getCount());
+            assertEquals(names.size(), 2);
+            assertEquals(names.get(0).length(), names.get(1).length(), "name1: " + names.get(0) + " - " + "name2: " + names.get(1));
         }
         finally
         {
@@ -118,7 +121,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testCustomExecutor() throws Exception
     {
         final int       ITERATIONS = 1000;
@@ -200,9 +203,9 @@ public class TestDistributedQueue extends BaseClassForTests
                 queue.put(Integer.toString(i));
             }
 
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
 
-            Assert.assertTrue(doubleUsed.size() == 0, doubleUsed.toString());
+            assertTrue(doubleUsed.size() == 0, doubleUsed.toString());
         }
         finally
         {
@@ -211,7 +214,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testPutListener() throws Exception
     {
         final int                   itemQty = 10;
@@ -250,17 +253,17 @@ public class TestDistributedQueue extends BaseClassForTests
             int                 iteration = 0;
             while ( consumer.size() < itemQty )
             {
-                Assert.assertTrue(++iteration < 10);
+                assertTrue(++iteration < 10);
                 Thread.sleep(1000);
             }
 
             int                 i = 0;
             for ( TestQueueItem item : consumer.getItems() )
             {
-                Assert.assertEquals(item.str, Integer.toString(i++));
+                assertEquals(item.str, Integer.toString(i++));
             }
             
-            Assert.assertEquals(listenerCalls.get(), itemQty);
+            assertEquals(listenerCalls.get(), itemQty);
         }
         finally
         {
@@ -269,7 +272,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
     
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testErrorMode() throws Exception
     {
         Timing                    timing = new Timing();
@@ -304,8 +307,8 @@ public class TestDistributedQueue extends BaseClassForTests
                 TestQueueItem       item = new TestQueueItem("1");
                 queue.put(item);
 
-                Assert.assertTrue(timing.awaitLatch(latch.get()));
-                Assert.assertEquals(count.get(), 2);
+                assertTrue(timing.awaitLatch(latch.get()));
+                assertEquals(count.get(), 2);
 
                 queue.setErrorMode(ErrorMode.DELETE);
 
@@ -315,8 +318,8 @@ public class TestDistributedQueue extends BaseClassForTests
                 item = new TestQueueItem("1");
                 queue.put(item);
 
-                Assert.assertFalse(latch.get().await(5, TimeUnit.SECONDS)); // consumer should get called only once
-                Assert.assertEquals(count.get(), 1);
+                assertFalse(latch.get().await(5, TimeUnit.SECONDS)); // consumer should get called only once
+                assertEquals(count.get(), 1);
             }
             finally
             {
@@ -329,7 +332,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testNoDuplicateProcessing() throws Exception
     {
         final int                 itemQty = 1000;
@@ -409,7 +412,7 @@ public class TestDistributedQueue extends BaseClassForTests
             }
 
             timing.awaitLatch(latch);
-            Assert.assertTrue(duplicateMessages.size() == 0, duplicateMessages.toString());
+            assertTrue(duplicateMessages.size() == 0, duplicateMessages.toString());
         }
         finally
         {
@@ -424,7 +427,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSafetyWithCrash() throws Exception
     {
         final int                   itemQty = 100;
@@ -530,12 +533,12 @@ public class TestDistributedQueue extends BaseClassForTests
             int                 i = 0;
             for ( TestQueueItem item : takenItems )
             {
-                Assert.assertEquals(item.str, Integer.toString(i++));
+                assertEquals(item.str, Integer.toString(i++));
             }
 
-            Assert.assertNotNull(thrownItemFromConsumer1.get());
-            Assert.assertTrue((takenItemsForConsumer2.contains(thrownItemFromConsumer1.get())));
-            Assert.assertTrue(Sets.intersection(takenItemsForConsumer1, takenItemsForConsumer2).size() == 0);
+            assertNotNull(thrownItemFromConsumer1.get());
+            assertTrue((takenItemsForConsumer2.contains(thrownItemFromConsumer1.get())));
+            assertTrue(Sets.intersection(takenItemsForConsumer1, takenItemsForConsumer2).size() == 0);
         }
         finally
         {
@@ -561,7 +564,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSafetyBasic() throws Exception
     {
         final int                   itemQty = 10;
@@ -593,14 +596,14 @@ public class TestDistributedQueue extends BaseClassForTests
                         for ( int i = 0; i < itemQty; ++i )
                         {
                             TestQueueItem item = consumer.take();
-                            Assert.assertEquals(item.str, Integer.toString(i));
+                            assertEquals(item.str, Integer.toString(i));
                         }
                         latch.countDown();
                         return null;
                     }
                 }
             );
-            Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
         }
         finally
         {
@@ -609,7 +612,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testPutMulti() throws Exception
     {
         final int                   itemQty = 100;
@@ -643,8 +646,8 @@ public class TestDistributedQueue extends BaseClassForTests
             for ( int i = 0; i < itemQty; ++i )
             {
                 TestQueueItem   queueItem = consumer.take(1, TimeUnit.SECONDS);
-                Assert.assertNotNull(queueItem);
-                Assert.assertEquals(queueItem, new TestQueueItem(Integer.toString(i)));
+                assertNotNull(queueItem);
+                assertEquals(queueItem, new TestQueueItem(Integer.toString(i)));
             }
         }
         finally
@@ -654,7 +657,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testMultiPutterSingleGetter() throws Exception
     {
         final int                   itemQty = 100;
@@ -679,13 +682,13 @@ public class TestDistributedQueue extends BaseClassForTests
             int                 iteration = 0;
             while ( consumer.size() < itemQty )
             {
-                Assert.assertTrue(++iteration < 10);
+                assertTrue(++iteration < 10);
                 Thread.sleep(1000);
             }
 
             List<TestQueueItem> items = consumer.getItems();
 
-            Assert.assertEquals(com.google.common.collect.Sets.<TestQueueItem>newHashSet(items).size(), items.size()); // check no duplicates
+            assertEquals(com.google.common.collect.Sets.<TestQueueItem>newHashSet(items).size(), items.size()); // check no duplicates
         }
         finally
         {
@@ -694,7 +697,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testFlush() throws Exception
     {
         final Timing                      timing = new Timing();
@@ -736,10 +739,10 @@ public class TestDistributedQueue extends BaseClassForTests
             queue.start();
 
             queue.put(new TestQueueItem("1"));
-            Assert.assertFalse(queue.flushPuts(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+            assertFalse(queue.flushPuts(timing.forWaiting().seconds(), TimeUnit.SECONDS));
             latch.countDown();
 
-            Assert.assertTrue(queue.flushPuts(timing.forWaiting().seconds(), TimeUnit.SECONDS));
+            assertTrue(queue.flushPuts(timing.forWaiting().seconds(), TimeUnit.SECONDS));
         }
         finally
         {
@@ -753,7 +756,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSimple() throws Exception
     {
         final int                   itemQty = 10;
@@ -776,14 +779,14 @@ public class TestDistributedQueue extends BaseClassForTests
             int                 iteration = 0;
             while ( consumer.size() < itemQty )
             {
-                Assert.assertTrue(++iteration < 10);
+                assertTrue(++iteration < 10);
                 Thread.sleep(1000);
             }
 
             int                 i = 0;
             for ( TestQueueItem item : consumer.getItems() )
             {
-                Assert.assertEquals(item.str, Integer.toString(i++));
+                assertEquals(item.str, Integer.toString(i++));
             }
         }
         finally

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestDistributedQueue.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -39,6 +38,7 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.Timing;
 import org.apache.zookeeper.CreateMode;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,7 +60,7 @@ public class TestDistributedQueue extends BaseClassForTests
 
     private static final QueueSerializer<TestQueueItem>  serializer = new QueueItemSerializer();
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRetryAfterFailure_Curator56() throws Exception
     {
         /*
@@ -121,7 +121,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testCustomExecutor() throws Exception
     {
         final int       ITERATIONS = 1000;
@@ -214,7 +214,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testPutListener() throws Exception
     {
         final int                   itemQty = 10;
@@ -272,7 +272,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
     
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testErrorMode() throws Exception
     {
         Timing                    timing = new Timing();
@@ -332,7 +332,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testNoDuplicateProcessing() throws Exception
     {
         final int                 itemQty = 1000;
@@ -427,7 +427,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSafetyWithCrash() throws Exception
     {
         final int                   itemQty = 100;
@@ -564,7 +564,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSafetyBasic() throws Exception
     {
         final int                   itemQty = 10;
@@ -612,7 +612,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testPutMulti() throws Exception
     {
         final int                   itemQty = 100;
@@ -657,7 +657,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testMultiPutterSingleGetter() throws Exception
     {
         final int                   itemQty = 100;
@@ -697,7 +697,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testFlush() throws Exception
     {
         final Timing                      timing = new Timing();
@@ -756,7 +756,7 @@ public class TestDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSimple() throws Exception
     {
         final int                   itemQty = 10;

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestQueueSharder.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestQueueSharder.java
@@ -18,7 +18,11 @@
  */
 package org.apache.curator.framework.recipes.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Sets;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.commons.math.stat.descriptive.SummaryStatistics;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -28,15 +32,13 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class TestQueueSharder extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testDistribution() throws Exception
     {
         final int               threshold = 100;
@@ -79,13 +81,13 @@ public class TestQueueSharder extends BaseClassForTests
             for ( String path : sharder.getQueuePaths() )
             {
                 int numChildren = client.checkExists().forPath(path).getNumChildren();
-                Assert.assertTrue(numChildren > 0);
-                Assert.assertTrue(numChildren >= (threshold * .1));
+                assertTrue(numChildren > 0);
+                assertTrue(numChildren >= (threshold * .1));
                 statistics.addValue(numChildren);
             }
             latch.countDown();
 
-            Assert.assertTrue(statistics.getMean() >= (threshold * .9));
+            assertTrue(statistics.getMean() >= (threshold * .9));
         }
         finally
         {
@@ -95,7 +97,7 @@ public class TestQueueSharder extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSharderWatchSync() throws Exception
     {
         Timing                  timing = new Timing();
@@ -119,9 +121,9 @@ public class TestQueueSharder extends BaseClassForTests
             }
             timing.sleepABit();
 
-            Assert.assertTrue((sharder1.getShardQty() > 1) || (sharder2.getShardQty() > 1));
+            assertTrue((sharder1.getShardQty() > 1) || (sharder2.getShardQty() > 1));
             timing.forWaiting().sleepABit();
-            Assert.assertEquals(sharder1.getShardQty(), sharder2.getShardQty());
+            assertEquals(sharder1.getShardQty(), sharder2.getShardQty());
         }
         finally
         {
@@ -132,7 +134,7 @@ public class TestQueueSharder extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void     testSimpleDistributedQueue() throws Exception
     {
         Timing                  timing = new Timing();
@@ -160,17 +162,17 @@ public class TestQueueSharder extends BaseClassForTests
             sharder.getQueue().put("eight");
             timing.sleepABit();
 
-            Assert.assertTrue(sharder.getShardQty() > 1);
+            assertTrue(sharder.getShardQty() > 1);
 
             Set<String>             consumed = Sets.newHashSet();
             for ( int i = 0; i < 8; ++i )
             {
                 String s = consumer.take(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS);
-                Assert.assertNotNull(s);
+                assertNotNull(s);
                 consumed.add(s);
             }
 
-            Assert.assertEquals(consumed, Sets.newHashSet("one", "two", "three", "four", "five", "six", "seven", "eight"));
+            assertEquals(consumed, Sets.newHashSet("one", "two", "three", "four", "five", "six", "seven", "eight"));
 
             int         shardQty = sharder.getShardQty();
             sharder.close();
@@ -179,7 +181,7 @@ public class TestQueueSharder extends BaseClassForTests
 
             sharder = new QueueSharder<String, DistributedQueue<String>>(client, distributedQueueAllocator, "/queues", "/leader", policies);
             sharder.start();
-            Assert.assertEquals(sharder.getShardQty(), shardQty);
+            assertEquals(sharder.getShardQty(), shardQty);
         }
         finally
         {

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestQueueSharder.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestQueueSharder.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Sets;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.commons.math.stat.descriptive.SummaryStatistics;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -32,13 +31,15 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
+import org.junit.jupiter.api.Test;
+
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class TestQueueSharder extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testDistribution() throws Exception
     {
         final int               threshold = 100;
@@ -97,7 +98,7 @@ public class TestQueueSharder extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSharderWatchSync() throws Exception
     {
         Timing                  timing = new Timing();
@@ -134,7 +135,7 @@ public class TestQueueSharder extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void     testSimpleDistributedQueue() throws Exception
     {
         Timing                  timing = new Timing();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestSimpleDistributedQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestSimpleDistributedQueue.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
@@ -30,6 +29,8 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
+import org.junit.jupiter.api.Test;
+
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -71,7 +72,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         protected abstract void processItem(int itemNumber) throws Exception;
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testHangFromContainerLoss() throws Exception
     {
         // for CURATOR-308
@@ -122,7 +123,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPollWithTimeout() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -147,7 +148,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testOffer1() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -176,7 +177,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testOffer2() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -205,7 +206,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testTake1() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -234,7 +235,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemova1() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -302,13 +303,13 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemove2() throws Exception
     {
         createNremoveMtest("/testRemove2", 10, 2);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRemove3() throws Exception
     {
         createNremoveMtest("/testRemove3", 1000, 1000);
@@ -348,31 +349,31 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testElement1() throws Exception
     {
         createNremoveMelementTest("/testElement1", 1, 0);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testElement2() throws Exception
     {
         createNremoveMelementTest("/testElement2", 10, 2);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testElement3() throws Exception
     {
         createNremoveMelementTest("/testElement3", 1000, 500);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testElement4() throws Exception
     {
         createNremoveMelementTest("/testElement4", 1000, 1000 - 1);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testTakeWait1() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -436,7 +437,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testTakeWait2() throws Exception
     {
         String dir = "/testTakeWait2";

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestSimpleDistributedQueue.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/queue/TestSimpleDistributedQueue.java
@@ -18,6 +18,11 @@
  */
 package org.apache.curator.framework.recipes.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
@@ -25,15 +30,10 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestSimpleDistributedQueue extends BaseClassForTests
 {
@@ -71,7 +71,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         protected abstract void processItem(int itemNumber) throws Exception;
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testHangFromContainerLoss() throws Exception
     {
         // for CURATOR-308
@@ -113,7 +113,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
             });
 
             executor.shutdown();
-            Assert.assertTrue(executor.awaitTermination((QueueUser.ITEM_COUNT * 2) * timing.milliseconds(), TimeUnit.MILLISECONDS));
+            assertTrue(executor.awaitTermination((QueueUser.ITEM_COUNT * 2) * timing.milliseconds(), TimeUnit.MILLISECONDS));
         }
         finally
         {
@@ -122,7 +122,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testPollWithTimeout() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -139,7 +139,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
                 queueHandles[i] = new SimpleDistributedQueue(clients[i], dir);
             }
 
-            Assert.assertNull(queueHandles[0].poll(3, TimeUnit.SECONDS));
+            assertNull(queueHandles[0].poll(3, TimeUnit.SECONDS));
         }
         finally
         {
@@ -147,7 +147,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testOffer1() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -176,7 +176,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testOffer2() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -205,7 +205,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testTake1() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -234,7 +234,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemova1() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -302,13 +302,13 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemove2() throws Exception
     {
         createNremoveMtest("/testRemove2", 10, 2);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRemove3() throws Exception
     {
         createNremoveMtest("/testRemove3", 1000, 1000);
@@ -348,31 +348,31 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testElement1() throws Exception
     {
         createNremoveMelementTest("/testElement1", 1, 0);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testElement2() throws Exception
     {
         createNremoveMelementTest("/testElement2", 10, 2);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testElement3() throws Exception
     {
         createNremoveMelementTest("/testElement3", 1000, 500);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testElement4() throws Exception
     {
         createNremoveMelementTest("/testElement4", 1000, 1000 - 1);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testTakeWait1() throws Exception
     {
         CuratorFramework clients[] = null;
@@ -436,7 +436,7 @@ public class TestSimpleDistributedQueue extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testTakeWait2() throws Exception
     {
         String dir = "/testTakeWait2";

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/shared/TestSharedCount.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/shared/TestSharedCount.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -34,11 +33,12 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.WatchedEvent;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
@@ -54,7 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestSharedCount extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMultiClients() throws Exception
     {
         final int CLIENT_QTY = 5;
@@ -165,7 +165,7 @@ public class TestSharedCount extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSimple() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -209,7 +209,7 @@ public class TestSharedCount extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSimpleVersioned() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -254,7 +254,7 @@ public class TestSharedCount extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMultiClientVersioned() throws Exception
     {
         Timing timing = new Timing();
@@ -311,7 +311,7 @@ public class TestSharedCount extends CuratorTestBase
     }
 
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMultiClientDifferentSeed() throws Exception
     {
         CuratorFramework client1 = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -338,7 +338,7 @@ public class TestSharedCount extends CuratorTestBase
     }
 
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDisconnectEventOnWatcherDoesNotRetry() throws Exception
     {
         final CountDownLatch gotSuspendEvent = new CountDownLatch(1);
@@ -372,7 +372,7 @@ public class TestSharedCount extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDisconnectReconnectEventDoesNotFireValueWatcher() throws Exception
     {
         final CountDownLatch gotSuspendEvent = new CountDownLatch(1);
@@ -441,7 +441,7 @@ public class TestSharedCount extends CuratorTestBase
     }
 
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDisconnectReconnectWithMultipleClients() throws Exception
     {
         Timing timing = new Timing();

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/shared/TestSharedCount.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/shared/TestSharedCount.java
@@ -19,8 +19,12 @@
 
 package org.apache.curator.framework.recipes.shared;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.BackgroundCallback;
@@ -30,12 +34,11 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.WatchedEvent;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
@@ -51,7 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestSharedCount extends CuratorTestBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testMultiClients() throws Exception
     {
         final int CLIENT_QTY = 5;
@@ -123,7 +126,7 @@ public class TestSharedCount extends CuratorTestBase
             client.start();
             client.checkExists().forPath("/");  // clear initial connect event
 
-            Assert.assertTrue(startLatch.await(10, TimeUnit.SECONDS));
+            assertTrue(startLatch.await(10, TimeUnit.SECONDS));
 
             SharedCount count = new SharedCount(client, "/count", 10);
             counts.add(count);
@@ -139,14 +142,14 @@ public class TestSharedCount extends CuratorTestBase
                 countList.add(next);
                 count.setCount(next);
 
-                Assert.assertTrue(semaphore.tryAcquire(CLIENT_QTY, 10, TimeUnit.SECONDS));
+                assertTrue(semaphore.tryAcquire(CLIENT_QTY, 10, TimeUnit.SECONDS));
             }
             count.setCount(-1);
 
             for ( Future<List<Integer>> future : futures )
             {
                 List<Integer> thisCountList = future.get();
-                Assert.assertEquals(thisCountList, countList);
+                assertEquals(thisCountList, countList);
             }
         }
         finally
@@ -162,7 +165,7 @@ public class TestSharedCount extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSimple() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -189,15 +192,15 @@ public class TestSharedCount extends CuratorTestBase
             };
             count.addListener(listener);
 
-            Assert.assertTrue(count.trySetCount(1));
+            assertTrue(count.trySetCount(1));
             timing.sleepABit();
-            Assert.assertTrue(count.trySetCount(2));
+            assertTrue(count.trySetCount(2));
             timing.sleepABit();
-            Assert.assertTrue(count.trySetCount(10));
+            assertTrue(count.trySetCount(10));
             timing.sleepABit();
-            Assert.assertEquals(count.getCount(), 10);
+            assertEquals(count.getCount(), 10);
 
-            Assert.assertTrue(new Timing().awaitLatch(setLatch));
+            assertTrue(new Timing().awaitLatch(setLatch));
         }
         finally
         {
@@ -206,7 +209,7 @@ public class TestSharedCount extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSimpleVersioned() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -217,32 +220,32 @@ public class TestSharedCount extends CuratorTestBase
             count.start();
 
             VersionedValue<Integer> current = count.getVersionedValue();
-            Assert.assertEquals(current.getVersion(), 0);
+            assertEquals(current.getVersion(), 0);
 
-            Assert.assertTrue(count.trySetCount(current, 1));
+            assertTrue(count.trySetCount(current, 1));
             current = count.getVersionedValue();
-            Assert.assertEquals(current.getVersion(), 1);
-            Assert.assertEquals(count.getCount(), 1);
+            assertEquals(current.getVersion(), 1);
+            assertEquals(count.getCount(), 1);
 
-            Assert.assertTrue(count.trySetCount(current, 5));
+            assertTrue(count.trySetCount(current, 5));
             current = count.getVersionedValue();
-            Assert.assertEquals(current.getVersion(), 2);
-            Assert.assertEquals(count.getCount(), 5);
+            assertEquals(current.getVersion(), 2);
+            assertEquals(count.getCount(), 5);
 
-            Assert.assertTrue(count.trySetCount(current, 10));
+            assertTrue(count.trySetCount(current, 10));
 
             current = count.getVersionedValue();
-            Assert.assertEquals(current.getVersion(), 3);
-            Assert.assertEquals(count.getCount(), 10);
+            assertEquals(current.getVersion(), 3);
+            assertEquals(count.getCount(), 10);
 
             // Wrong value
-            Assert.assertFalse(count.trySetCount(new VersionedValue<Integer>(3, 20), 7));
+            assertFalse(count.trySetCount(new VersionedValue<Integer>(3, 20), 7));
             // Wrong version
-            Assert.assertFalse(count.trySetCount(new VersionedValue<Integer>(10, 10), 7));
+            assertFalse(count.trySetCount(new VersionedValue<Integer>(10, 10), 7));
 
             // Server changed
             client.setData().forPath("/count", SharedCount.toBytes(88));
-            Assert.assertFalse(count.trySetCount(current, 234));
+            assertFalse(count.trySetCount(current, 234));
         }
         finally
         {
@@ -251,7 +254,7 @@ public class TestSharedCount extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testMultiClientVersioned() throws Exception
     {
         Timing timing = new Timing();
@@ -267,10 +270,10 @@ public class TestSharedCount extends CuratorTestBase
             count2.start();
 
             VersionedValue<Integer> versionedValue = count1.getVersionedValue();
-            Assert.assertTrue(count1.trySetCount(versionedValue, 10));
+            assertTrue(count1.trySetCount(versionedValue, 10));
             timing.sleepABit();
             versionedValue = count2.getVersionedValue();
-            Assert.assertTrue(count2.trySetCount(versionedValue, 20));
+            assertTrue(count2.trySetCount(versionedValue, 20));
             timing.sleepABit();
 
             final CountDownLatch setLatch = new CountDownLatch(2);
@@ -291,12 +294,12 @@ public class TestSharedCount extends CuratorTestBase
             count1.addListener(listener);
             VersionedValue<Integer> versionedValue1 = count1.getVersionedValue();
             VersionedValue<Integer> versionedValue2 = count2.getVersionedValue();
-            Assert.assertTrue(count2.trySetCount(versionedValue2, 30));
-            Assert.assertFalse(count1.trySetCount(versionedValue1, 40));
+            assertTrue(count2.trySetCount(versionedValue2, 30));
+            assertFalse(count1.trySetCount(versionedValue1, 40));
 
             versionedValue1 = count1.getVersionedValue();
-            Assert.assertTrue(count1.trySetCount(versionedValue1, 40));
-            Assert.assertTrue(timing.awaitLatch(setLatch));
+            assertTrue(count1.trySetCount(versionedValue1, 40));
+            assertTrue(timing.awaitLatch(setLatch));
         }
         finally
         {
@@ -308,7 +311,7 @@ public class TestSharedCount extends CuratorTestBase
     }
 
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testMultiClientDifferentSeed() throws Exception
     {
         CuratorFramework client1 = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -322,8 +325,8 @@ public class TestSharedCount extends CuratorTestBase
             count1.start();
             count2.start();
 
-            Assert.assertEquals(count1.getCount(), 10);
-            Assert.assertEquals(count2.getCount(), 10);
+            assertEquals(count1.getCount(), 10);
+            assertEquals(count2.getCount(), 10);
         }
         finally
         {
@@ -335,7 +338,7 @@ public class TestSharedCount extends CuratorTestBase
     }
 
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDisconnectEventOnWatcherDoesNotRetry() throws Exception
     {
         final CountDownLatch gotSuspendEvent = new CountDownLatch(1);
@@ -360,7 +363,7 @@ public class TestSharedCount extends CuratorTestBase
         {
             server.stop();
             // if watcher goes into 10second retry loop we won't get timely notification
-            Assert.assertTrue(gotSuspendEvent.await(5, TimeUnit.SECONDS));
+            assertTrue(gotSuspendEvent.await(5, TimeUnit.SECONDS));
         }
         finally
         {
@@ -369,7 +372,7 @@ public class TestSharedCount extends CuratorTestBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDisconnectReconnectEventDoesNotFireValueWatcher() throws Exception
     {
         final CountDownLatch gotSuspendEvent = new CountDownLatch(1);
@@ -405,14 +408,14 @@ public class TestSharedCount extends CuratorTestBase
         try
         {
             sharedCount.setCount(11);
-            Assert.assertTrue(gotChangeEvent.await(2, TimeUnit.SECONDS));
+            assertTrue(gotChangeEvent.await(2, TimeUnit.SECONDS));
 
             server.stop();
-            Assert.assertTrue(gotSuspendEvent.await(2, TimeUnit.SECONDS));
+            assertTrue(gotSuspendEvent.await(2, TimeUnit.SECONDS));
 
             server.restart();
-            Assert.assertTrue(getReconnectEvent.await(2, TimeUnit.SECONDS));
-            Assert.assertEquals(numChangeEvents.get(), 1);
+            assertTrue(getReconnectEvent.await(2, TimeUnit.SECONDS));
+            assertEquals(numChangeEvents.get(), 1);
 
             sharedCount.trySetCount(sharedCount.getVersionedValue(), 12);
 
@@ -428,7 +431,7 @@ public class TestSharedCount extends CuratorTestBase
 
             // CURATOR-311: when a Curator client's state became RECONNECTED, countHasChanged method is called back
             // because the Curator client calls readValueAndNotifyListenersInBackground in SharedValue#ConnectionStateListener#stateChanged.
-            Assert.assertTrue(numChangeEvents.get() > 2);
+            assertTrue(numChangeEvents.get() > 2);
         }
         finally
         {
@@ -438,7 +441,7 @@ public class TestSharedCount extends CuratorTestBase
     }
 
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDisconnectReconnectWithMultipleClients() throws Exception
     {
         Timing timing = new Timing();
@@ -489,24 +492,24 @@ public class TestSharedCount extends CuratorTestBase
         try
         {
             sharedCount1.setCount(12);
-            Assert.assertEquals(listener1.gotChangeEvent.awaitAdvanceInterruptibly(0, timing.seconds(), TimeUnit.SECONDS), 1);
-            Assert.assertEquals(sharedCount1.getCount(), 12);
+            assertEquals(listener1.gotChangeEvent.awaitAdvanceInterruptibly(0, timing.seconds(), TimeUnit.SECONDS), 1);
+            assertEquals(sharedCount1.getCount(), 12);
 
-            Assert.assertEquals(sharedCountWithFaultyWatcher.getCount(), 10);
+            assertEquals(sharedCountWithFaultyWatcher.getCount(), 10);
             // new counter with faultyWatcher start
             sharedCountWithFaultyWatcher.start();
 
             for (int i = 0; i < 10; i++) {
                 sharedCount1.setCount(13 + i);
-                Assert.assertEquals(sharedCount1.getCount(), 13 + i);
+                assertEquals(sharedCount1.getCount(), 13 + i);
 
                 server.restart();
 
-                Assert.assertEquals(listener2.getReconnectEvent.awaitAdvanceInterruptibly(i, timing.forWaiting().seconds(), TimeUnit.SECONDS), i + 1);
+                assertEquals(listener2.getReconnectEvent.awaitAdvanceInterruptibly(i, timing.forWaiting().seconds(), TimeUnit.SECONDS), i + 1);
                 // CURATOR-311 introduces to Curator's client reading server's shared count value
                 // when client's state gets ConnectionState.RECONNECTED. Following tests ensures that.
-                Assert.assertEquals(listener2.gotChangeEvent.awaitAdvanceInterruptibly(i, timing.forWaiting().seconds(), TimeUnit.SECONDS), i + 1);
-                Assert.assertEquals(sharedCountWithFaultyWatcher.getCount(), 13 + i);
+                assertEquals(listener2.gotChangeEvent.awaitAdvanceInterruptibly(i, timing.forWaiting().seconds(), TimeUnit.SECONDS), i + 1);
+                assertEquals(sharedCountWithFaultyWatcher.getCount(), 13 + i);
             }
         }
         finally

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/watch/TestPersistentWatcher.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/watch/TestPersistentWatcher.java
@@ -22,16 +22,16 @@ package org.apache.curator.framework.recipes.watch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -39,13 +39,13 @@ import java.util.concurrent.LinkedBlockingQueue;
 @Tag(CuratorTestBase.zk36Group)
 public class TestPersistentWatcher extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConnectionLostRecursive() throws Exception
     {
         internalTest(true);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConnectionLost() throws Exception
     {
         internalTest(false);

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/watch/TestPersistentWatcher.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/watch/TestPersistentWatcher.java
@@ -19,29 +19,33 @@
 
 package org.apache.curator.framework.recipes.watch;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 
-@Test(groups = CuratorTestBase.zk36Group)
+@Tag(CuratorTestBase.zk36Group)
 public class TestPersistentWatcher extends CuratorTestBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testConnectionLostRecursive() throws Exception
     {
         internalTest(true);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testConnectionLost() throws Exception
     {
         internalTest(false);
@@ -73,22 +77,22 @@ public class TestPersistentWatcher extends CuratorTestBase
                 persistentWatcher.getListenable().addListener(events::add);
 
                 client.create().creatingParentsIfNeeded().forPath("/top/main/a");
-                Assert.assertEquals(timing.takeFromQueue(events).getPath(), "/top/main");
+                assertEquals(timing.takeFromQueue(events).getPath(), "/top/main");
                 if ( recursive )
                 {
-                    Assert.assertEquals(timing.takeFromQueue(events).getPath(), "/top/main/a");
+                    assertEquals(timing.takeFromQueue(events).getPath(), "/top/main/a");
                 }
                 else
                 {
-                    Assert.assertEquals(timing.takeFromQueue(events).getPath(), "/top/main");   // child added
+                    assertEquals(timing.takeFromQueue(events).getPath(), "/top/main");   // child added
                 }
 
                 server.stop();
-                Assert.assertEquals(timing.takeFromQueue(events).getState(), Watcher.Event.KeeperState.Disconnected);
-                Assert.assertTrue(timing.awaitLatch(lostLatch));
+                assertEquals(timing.takeFromQueue(events).getState(), Watcher.Event.KeeperState.Disconnected);
+                assertTrue(timing.awaitLatch(lostLatch));
 
                 server.restart();
-                Assert.assertTrue(timing.awaitLatch(reconnectedLatch));
+                assertTrue(timing.awaitLatch(reconnectedLatch));
 
                 timing.sleepABit();     // time to allow watcher to get reset
                 events.clear();
@@ -96,10 +100,10 @@ public class TestPersistentWatcher extends CuratorTestBase
                 if ( recursive )
                 {
                     client.setData().forPath("/top/main/a", "foo".getBytes());
-                    Assert.assertEquals(timing.takeFromQueue(events).getType(), Watcher.Event.EventType.NodeDataChanged);
+                    assertEquals(timing.takeFromQueue(events).getType(), Watcher.Event.EventType.NodeDataChanged);
                 }
                 client.setData().forPath("/top/main", "bar".getBytes());
-                Assert.assertEquals(timing.takeFromQueue(events).getPath(), "/top/main");
+                assertEquals(timing.takeFromQueue(events).getPath(), "/top/main");
             }
         }
     }

--- a/curator-test-zk35/pom.xml
+++ b/curator-test-zk35/pom.xml
@@ -131,6 +131,31 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson-version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/curator-test-zk35/pom.xml
+++ b/curator-test-zk35/pom.xml
@@ -137,12 +137,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.artsok</groupId>
-            <artifactId>rerunner-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>

--- a/curator-test-zk35/pom.xml
+++ b/curator-test-zk35/pom.xml
@@ -131,8 +131,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.artsok</groupId>
+            <artifactId>rerunner-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/curator-test-zk35/src/test/java/org/apache/curator/framework/TestCompatibility.java
+++ b/curator-test-zk35/src/test/java/org/apache/curator/framework/TestCompatibility.java
@@ -19,15 +19,14 @@
 package org.apache.curator.framework;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.junit.jupiter.api.Test;
 
 public class TestCompatibility extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPersistentWatchesNotAvailable()
     {
         assertThrows(IllegalStateException.class, ()-> {
@@ -38,7 +37,7 @@ public class TestCompatibility extends CuratorTestBase
         });
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPersistentWatchesNotAvailableAsync()
     {
         assertThrows(IllegalStateException.class, ()->{

--- a/curator-test-zk35/src/test/java/org/apache/curator/framework/TestCompatibility.java
+++ b/curator-test-zk35/src/test/java/org/apache/curator/framework/TestCompatibility.java
@@ -18,32 +18,37 @@
  */
 package org.apache.curator.framework;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.x.async.AsyncCuratorFramework;
-import org.testng.annotations.Test;
 
 public class TestCompatibility extends CuratorTestBase
 {
-    @Test(expectedExceptions = IllegalStateException.class)
-    public void testPersistentWatchesNotAvailable() throws Exception
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    public void testPersistentWatchesNotAvailable()
     {
-        try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
-        {
-            client.start();
-            client.watchers().add().forPath("/foo");
-        }
+        assertThrows(IllegalStateException.class, ()-> {
+            try (CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1))) {
+                client.start();
+                client.watchers().add().forPath("/foo");
+            }
+        });
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testPersistentWatchesNotAvailableAsync()
     {
-        try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
-        {
-            client.start();
+        assertThrows(IllegalStateException.class, ()->{
+            try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
+            {
+                client.start();
 
-            AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
-            async.addWatch().forPath("/foo");
-        }
+                AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
+                async.addWatch().forPath("/foo");
+            }
+        });
     }
 }

--- a/curator-test-zk35/src/test/java/org/apache/curator/zk35/TestIs35.java
+++ b/curator-test-zk35/src/test/java/org/apache/curator/zk35/TestIs35.java
@@ -18,18 +18,19 @@
  */
 package org.apache.curator.zk35;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.curator.utils.Compatibility;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestIs35
 {
     @Test
     public void testIsZk35()
     {
-        Assert.assertFalse(Compatibility.hasGetReachableOrOneMethod());
-        Assert.assertTrue(Compatibility.hasAddrField());
-        Assert.assertFalse(Compatibility.hasPersistentWatchers());
+        assertFalse(Compatibility.hasGetReachableOrOneMethod());
+        assertTrue(Compatibility.hasAddrField());
+        assertFalse(Compatibility.hasPersistentWatchers());
     }
 }
 

--- a/curator-test/pom.xml
+++ b/curator-test/pom.xml
@@ -56,12 +56,11 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>provided</scope>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
         </dependency>
 
-	    <dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
@@ -106,6 +105,16 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <threadCount>1</threadCount>
+                    <reuseForks>false</reuseForks>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/curator-test/src/main/java/org/apache/curator/test/BaseClassForTests.java
+++ b/curator-test/src/main/java/org/apache/curator/test/BaseClassForTests.java
@@ -38,8 +38,6 @@ public class BaseClassForTests
     private static final String INTERNAL_PROPERTY_REMOVE_WATCHERS_IN_FOREGROUND;
     private static final String INTERNAL_PROPERTY_VALIDATE_NAMESPACE_WATCHER_MAP_EMPTY;
 
-    protected static final int REPEATS = 2;
-
     static
     {
         String logConnectionIssues = null;

--- a/curator-test/src/test/java/org/apache/curator/test/TestQuorumConfigBuilder.java
+++ b/curator-test/src/test/java/org/apache/curator/test/TestQuorumConfigBuilder.java
@@ -20,10 +20,10 @@
 
 package org.apache.curator.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashMap;
 import java.util.Map;
-import static org.testng.AssertJUnit.assertEquals;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test QuorumConfigBuilder

--- a/curator-x-async/pom.xml
+++ b/curator-x-async/pom.xml
@@ -44,12 +44,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.artsok</groupId>
-            <artifactId>rerunner-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>

--- a/curator-x-async/pom.xml
+++ b/curator-x-async/pom.xml
@@ -38,8 +38,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.artsok</groupId>
+            <artifactId>rerunner-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestAddWatch.java
+++ b/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestAddWatch.java
@@ -18,22 +18,24 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.ZookeeperFactory;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.AddWatchMode;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.concurrent.CountDownLatch;
 
 public class TestAddWatch extends CuratorTestBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testPersistentRecursiveWatch() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -52,11 +54,11 @@ public class TestAddWatch extends CuratorTestBase
             client.create().forPath("/test/a/b/c");
             client.create().forPath("/test/a/b/c/d");
 
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testPersistentRecursiveDefaultWatch() throws Exception
     {
         CountDownLatch latch = new CountDownLatch(6);   // 5 creates plus the initial sync
@@ -81,7 +83,7 @@ public class TestAddWatch extends CuratorTestBase
             client.create().forPath("/test/a/b/c");
             client.create().forPath("/test/a/b/c/d");
 
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
         }
     }
 }

--- a/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestAddWatch.java
+++ b/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestAddWatch.java
@@ -20,22 +20,22 @@ package org.apache.curator.framework.imps;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.ZookeeperFactory;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.AddWatchMode;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 
 public class TestAddWatch extends CuratorTestBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPersistentRecursiveWatch() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -58,7 +58,7 @@ public class TestAddWatch extends CuratorTestBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPersistentRecursiveDefaultWatch() throws Exception
     {
         CountDownLatch latch = new CountDownLatch(6);   // 5 creates plus the initial sync

--- a/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFramework.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.AuthInfo;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -50,6 +49,8 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -80,7 +81,7 @@ public class TestFramework extends BaseClassForTests
         super.teardown();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testQuietDelete() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -115,7 +116,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNamespaceWithWatcher() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -148,7 +149,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateACLSingleAuth() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -207,7 +208,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateACLMultipleAuths() throws Exception
     {
         // Add a few authInfos
@@ -289,7 +290,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateACLWithReset() throws Exception
     {
         Timing timing = new Timing();
@@ -348,7 +349,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateParents() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -371,7 +372,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateParentContainers() throws Exception
     {
         if ( !checkForContainers() )
@@ -402,7 +403,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateWithProtection() throws ExecutionException, InterruptedException
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -432,7 +433,7 @@ public class TestFramework extends BaseClassForTests
         return true;
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreatingParentsTheSame() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -459,7 +460,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testExistsCreatingParents() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -480,7 +481,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSyncNew() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -506,7 +507,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackgroundDelete() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -532,7 +533,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackgroundDeleteWithChildren() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -568,7 +569,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDeleteGuaranteedWithChildren() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -589,7 +590,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGetSequentialChildren() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -615,7 +616,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackgroundGetDataWithWatch() throws Exception
     {
         final byte[] data1 = {1, 2, 3};

--- a/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFramework.java
@@ -18,7 +18,14 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.AuthInfo;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -41,10 +48,8 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -59,7 +64,7 @@ import java.util.concurrent.TimeUnit;
 @SuppressWarnings("deprecation")
 public class TestFramework extends BaseClassForTests
 {
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setup() throws Exception
     {
@@ -67,7 +72,7 @@ public class TestFramework extends BaseClassForTests
         super.setup();
     }
 
-    @AfterMethod
+    @AfterEach
     @Override
     public void teardown() throws Exception
     {
@@ -75,7 +80,7 @@ public class TestFramework extends BaseClassForTests
         super.teardown();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testQuietDelete() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -101,8 +106,8 @@ public class TestFramework extends BaseClassForTests
             });
 
             Integer code = rc.poll(new Timing().milliseconds(), TimeUnit.MILLISECONDS);
-            Assert.assertNotNull(code);
-            Assert.assertEquals(code.intValue(), KeeperException.Code.OK.intValue());
+            assertNotNull(code);
+            assertEquals(code.intValue(), KeeperException.Code.OK.intValue());
         }
         finally
         {
@@ -110,7 +115,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testNamespaceWithWatcher() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -135,7 +140,7 @@ public class TestFramework extends BaseClassForTests
                 .thenRun(() -> async.create().forPath("/base/child"));
 
             String path = queue.take();
-            Assert.assertEquals(path, "/base");
+            assertEquals(path, "/base");
         }
         finally
         {
@@ -143,7 +148,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateACLSingleAuth() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -174,7 +179,7 @@ public class TestFramework extends BaseClassForTests
             }
             catch ( ExecutionException e )
             {
-                Assert.fail("Auth failed");
+                fail("Auth failed");
             }
             client.close();
 
@@ -189,7 +194,7 @@ public class TestFramework extends BaseClassForTests
             {
                 AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
                 async.setData().forPath("/test", "test".getBytes()).toCompletableFuture().get();
-                Assert.fail("Should have failed with auth exception");
+                fail("Should have failed with auth exception");
             }
             catch ( ExecutionException e )
             {
@@ -202,7 +207,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateACLMultipleAuths() throws Exception
     {
         // Add a few authInfos
@@ -238,7 +243,7 @@ public class TestFramework extends BaseClassForTests
             }
             catch ( ExecutionException e )
             {
-                Assert.fail("Auth failed");
+                fail("Auth failed");
             }
             client.close();
 
@@ -256,7 +261,7 @@ public class TestFramework extends BaseClassForTests
             }
             catch ( ExecutionException e )
             {
-                Assert.fail("Auth failed");
+                fail("Auth failed");
             }
             client.close();
 
@@ -271,7 +276,7 @@ public class TestFramework extends BaseClassForTests
             {
                 AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
                 async.setData().forPath("/test", "test".getBytes()).toCompletableFuture().get();
-                Assert.fail("Should have failed with auth exception");
+                fail("Should have failed with auth exception");
             }
             catch ( ExecutionException e )
             {
@@ -284,7 +289,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateACLWithReset() throws Exception
     {
         Timing timing = new Timing();
@@ -314,12 +319,12 @@ public class TestFramework extends BaseClassForTests
             client.create().withACL(aclList).forPath("/test", "test".getBytes());
 
             server.stop();
-            Assert.assertTrue(timing.awaitLatch(lostLatch));
+            assertTrue(timing.awaitLatch(lostLatch));
             try
             {
                 AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
                 async.checkExists().forPath("/").toCompletableFuture().get();
-                Assert.fail("Connection should be down");
+                fail("Connection should be down");
             }
             catch ( ExecutionException e )
             {
@@ -334,7 +339,7 @@ public class TestFramework extends BaseClassForTests
             }
             catch ( ExecutionException e )
             {
-                Assert.fail("Auth failed", e);
+                fail("Auth failed", e);
             }
         }
         finally
@@ -343,7 +348,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateParents() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -354,11 +359,11 @@ public class TestFramework extends BaseClassForTests
             AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
             async.create().withOptions(EnumSet.of(CreateOption.createParentsIfNeeded)).forPath("/one/two/three", "foo".getBytes()).toCompletableFuture().get();
             byte[] data = async.getData().forPath("/one/two/three").toCompletableFuture().get();
-            Assert.assertEquals(data, "foo".getBytes());
+            assertArrayEquals(data, "foo".getBytes());
 
             async.create().withOptions(EnumSet.of(CreateOption.createParentsIfNeeded)).forPath("/one/two/another", "bar".getBytes());
             data = async.getData().forPath("/one/two/another").toCompletableFuture().get();
-            Assert.assertEquals(data, "bar".getBytes());
+            assertArrayEquals(data, "bar".getBytes());
         }
         finally
         {
@@ -366,7 +371,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateParentContainers() throws Exception
     {
         if ( !checkForContainers() )
@@ -382,14 +387,14 @@ public class TestFramework extends BaseClassForTests
             AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
             async.create().withOptions(EnumSet.of(CreateOption.createParentsAsContainers)).forPath("/one/two/three", "foo".getBytes()).toCompletableFuture().get();
             byte[] data = async.getData().forPath("/one/two/three").toCompletableFuture().get();
-            Assert.assertEquals(data, "foo".getBytes());
+            assertArrayEquals(data, "foo".getBytes());
 
             async.delete().forPath("/one/two/three").toCompletableFuture().get();
             new Timing().sleepABit();
 
-            Assert.assertNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
+            assertNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
             new Timing().sleepABit();
-            Assert.assertNull(async.checkExists().forPath("/one").toCompletableFuture().get());
+            assertNull(async.checkExists().forPath("/one").toCompletableFuture().get());
         }
         finally
         {
@@ -397,7 +402,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateWithProtection() throws ExecutionException, InterruptedException
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -408,8 +413,8 @@ public class TestFramework extends BaseClassForTests
             String path = async.create().withOptions(Collections.singleton(CreateOption.doProtected)).forPath("/yo").toCompletableFuture().get();
             String node = ZKPaths.getNodeFromPath(path);
             // CURATOR-489: confirm that the node contains a valid UUID, eg '_c_53345f98-9423-4e0c-a7b5-9f819e3ec2e1-yo'
-            Assert.assertTrue(ProtectedUtils.isProtectedZNode(node));
-            Assert.assertEquals(ProtectedUtils.normalize(node), "yo");
+            assertTrue(ProtectedUtils.isProtectedZNode(node));
+            assertEquals(ProtectedUtils.normalize(node), "yo");
         }
         finally
         {
@@ -427,7 +432,7 @@ public class TestFramework extends BaseClassForTests
         return true;
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreatingParentsTheSame() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -436,17 +441,17 @@ public class TestFramework extends BaseClassForTests
             client.start();
             AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
 
-            Assert.assertNull(client.checkExists().forPath("/one/two"));
+            assertNull(client.checkExists().forPath("/one/two"));
             async.create().withOptions(EnumSet.of(CreateOption.createParentsAsContainers)).forPath("/one/two/three").toCompletableFuture().get();
-            Assert.assertNotNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
+            assertNotNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
 
             async.delete().withOptions(EnumSet.of(DeleteOption.deletingChildrenIfNeeded)).forPath("/one").toCompletableFuture().get();
-            Assert.assertNull(client.checkExists().forPath("/one"));
+            assertNull(client.checkExists().forPath("/one"));
 
-            Assert.assertNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
+            assertNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
             async.checkExists().withOptions(EnumSet.of(ExistsOption.createParentsAsContainers)).forPath("/one/two/three").toCompletableFuture().get();
-            Assert.assertNotNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
-            Assert.assertNull(async.checkExists().forPath("/one/two/three").toCompletableFuture().get());
+            assertNotNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
+            assertNull(async.checkExists().forPath("/one/two/three").toCompletableFuture().get());
         }
         finally
         {
@@ -454,7 +459,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testExistsCreatingParents() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -463,11 +468,11 @@ public class TestFramework extends BaseClassForTests
             client.start();
             AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
 
-            Assert.assertNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
+            assertNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
             async.checkExists().withOptions(EnumSet.of(ExistsOption.createParentsAsContainers)).forPath("/one/two/three").toCompletableFuture().get();
-            Assert.assertNotNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
-            Assert.assertNull(async.checkExists().forPath("/one/two/three").toCompletableFuture().get());
-            Assert.assertNull(async.checkExists().withOptions(EnumSet.of(ExistsOption.createParentsAsContainers)).forPath("/one/two/three").toCompletableFuture().get());
+            assertNotNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
+            assertNull(async.checkExists().forPath("/one/two/three").toCompletableFuture().get());
+            assertNull(async.checkExists().withOptions(EnumSet.of(ExistsOption.createParentsAsContainers)).forPath("/one/two/three").toCompletableFuture().get());
         }
         finally
         {
@@ -475,7 +480,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSyncNew() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -483,17 +488,17 @@ public class TestFramework extends BaseClassForTests
         try
         {
             client.create().forPath("/head");
-            Assert.assertNotNull(client.checkExists().forPath("/head"));
+            assertNotNull(client.checkExists().forPath("/head"));
 
             final CountDownLatch latch = new CountDownLatch(1);
             AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
             async.sync().forPath("/head").handle((v, e) -> {
-                Assert.assertNull(v);
-                Assert.assertNull(e);
+                assertNull(v);
+                assertNull(e);
                 latch.countDown();
                 return null;
             });
-            Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
         }
         finally
         {
@@ -501,7 +506,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBackgroundDelete() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -512,14 +517,14 @@ public class TestFramework extends BaseClassForTests
             CountDownLatch latch = new CountDownLatch(1);
             async.create().forPath("/head").thenRun(() ->
                 async.delete().forPath("/head").handle((v, e) -> {
-                    Assert.assertNull(v);
-                    Assert.assertNull(e);
+                    assertNull(v);
+                    assertNull(e);
                     latch.countDown();
                     return null;
                 })
             );
-            Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
-            Assert.assertNull(client.checkExists().forPath("/head"));
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertNull(client.checkExists().forPath("/head"));
         }
         finally
         {
@@ -527,7 +532,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBackgroundDeleteWithChildren() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -539,7 +544,7 @@ public class TestFramework extends BaseClassForTests
                 {
                     if ( event.getType() == CuratorEventType.DELETE )
                     {
-                        Assert.assertEquals(event.getPath(), "/one/two");
+                        assertEquals(event.getPath(), "/one/two");
                         ((CountDownLatch)event.getContext()).countDown();
                     }
                 });
@@ -548,14 +553,14 @@ public class TestFramework extends BaseClassForTests
             AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
             async.create().withOptions(EnumSet.of(CreateOption.createParentsIfNeeded)).forPath("/one/two/three/four").thenRun(() ->
                 async.delete().withOptions(EnumSet.of(DeleteOption.deletingChildrenIfNeeded)).forPath("/one/two").handle((v, e) -> {
-                    Assert.assertNull(v);
-                    Assert.assertNull(e);
+                    assertNull(v);
+                    assertNull(e);
                     latch.countDown();
                     return null;
                 })
             );
-            Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
-            Assert.assertNull(client.checkExists().forPath("/one/two"));
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertNull(client.checkExists().forPath("/one/two"));
         }
         finally
         {
@@ -563,7 +568,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDeleteGuaranteedWithChildren() throws Exception
     {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
@@ -574,9 +579,9 @@ public class TestFramework extends BaseClassForTests
             AsyncCuratorFramework async = AsyncCuratorFramework.wrap(client);
             async.create().withOptions(EnumSet.of(CreateOption.createParentsIfNeeded)).forPath("/one/two/three/four/five/six", "foo".getBytes()).toCompletableFuture().get();
             async.delete().withOptions(EnumSet.of(DeleteOption.guaranteed, DeleteOption.deletingChildrenIfNeeded)).forPath("/one/two/three/four/five").toCompletableFuture().get();
-            Assert.assertNull(async.checkExists().forPath("/one/two/three/four/five").toCompletableFuture().get());
+            assertNull(async.checkExists().forPath("/one/two/three/four/five").toCompletableFuture().get());
             async.delete().withOptions(EnumSet.of(DeleteOption.guaranteed, DeleteOption.deletingChildrenIfNeeded)).forPath("/one/two").toCompletableFuture().get();
-            Assert.assertNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
+            assertNull(async.checkExists().forPath("/one/two").toCompletableFuture().get());
         }
         finally
         {
@@ -584,7 +589,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testGetSequentialChildren() throws Exception
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -600,9 +605,9 @@ public class TestFramework extends BaseClassForTests
                 }
             });
 
-            Assert.assertTrue(new Timing().acquireSemaphore(semaphore, 10));
+            assertTrue(new Timing().acquireSemaphore(semaphore, 10));
             List<String> children = async.getChildren().forPath("/head").toCompletableFuture().get();
-            Assert.assertEquals(children.size(), 10);
+            assertEquals(children.size(), 10);
         }
         finally
         {
@@ -610,7 +615,7 @@ public class TestFramework extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBackgroundGetDataWithWatch() throws Exception
     {
         final byte[] data1 = {1, 2, 3};
@@ -627,22 +632,22 @@ public class TestFramework extends BaseClassForTests
             CountDownLatch backgroundLatch = new CountDownLatch(1);
             AsyncStage<byte[]> stage = async.watched().getData().forPath("/test");
             stage.event().handle((event, x) -> {
-                Assert.assertEquals(event.getPath(), "/test");
+                assertEquals(event.getPath(), "/test");
                 watchedLatch.countDown();
                 return null;
             });
             stage.handle((d, x) -> {
-                Assert.assertEquals(d, data1);
+                assertArrayEquals(d, data1);
                 backgroundLatch.countDown();
                 return null;
             });
 
-            Assert.assertTrue(backgroundLatch.await(10, TimeUnit.SECONDS));
+            assertTrue(backgroundLatch.await(10, TimeUnit.SECONDS));
 
             async.setData().forPath("/test", data2);
-            Assert.assertTrue(watchedLatch.await(10, TimeUnit.SECONDS));
+            assertTrue(watchedLatch.await(10, TimeUnit.SECONDS));
             byte[] checkData = async.getData().forPath("/test").toCompletableFuture().get();
-            Assert.assertEquals(checkData, data2);
+            assertArrayEquals(checkData, data2);
         }
         finally
         {

--- a/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
+++ b/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
@@ -18,7 +18,11 @@
  */
 package org.apache.curator.framework.imps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
@@ -35,8 +39,6 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -48,7 +50,7 @@ public class TestFrameworkBackground extends BaseClassForTests
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testErrorListener() throws Exception
     {
         //The first call to the ACL provider will return a reasonable
@@ -102,7 +104,7 @@ public class TestFrameworkBackground extends BaseClassForTests
                 }
             };
             async.with(listener).create().forPath("/foo");
-            Assert.assertTrue(new Timing().awaitLatch(errorLatch));
+            assertTrue(new Timing().awaitLatch(errorLatch));
         }
         finally
         {
@@ -110,7 +112,7 @@ public class TestFrameworkBackground extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testListenerConnectedAtStart() throws Exception
     {
         server.stop();
@@ -144,10 +146,10 @@ public class TestFrameworkBackground extends BaseClassForTests
 
             server.restart();
 
-            Assert.assertTrue(timing.awaitLatch(connectedLatch));
-            Assert.assertFalse(firstListenerAction.get());
+            assertTrue(timing.awaitLatch(connectedLatch));
+            assertFalse(firstListenerAction.get());
             ConnectionState firstconnectionState = firstListenerState.get();
-            Assert.assertEquals(firstconnectionState, ConnectionState.CONNECTED, "First listener state MUST BE CONNECTED but is " + firstconnectionState);
+            assertEquals(firstconnectionState, ConnectionState.CONNECTED, "First listener state MUST BE CONNECTED but is " + firstconnectionState);
         }
         finally
         {
@@ -155,7 +157,7 @@ public class TestFrameworkBackground extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRetries() throws Exception
     {
         final int SLEEP = 1000;
@@ -190,7 +192,7 @@ public class TestFrameworkBackground extends BaseClassForTests
 
             for ( long elapsed : times.subList(1, times.size()) )   // first one isn't a retry
             {
-                Assert.assertTrue(elapsed >= SLEEP, elapsed + ": " + times);
+                assertTrue(elapsed >= SLEEP, elapsed + ": " + times);
             }
         }
         finally
@@ -203,7 +205,7 @@ public class TestFrameworkBackground extends BaseClassForTests
      * Attempt a background operation while Zookeeper server is down.
      * Return code must be {@link org.apache.zookeeper.KeeperException.Code#CONNECTIONLOSS}
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCuratorCallbackOnError() throws Exception
     {
         Timing timing = new Timing();
@@ -223,7 +225,7 @@ public class TestFrameworkBackground extends BaseClassForTests
                 return null;
             });
             // Check if the callback has been called with a correct return code
-            Assert.assertTrue(timing.awaitLatch(latch), "Callback has not been called by curator !");
+            assertTrue(timing.awaitLatch(latch), "Callback has not been called by curator !");
         }
     }
 
@@ -231,7 +233,7 @@ public class TestFrameworkBackground extends BaseClassForTests
      * CURATOR-126
      * Shutdown the Curator client while there are still background operations running.
      */
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testShutdown() throws Exception
     {
         Timing timing = new Timing();
@@ -280,7 +282,7 @@ public class TestFrameworkBackground extends BaseClassForTests
             timing.sleepABit();
 
             // should not generate an exception
-            Assert.assertFalse(hadIllegalStateException.get());
+            assertFalse(hadIllegalStateException.get());
         }
         finally
         {

--- a/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
+++ b/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
@@ -37,6 +36,7 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.ACL;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
@@ -50,7 +50,7 @@ public class TestFrameworkBackground extends BaseClassForTests
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testErrorListener() throws Exception
     {
         //The first call to the ACL provider will return a reasonable
@@ -112,7 +112,7 @@ public class TestFrameworkBackground extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testListenerConnectedAtStart() throws Exception
     {
         server.stop();
@@ -157,7 +157,7 @@ public class TestFrameworkBackground extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRetries() throws Exception
     {
         final int SLEEP = 1000;
@@ -205,7 +205,7 @@ public class TestFrameworkBackground extends BaseClassForTests
      * Attempt a background operation while Zookeeper server is down.
      * Return code must be {@link org.apache.zookeeper.KeeperException.Code#CONNECTIONLOSS}
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCuratorCallbackOnError() throws Exception
     {
         Timing timing = new Timing();
@@ -233,7 +233,7 @@ public class TestFrameworkBackground extends BaseClassForTests
      * CURATOR-126
      * Shutdown the Curator client while there are still background operations running.
      */
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testShutdown() throws Exception
     {
         Timing timing = new Timing();

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/CompletableBaseClassForTests.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/CompletableBaseClassForTests.java
@@ -18,10 +18,10 @@
  */
 package org.apache.curator.x.async;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.base.Throwables;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.Timing2;
-import org.testng.Assert;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -61,11 +61,11 @@ public abstract class CompletableBaseClassForTests extends BaseClassForTests
             {
                 throw (AssertionError)e.getCause();
             }
-            Assert.fail("get() failed", e);
+            fail("get() failed", e);
         }
         catch ( TimeoutException e )
         {
-            Assert.fail("get() timed out");
+            fail("get() timed out");
         }
     }
 }

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/TestAsyncWrappers.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/TestAsyncWrappers.java
@@ -21,18 +21,18 @@ package org.apache.curator.x.async;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.locks.InterProcessMutex;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
+import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class TestAsyncWrappers extends CompletableBaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic()
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -47,7 +47,7 @@ public class TestAsyncWrappers extends CompletableBaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testContention() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/TestAsyncWrappers.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/TestAsyncWrappers.java
@@ -18,18 +18,21 @@
  */
 package org.apache.curator.x.async;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.locks.InterProcessMutex;
 import org.apache.curator.retry.RetryOneTime;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.apache.curator.test.BaseClassForTests;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class TestAsyncWrappers extends CompletableBaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic()
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -38,13 +41,13 @@ public class TestAsyncWrappers extends CompletableBaseClassForTests
 
             InterProcessMutex lock = new InterProcessMutex(client, "/one/two");
             complete(AsyncWrappers.lockAsync(lock), (__, e) -> {
-                Assert.assertNull(e);
+                assertNull(e);
                 AsyncWrappers.release(lock);
             });
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testContention() throws Exception
     {
         try ( CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1)) )
@@ -57,7 +60,7 @@ public class TestAsyncWrappers extends CompletableBaseClassForTests
             AsyncWrappers.lockAsync(lock1).thenAccept(__ -> {
                 latch.countDown();  // don't release the lock
             });
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
 
             CountDownLatch latch2 = new CountDownLatch(1);
             AsyncWrappers.lockAsync(lock2, timing.forSleepingABit().milliseconds(), TimeUnit.MILLISECONDS).exceptionally(e -> {
@@ -67,7 +70,7 @@ public class TestAsyncWrappers extends CompletableBaseClassForTests
                 }
                 return null;
             });
-            Assert.assertTrue(timing.awaitLatch(latch2));
+            assertTrue(timing.awaitLatch(latch2));
         }
     }
 }

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/TestBasicOperations.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/TestBasicOperations.java
@@ -29,18 +29,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.data.Stat;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.CompletionStage;
@@ -70,7 +70,7 @@ public class TestBasicOperations extends CompletableBaseClassForTests
         super.teardown();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCreateTransactionWithMode() throws Exception
     {
         complete(AsyncWrappers.asyncEnsureContainers(client, "/test"));
@@ -82,7 +82,7 @@ public class TestBasicOperations extends CompletableBaseClassForTests
         assertEquals(client.unwrap().getChildren().forPath("/test").size(), 2);
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCrud()
     {
         AsyncStage<String> createStage = client.create().forPath("/test", "one".getBytes());
@@ -104,7 +104,7 @@ public class TestBasicOperations extends CompletableBaseClassForTests
         complete(setDataIfStage, (data, e) -> assertArrayEquals(data, "last".getBytes()));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testException()
     {
         CountDownLatch latch = new CountDownLatch(1);
@@ -117,7 +117,7 @@ public class TestBasicOperations extends CompletableBaseClassForTests
         assertTrue(timing.awaitLatch(latch));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWatching()
     {
         CountDownLatch latch = new CountDownLatch(1);
@@ -130,7 +130,7 @@ public class TestBasicOperations extends CompletableBaseClassForTests
         assertTrue(timing.awaitLatch(latch));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWatchingWithServerLoss() throws Exception
     {
         AsyncStage<Stat> stage = client.watched().checkExists().forPath("/test");
@@ -157,7 +157,7 @@ public class TestBasicOperations extends CompletableBaseClassForTests
         assertTrue(timing.awaitLatch(latch));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testResultWrapper() throws Exception
     {
         CompletionStage<AsyncResult<String>> resultStage = AsyncResult.of(client.create().forPath("/first"));
@@ -195,7 +195,7 @@ public class TestBasicOperations extends CompletableBaseClassForTests
         });
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGetDataWithStat()
     {
         complete(client.create().forPath("/test", "hey".getBytes()));

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/TestBasicOperations.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/TestBasicOperations.java
@@ -18,34 +18,39 @@
  */
 package org.apache.curator.x.async;
 
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.api.transaction.CuratorOp;
-import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.utils.CloseableUtils;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.data.Stat;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.CountDownLatch;
-
 import static java.util.EnumSet.of;
 import static org.apache.curator.x.async.api.CreateOption.compress;
 import static org.apache.curator.x.async.api.CreateOption.setDataIfExists;
 import static org.apache.zookeeper.CreateMode.EPHEMERAL_SEQUENTIAL;
 import static org.apache.zookeeper.CreateMode.PERSISTENT_SEQUENTIAL;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.transaction.CuratorOp;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
 
 public class TestBasicOperations extends CompletableBaseClassForTests
 {
     private AsyncCuratorFramework client;
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setup() throws Exception
     {
@@ -56,7 +61,7 @@ public class TestBasicOperations extends CompletableBaseClassForTests
         this.client = AsyncCuratorFramework.wrap(client);
     }
 
-    @AfterMethod
+    @AfterEach
     @Override
     public void teardown() throws Exception
     {
@@ -65,7 +70,7 @@ public class TestBasicOperations extends CompletableBaseClassForTests
         super.teardown();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCreateTransactionWithMode() throws Exception
     {
         complete(AsyncWrappers.asyncEnsureContainers(client, "/test"));
@@ -74,58 +79,58 @@ public class TestBasicOperations extends CompletableBaseClassForTests
         CuratorOp op2 = client.transactionOp().create().withMode(PERSISTENT_SEQUENTIAL).forPath("/test/node-");
         complete(client.transaction().forOperations(Arrays.asList(op1, op2)));
 
-        Assert.assertEquals(client.unwrap().getChildren().forPath("/test").size(), 2);
+        assertEquals(client.unwrap().getChildren().forPath("/test").size(), 2);
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCrud()
     {
         AsyncStage<String> createStage = client.create().forPath("/test", "one".getBytes());
-        complete(createStage, (path, e) -> Assert.assertEquals(path, "/test"));
+        complete(createStage, (path, e) -> assertEquals(path, "/test"));
 
         AsyncStage<byte[]> getStage = client.getData().forPath("/test");
-        complete(getStage, (data, e) -> Assert.assertEquals(data, "one".getBytes()));
+        complete(getStage, (data, e) -> assertArrayEquals(data, "one".getBytes()));
 
         CompletionStage<byte[]> combinedStage = client.setData().forPath("/test", "new".getBytes()).thenCompose(
             __ -> client.getData().forPath("/test"));
-        complete(combinedStage, (data, e) -> Assert.assertEquals(data, "new".getBytes()));
+        complete(combinedStage, (data, e) -> assertArrayEquals(data, "new".getBytes()));
 
         CompletionStage<Void> combinedDelete = client.create().withMode(EPHEMERAL_SEQUENTIAL).forPath("/deleteme").thenCompose(
             path -> client.delete().forPath(path));
-        complete(combinedDelete, (v, e) -> Assert.assertNull(e));
+        complete(combinedDelete, (v, e) -> assertNull(e));
 
         CompletionStage<byte[]> setDataIfStage = client.create().withOptions(of(compress, setDataIfExists)).forPath("/test", "last".getBytes())
             .thenCompose(__ -> client.getData().decompressed().forPath("/test"));
-        complete(setDataIfStage, (data, e) -> Assert.assertEquals(data, "last".getBytes()));
+        complete(setDataIfStage, (data, e) -> assertArrayEquals(data, "last".getBytes()));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testException()
     {
         CountDownLatch latch = new CountDownLatch(1);
         client.getData().forPath("/woop").exceptionally(e -> {
-            Assert.assertTrue(e instanceof KeeperException);
-            Assert.assertEquals(((KeeperException)e).code(), KeeperException.Code.NONODE);
+            assertTrue(e instanceof KeeperException);
+            assertEquals(((KeeperException)e).code(), KeeperException.Code.NONODE);
             latch.countDown();
             return null;
         });
-        Assert.assertTrue(timing.awaitLatch(latch));
+        assertTrue(timing.awaitLatch(latch));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWatching()
     {
         CountDownLatch latch = new CountDownLatch(1);
         client.watched().checkExists().forPath("/test").event().whenComplete((event, exception) -> {
-            Assert.assertNull(exception);
-            Assert.assertEquals(event.getType(), Watcher.Event.EventType.NodeCreated);
+            assertNull(exception);
+            assertEquals(event.getType(), Watcher.Event.EventType.NodeCreated);
             latch.countDown();
         });
         client.create().forPath("/test");
-        Assert.assertTrue(timing.awaitLatch(latch));
+        assertTrue(timing.awaitLatch(latch));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWatchingWithServerLoss() throws Exception
     {
         AsyncStage<Stat> stage = client.watched().checkExists().forPath("/test");
@@ -142,61 +147,61 @@ public class TestBasicOperations extends CompletableBaseClassForTests
 
         CountDownLatch latch = new CountDownLatch(1);
         complete(stage.event(), (v, e) -> {
-            Assert.assertTrue(e instanceof AsyncEventException);
-            Assert.assertEquals(((AsyncEventException)e).getKeeperState(), Watcher.Event.KeeperState.Disconnected);
+            assertTrue(e instanceof AsyncEventException);
+            assertEquals(((AsyncEventException)e).getKeeperState(), Watcher.Event.KeeperState.Disconnected);
             ((AsyncEventException)e).reset().thenRun(latch::countDown);
         });
 
         server.restart();
         client.create().forPath("/test");
-        Assert.assertTrue(timing.awaitLatch(latch));
+        assertTrue(timing.awaitLatch(latch));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testResultWrapper() throws Exception
     {
         CompletionStage<AsyncResult<String>> resultStage = AsyncResult.of(client.create().forPath("/first"));
         complete(resultStage, (v, e) -> {
-            Assert.assertNull(e);
-            Assert.assertEquals(v.getRawValue(), "/first");
-            Assert.assertNull(v.getRawException());
-            Assert.assertEquals(v.getCode(), KeeperException.Code.OK);
+            assertNull(e);
+            assertEquals(v.getRawValue(), "/first");
+            assertNull(v.getRawException());
+            assertEquals(v.getCode(), KeeperException.Code.OK);
         });
 
         resultStage = AsyncResult.of(client.create().forPath("/foo/bar"));
         complete(resultStage, (v, e) -> {
-            Assert.assertNull(e);
-            Assert.assertNull(v.getRawValue());
-            Assert.assertNull(v.getRawException());
-            Assert.assertEquals(v.getCode(), KeeperException.Code.NONODE);
+            assertNull(e);
+            assertNull(v.getRawValue());
+            assertNull(v.getRawException());
+            assertEquals(v.getCode(), KeeperException.Code.NONODE);
         });
 
         resultStage = AsyncResult.of(client.create().forPath("illegal path"));
         complete(resultStage, (v, e) -> {
-            Assert.assertNull(e);
-            Assert.assertNull(v.getRawValue());
-            Assert.assertNotNull(v.getRawException());
-            Assert.assertTrue(v.getRawException() instanceof IllegalArgumentException);
-            Assert.assertEquals(v.getCode(), KeeperException.Code.SYSTEMERROR);
+            assertNull(e);
+            assertNull(v.getRawValue());
+            assertNotNull(v.getRawException());
+            assertTrue(v.getRawException() instanceof IllegalArgumentException);
+            assertEquals(v.getCode(), KeeperException.Code.SYSTEMERROR);
         });
 
         server.stop();
         resultStage = AsyncResult.of(client.create().forPath("/second"));
         complete(resultStage, (v, e) -> {
-            Assert.assertNull(e);
-            Assert.assertNull(v.getRawValue());
-            Assert.assertNull(v.getRawException());
-            Assert.assertEquals(v.getCode(), KeeperException.Code.CONNECTIONLOSS);
+            assertNull(e);
+            assertNull(v.getRawValue());
+            assertNull(v.getRawException());
+            assertEquals(v.getCode(), KeeperException.Code.CONNECTIONLOSS);
         });
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testGetDataWithStat()
     {
         complete(client.create().forPath("/test", "hey".getBytes()));
 
         Stat stat = new Stat();
         complete(client.getData().storingStatIn(stat).forPath("/test"));
-        Assert.assertEquals(stat.getDataLength(), "hey".length());
+        assertEquals(stat.getDataLength(), "hey".length());
     }
 }

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/migrations/TestMigrationManager.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/migrations/TestMigrationManager.java
@@ -25,12 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.base.Throwables;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.AsyncWrappers;
@@ -45,6 +43,8 @@ import org.apache.curator.x.async.modeled.ZPath;
 import org.apache.zookeeper.KeeperException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -134,7 +134,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         super.teardown();
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic()
     {
         Migration m1 = () -> Arrays.asList(v1opA, v1opB);
@@ -156,7 +156,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         assertEquals(manager.debugCount.get(), count);   // second call should do nothing
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testStaged()
     {
         Migration m1 = () -> Arrays.asList(v1opA, v1opB);
@@ -188,7 +188,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         });
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDocExample() throws Exception
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/parent");
@@ -214,7 +214,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         assertNull(client.unwrap().checkExists().forPath("/main"));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testChecksumDataError()
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test");
@@ -237,7 +237,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testChecksumPathError()
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test2");
@@ -260,7 +260,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPartialApplyForBadOps() throws Exception
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test", "something".getBytes());
@@ -281,7 +281,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         assertNull(client.unwrap().checkExists().forPath("/test"));  // should be all or nothing
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testTransactionForBadOps() throws Exception
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test2", "something".getBytes());
@@ -301,7 +301,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         assertNull(client.unwrap().checkExists().forPath("/test"));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConcurrency1() throws Exception
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test");
@@ -329,7 +329,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         assertArrayEquals(client.unwrap().getData().forPath("/test/bar"), "first".getBytes());
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testConcurrency2() throws Exception
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test");

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/migrations/TestMigrationManager.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/migrations/TestMigrationManager.java
@@ -18,11 +18,19 @@
  */
 package org.apache.curator.x.async.migrations;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.base.Throwables;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.AsyncWrappers;
@@ -35,10 +43,8 @@ import org.apache.curator.x.async.modeled.ModelSpec;
 import org.apache.curator.x.async.modeled.ModeledFramework;
 import org.apache.curator.x.async.modeled.ZPath;
 import org.apache.zookeeper.KeeperException;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -69,7 +75,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
     private final AtomicReference<CountDownLatch> filterLatch = new AtomicReference<>();
     private CountDownLatch filterIsSetLatch;
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setup() throws Exception
     {
@@ -119,7 +125,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         manager.debugCount = new AtomicInteger();
     }
 
-    @AfterMethod
+    @AfterEach
     @Override
     public void teardown() throws Exception
     {
@@ -128,7 +134,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         super.teardown();
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic()
     {
         Migration m1 = () -> Arrays.asList(v1opA, v1opB);
@@ -140,17 +146,17 @@ public class TestMigrationManager extends CompletableBaseClassForTests
 
         ModeledFramework<ModelV3> v3Client = ModeledFramework.wrap(client, v3Spec);
         complete(v3Client.read(), (m, e) -> {
-            Assert.assertEquals(m.getAge(), 30);
-            Assert.assertEquals(m.getFirstName(), "One");
-            Assert.assertEquals(m.getLastName(), "Two");
+            assertEquals(m.getAge(), 30);
+            assertEquals(m.getFirstName(), "One");
+            assertEquals(m.getLastName(), "Two");
         });
 
         int count = manager.debugCount.get();
         complete(manager.migrate(migrationSet));
-        Assert.assertEquals(manager.debugCount.get(), count);   // second call should do nothing
+        assertEquals(manager.debugCount.get(), count);   // second call should do nothing
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testStaged()
     {
         Migration m1 = () -> Arrays.asList(v1opA, v1opB);
@@ -158,7 +164,7 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         complete(manager.migrate(migrationSet));
 
         ModeledFramework<ModelV1> v1Client = ModeledFramework.wrap(client, v1Spec);
-        complete(v1Client.read(), (m, e) -> Assert.assertEquals(m.getName(), "Test"));
+        complete(v1Client.read(), (m, e) -> assertEquals(m.getName(), "Test"));
 
         Migration m2 = () -> Collections.singletonList(v2op);
         migrationSet = MigrationSet.build("1", Arrays.asList(m1, m2));
@@ -166,8 +172,8 @@ public class TestMigrationManager extends CompletableBaseClassForTests
 
         ModeledFramework<ModelV2> v2Client = ModeledFramework.wrap(client, v2Spec);
         complete(v2Client.read(), (m, e) -> {
-            Assert.assertEquals(m.getName(), "Test 2");
-            Assert.assertEquals(m.getAge(), 10);
+            assertEquals(m.getName(), "Test 2");
+            assertEquals(m.getAge(), 10);
         });
 
         Migration m3 = () -> Collections.singletonList(v3op);
@@ -176,13 +182,13 @@ public class TestMigrationManager extends CompletableBaseClassForTests
 
         ModeledFramework<ModelV3> v3Client = ModeledFramework.wrap(client, v3Spec);
         complete(v3Client.read(), (m, e) -> {
-            Assert.assertEquals(m.getAge(), 30);
-            Assert.assertEquals(m.getFirstName(), "One");
-            Assert.assertEquals(m.getLastName(), "Two");
+            assertEquals(m.getAge(), 30);
+            assertEquals(m.getFirstName(), "One");
+            assertEquals(m.getLastName(), "Two");
         });
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDocExample() throws Exception
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/parent");
@@ -195,8 +201,8 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         MigrationSet migrationSet = MigrationSet.build("main", Collections.singletonList(initialMigration));
         complete(manager.migrate(migrationSet));
 
-        Assert.assertNotNull(client.unwrap().checkExists().forPath("/parent/three"));
-        Assert.assertEquals(client.unwrap().getData().forPath("/main"), "hey".getBytes());
+        assertNotNull(client.unwrap().checkExists().forPath("/parent/three"));
+        assertArrayEquals(client.unwrap().getData().forPath("/main"), "hey".getBytes());
 
         CuratorOp newOp1 = client.transactionOp().create().forPath("/new");
         CuratorOp newOp2 = client.transactionOp().delete().forPath("/main");    // maybe this is no longer needed
@@ -205,10 +211,10 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         migrationSet = MigrationSet.build("main", Arrays.asList(initialMigration, newMigration));
         complete(manager.migrate(migrationSet));
 
-        Assert.assertNull(client.unwrap().checkExists().forPath("/main"));
+        assertNull(client.unwrap().checkExists().forPath("/main"));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testChecksumDataError()
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test");
@@ -223,15 +229,15 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         try
         {
             complete(manager.migrate(migrationSet));
-            Assert.fail("Should throw");
+            fail("Should throw");
         }
         catch ( Throwable e )
         {
-            Assert.assertTrue(Throwables.getRootCause(e) instanceof MigrationException);
+            assertTrue(Throwables.getRootCause(e) instanceof MigrationException);
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testChecksumPathError()
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test2");
@@ -246,15 +252,15 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         try
         {
             complete(manager.migrate(migrationSet));
-            Assert.fail("Should throw");
+            fail("Should throw");
         }
         catch ( Throwable e )
         {
-            Assert.assertTrue(Throwables.getRootCause(e) instanceof MigrationException);
+            assertTrue(Throwables.getRootCause(e) instanceof MigrationException);
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testPartialApplyForBadOps() throws Exception
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test", "something".getBytes());
@@ -265,17 +271,17 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         try
         {
             complete(manager.migrate(migrationSet));
-            Assert.fail("Should throw");
+            fail("Should throw");
         }
         catch ( Throwable e )
         {
-            Assert.assertTrue(Throwables.getRootCause(e) instanceof KeeperException.NoNodeException);
+            assertTrue(Throwables.getRootCause(e) instanceof KeeperException.NoNodeException);
         }
 
-        Assert.assertNull(client.unwrap().checkExists().forPath("/test"));  // should be all or nothing
+        assertNull(client.unwrap().checkExists().forPath("/test"));  // should be all or nothing
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testTransactionForBadOps() throws Exception
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test2", "something".getBytes());
@@ -285,17 +291,17 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         try
         {
             complete(manager.migrate(migrationSet));
-            Assert.fail("Should throw");
+            fail("Should throw");
         }
         catch ( Throwable e )
         {
-            Assert.assertTrue(Throwables.getRootCause(e) instanceof KeeperException.NoNodeException);
+            assertTrue(Throwables.getRootCause(e) instanceof KeeperException.NoNodeException);
         }
 
-        Assert.assertNull(client.unwrap().checkExists().forPath("/test"));
+        assertNull(client.unwrap().checkExists().forPath("/test"));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testConcurrency1() throws Exception
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test");
@@ -305,25 +311,25 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         CountDownLatch latch = new CountDownLatch(1);
         filterLatch.set(latch);
         CompletionStage<Void> first = manager.migrate(migrationSet);
-        Assert.assertTrue(timing.awaitLatch(filterIsSetLatch));
+        assertTrue(timing.awaitLatch(filterIsSetLatch));
 
         MigrationManager manager2 = new MigrationManager(client, LOCK_PATH, META_DATA_PATH, executor, Duration.ofMillis(timing.forSleepingABit().milliseconds()));
         try
         {
             complete(manager2.migrate(migrationSet));
-            Assert.fail("Should throw");
+            fail("Should throw");
         }
         catch ( Throwable e )
         {
-            Assert.assertTrue(Throwables.getRootCause(e) instanceof AsyncWrappers.TimeoutException, "Should throw AsyncWrappers.TimeoutException, was: " + Throwables.getStackTraceAsString(Throwables.getRootCause(e)));
+            assertTrue(Throwables.getRootCause(e) instanceof AsyncWrappers.TimeoutException, "Should throw AsyncWrappers.TimeoutException, was: " + Throwables.getStackTraceAsString(Throwables.getRootCause(e)));
         }
 
         latch.countDown();
         complete(first);
-        Assert.assertEquals(client.unwrap().getData().forPath("/test/bar"), "first".getBytes());
+        assertArrayEquals(client.unwrap().getData().forPath("/test/bar"), "first".getBytes());
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testConcurrency2() throws Exception
     {
         CuratorOp op1 = client.transactionOp().create().forPath("/test");
@@ -333,23 +339,23 @@ public class TestMigrationManager extends CompletableBaseClassForTests
         CountDownLatch latch = new CountDownLatch(1);
         filterLatch.set(latch);
         CompletionStage<Void> first = manager.migrate(migrationSet);
-        Assert.assertTrue(timing.awaitLatch(filterIsSetLatch));
+        assertTrue(timing.awaitLatch(filterIsSetLatch));
 
         CompletionStage<Void> second = manager.migrate(migrationSet);
         try
         {
             second.toCompletableFuture().get(timing.forSleepingABit().milliseconds(), TimeUnit.MILLISECONDS);
-            Assert.fail("Should throw");
+            fail("Should throw");
         }
         catch ( Throwable e )
         {
-            Assert.assertTrue(Throwables.getRootCause(e) instanceof TimeoutException, "Should throw TimeoutException, was: " + Throwables.getStackTraceAsString(Throwables.getRootCause(e)));
+            assertTrue(Throwables.getRootCause(e) instanceof TimeoutException, "Should throw TimeoutException, was: " + Throwables.getStackTraceAsString(Throwables.getRootCause(e)));
         }
 
         latch.countDown();
         complete(first);
-        Assert.assertEquals(client.unwrap().getData().forPath("/test/bar"), "first".getBytes());
+        assertArrayEquals(client.unwrap().getData().forPath("/test/bar"), "first".getBytes());
         complete(second);
-        Assert.assertEquals(manager.debugCount.get(), 1);
+        assertEquals(manager.debugCount.get(), 1);
     }
 }

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
@@ -24,15 +24,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Sets;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.state.ConnectionState;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.x.async.modeled.cached.CachedModeledFramework;
 import org.apache.curator.x.async.modeled.cached.ModeledCacheListener;
 import org.apache.curator.x.async.modeled.models.TestModel;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestCachedModeledFramework extends TestModeledFrameworkBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDownServer() throws IOException
     {
         Timing timing = new Timing();
@@ -85,7 +85,7 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testPostInitializedFilter()
     {
         TestModel model1 = new TestModel("a", "b", "c", 1, BigInteger.ONE);
@@ -110,7 +110,7 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testChildren()
     {
         TestModel parent = new TestModel("a", "b", "c", 20, BigInteger.ONE);
@@ -159,7 +159,7 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
     }
 
     // note: CURATOR-546
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAccessCacheDirectly()
     {
         TestModel model = new TestModel("a", "b", "c", 20, BigInteger.ONE);

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
@@ -18,15 +18,21 @@
  */
 package org.apache.curator.x.async.modeled;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Sets;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.x.async.modeled.cached.CachedModeledFramework;
 import org.apache.curator.x.async.modeled.cached.ModeledCacheListener;
 import org.apache.curator.x.async.modeled.models.TestModel;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -39,10 +45,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestCachedModeledFramework extends TestModeledFrameworkBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDownServer() throws IOException
     {
         Timing timing = new Timing();
@@ -56,7 +62,7 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
         try
         {
             client.child(model).set(model);
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
+            assertTrue(timing.acquireSemaphore(semaphore));
 
             CountDownLatch latch = new CountDownLatch(1);
             rawClient.getConnectionStateListenable().addListener((__, state) -> {
@@ -66,11 +72,11 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
                 }
             });
             server.stop();
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
 
             complete(client.child(model).read().whenComplete((value, e) -> {
-                Assert.assertNotNull(value);
-                Assert.assertNull(e);
+                assertNotNull(value);
+                assertNull(e);
             }));
         }
         finally
@@ -79,7 +85,7 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testPostInitializedFilter()
     {
         TestModel model1 = new TestModel("a", "b", "c", 1, BigInteger.ONE);
@@ -93,10 +99,10 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
         client.start();
         try
         {
-            Assert.assertFalse(timing.forSleepingABit().acquireSemaphore(semaphore));
+            assertFalse(timing.forSleepingABit().acquireSemaphore(semaphore));
 
             client.child("2").set(model2);  // set before cache is started
-            Assert.assertTrue(timing.acquireSemaphore(semaphore));
+            assertTrue(timing.acquireSemaphore(semaphore));
         }
         finally
         {
@@ -104,7 +110,7 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testChildren()
     {
         TestModel parent = new TestModel("a", "b", "c", 20, BigInteger.ONE);
@@ -124,7 +130,7 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
             complete(client.child("p").child("c2").set(child2));
             complete(client.child("p").child("c1").child("g1").set(grandChild1));
             complete(client.child("p").child("c2").child("g2").set(grandChild2));
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
 
             complete(client.child("p").children(), (v, e) ->
             {
@@ -132,28 +138,28 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
                     client.child("p").child("c1").modelSpec().path(),
                     client.child("p").child("c2").modelSpec().path()
                 );
-                Assert.assertEquals(v, paths);
+                assertEquals(v, paths);
             });
 
             complete(client.child("p").childrenAsZNodes(), (v, e) ->
             {
                 Set<TestModel> cachedModels = toSet(v.stream(), ZNode::model);
-                Assert.assertEquals(cachedModels, Sets.newHashSet(child1, child2));
+                assertEquals(cachedModels, Sets.newHashSet(child1, child2));
 
                 // verify that the same nodes are returned from the uncached method
                 complete(ModeledFramework.wrap(async, modelSpec).child("p").childrenAsZNodes(), (v2, e2) -> {
                     Set<TestModel> uncachedModels = toSet(v2.stream(), ZNode::model);
-                    Assert.assertEquals(cachedModels, uncachedModels);
+                    assertEquals(cachedModels, uncachedModels);
                 });
             });
 
-            complete(client.child("p").child("c1").childrenAsZNodes(), (v, e) -> Assert.assertEquals(toSet(v.stream(), ZNode::model), Sets.newHashSet(grandChild1)));
-            complete(client.child("p").child("c2").childrenAsZNodes(), (v, e) -> Assert.assertEquals(toSet(v.stream(), ZNode::model), Sets.newHashSet(grandChild2)));
+            complete(client.child("p").child("c1").childrenAsZNodes(), (v, e) -> assertEquals(toSet(v.stream(), ZNode::model), Sets.newHashSet(grandChild1)));
+            complete(client.child("p").child("c2").childrenAsZNodes(), (v, e) -> assertEquals(toSet(v.stream(), ZNode::model), Sets.newHashSet(grandChild2)));
         }
     }
 
     // note: CURATOR-546
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testAccessCacheDirectly()
     {
         TestModel model = new TestModel("a", "b", "c", 20, BigInteger.ONE);
@@ -164,13 +170,13 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase
 
             client.start();
             complete(client.child("m").set(model));
-            Assert.assertTrue(timing.awaitLatch(latch));
+            assertTrue(timing.awaitLatch(latch));
 
             // call 2 times in a row to validate CURATOR-546
             Optional<ZNode<TestModel>> optZNode = client.cache().currentData(modelSpec.path().child("m"));
-            Assert.assertEquals(optZNode.orElseThrow(() -> new AssertionError("node is missing")).model(), model);
+            assertEquals(optZNode.orElseThrow(() -> new AssertionError("node is missing")).model(), model);
             optZNode = client.cache().currentData(modelSpec.path().child("m"));
-            Assert.assertEquals(optZNode.orElseThrow(() -> new AssertionError("node is missing")).model(), model);
+            assertEquals(optZNode.orElseThrow(() -> new AssertionError("node is missing")).model(), model);
         }
     }
 

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestModeledFramework.java
@@ -25,14 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Sets;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.schema.Schema;
 import org.apache.curator.framework.schema.SchemaSet;
 import org.apache.curator.framework.schema.SchemaViolation;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.modeled.models.TestModel;
@@ -45,6 +43,8 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.auth.DigestAuthenticationProvider;
+import org.junit.jupiter.api.Test;
+
 import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
@@ -54,7 +54,7 @@ import java.util.concurrent.CountDownLatch;
 
 public class TestModeledFramework extends TestModeledFrameworkBase
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCrud()
     {
         TestModel rawModel = new TestModel("John", "Galt", "1 Galt's Gulch", 42, BigInteger.valueOf(1));
@@ -70,7 +70,7 @@ public class TestModeledFramework extends TestModeledFrameworkBase
         complete(client.checkExists(), (stat, e) -> assertNull(stat));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBackwardCompatibility()
     {
         TestNewerModel rawNewModel = new TestNewerModel("John", "Galt", "1 Galt's Gulch", 42, BigInteger.valueOf(1), 100);
@@ -81,7 +81,7 @@ public class TestModeledFramework extends TestModeledFrameworkBase
         complete(clientForOld.read(), (model, e) -> assertTrue(rawNewModel.equalsOld(model)));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWatched() throws InterruptedException
     {
         CountDownLatch latch = new CountDownLatch(1);
@@ -93,7 +93,7 @@ public class TestModeledFramework extends TestModeledFrameworkBase
         assertTrue(timing.awaitLatch(latch));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testGetChildren()
     {
         TestModel model = new TestModel("John", "Galt", "1 Galt's Gulch", 42, BigInteger.valueOf(1));
@@ -106,7 +106,7 @@ public class TestModeledFramework extends TestModeledFrameworkBase
         complete(client.children(), (children, e) -> assertEquals(Sets.newHashSet(children), expected));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBadNode()
     {
         complete(async.create().forPath(modelSpec.path().fullPath(), "fubar".getBytes()), (v, e) -> {
@@ -116,7 +116,7 @@ public class TestModeledFramework extends TestModeledFrameworkBase
         complete(client.read(), (model, e) -> assertTrue(e instanceof KeeperException.NoNodeException));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSchema() throws Exception
     {
         Schema schema = modelSpec.schema();
@@ -139,7 +139,7 @@ public class TestModeledFramework extends TestModeledFrameworkBase
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testVersioned()
     {
         ModeledFramework<TestModel> client = ModeledFramework.wrap(async, modelSpec);
@@ -164,7 +164,7 @@ public class TestModeledFramework extends TestModeledFrameworkBase
         complete(client.delete(stat.getVersion()));
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testAcl() throws NoSuchAlgorithmException
     {
         List<ACL> aclList = Collections.singletonList(new ACL(ZooDefs.Perms.WRITE, new Id("digest", DigestAuthenticationProvider.generateDigest("test:test"))));

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestModeledFramework.java
@@ -19,13 +19,20 @@
 
 package org.apache.curator.x.async.modeled;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.Sets;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.schema.Schema;
 import org.apache.curator.framework.schema.SchemaSet;
 import org.apache.curator.framework.schema.SchemaViolation;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.modeled.models.TestModel;
@@ -38,8 +45,6 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.auth.DigestAuthenticationProvider;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
@@ -49,46 +54,46 @@ import java.util.concurrent.CountDownLatch;
 
 public class TestModeledFramework extends TestModeledFrameworkBase
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCrud()
     {
         TestModel rawModel = new TestModel("John", "Galt", "1 Galt's Gulch", 42, BigInteger.valueOf(1));
         TestModel rawModel2 = new TestModel("Wayne", "Rooney", "Old Trafford", 10, BigInteger.valueOf(1));
         ModeledFramework<TestModel> client = ModeledFramework.wrap(async, modelSpec);
         AsyncStage<String> stage = client.set(rawModel);
-        Assert.assertNull(stage.event());
-        complete(stage, (s, e) -> Assert.assertNotNull(s));
-        complete(client.read(), (model, e) -> Assert.assertEquals(model, rawModel));
+        assertNull(stage.event());
+        complete(stage, (s, e) -> assertNotNull(s));
+        complete(client.read(), (model, e) -> assertEquals(model, rawModel));
         complete(client.update(rawModel2));
-        complete(client.read(), (model, e) -> Assert.assertEquals(model, rawModel2));
+        complete(client.read(), (model, e) -> assertEquals(model, rawModel2));
         complete(client.delete());
-        complete(client.checkExists(), (stat, e) -> Assert.assertNull(stat));
+        complete(client.checkExists(), (stat, e) -> assertNull(stat));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBackwardCompatibility()
     {
         TestNewerModel rawNewModel = new TestNewerModel("John", "Galt", "1 Galt's Gulch", 42, BigInteger.valueOf(1), 100);
         ModeledFramework<TestNewerModel> clientForNew = ModeledFramework.wrap(async, newModelSpec);
-        complete(clientForNew.set(rawNewModel), (s, e) -> Assert.assertNotNull(s));
+        complete(clientForNew.set(rawNewModel), (s, e) -> assertNotNull(s));
 
         ModeledFramework<TestModel> clientForOld = ModeledFramework.wrap(async, modelSpec);
-        complete(clientForOld.read(), (model, e) -> Assert.assertTrue(rawNewModel.equalsOld(model)));
+        complete(clientForOld.read(), (model, e) -> assertTrue(rawNewModel.equalsOld(model)));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWatched() throws InterruptedException
     {
         CountDownLatch latch = new CountDownLatch(1);
         ModeledFramework<TestModel> client = ModeledFramework.builder(async, modelSpec).watched().build();
         client.checkExists().event().whenComplete((event, ex) -> latch.countDown());
         timing.sleepABit();
-        Assert.assertEquals(latch.getCount(), 1);
+        assertEquals(latch.getCount(), 1);
         client.set(new TestModel());
-        Assert.assertTrue(timing.awaitLatch(latch));
+        assertTrue(timing.awaitLatch(latch));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testGetChildren()
     {
         TestModel model = new TestModel("John", "Galt", "1 Galt's Gulch", 42, BigInteger.valueOf(1));
@@ -98,20 +103,20 @@ public class TestModeledFramework extends TestModeledFrameworkBase
         complete(client.child("three").set(model));
 
         Set<ZPath> expected = Sets.newHashSet(path.child("one"), path.child("two"), path.child("three"));
-        complete(client.children(), (children, e) -> Assert.assertEquals(Sets.newHashSet(children), expected));
+        complete(client.children(), (children, e) -> assertEquals(Sets.newHashSet(children), expected));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBadNode()
     {
         complete(async.create().forPath(modelSpec.path().fullPath(), "fubar".getBytes()), (v, e) -> {
         });    // ignore error
 
         ModeledFramework<TestModel> client = ModeledFramework.builder(async, modelSpec).watched().build();
-        complete(client.read(), (model, e) -> Assert.assertTrue(e instanceof KeeperException.NoNodeException));
+        complete(client.read(), (model, e) -> assertTrue(e instanceof KeeperException.NoNodeException));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSchema() throws Exception
     {
         Schema schema = modelSpec.schema();
@@ -122,7 +127,7 @@ public class TestModeledFramework extends TestModeledFrameworkBase
             try
             {
                 schemaClient.create().forPath(modelSpec.path().fullPath(), "asflasfas".getBytes());
-                Assert.fail("Should've thrown SchemaViolation");
+                fail("Should've thrown SchemaViolation");
             }
             catch ( SchemaViolation dummy )
             {
@@ -130,11 +135,11 @@ public class TestModeledFramework extends TestModeledFrameworkBase
             }
 
             ModeledFramework<TestModel> modeledSchemaClient = ModeledFramework.wrap(AsyncCuratorFramework.wrap(schemaClient), modelSpec);
-            complete(modeledSchemaClient.set(new TestModel("one", "two", "three", 4, BigInteger.ONE)), (dummy, e) -> Assert.assertNull(e));
+            complete(modeledSchemaClient.set(new TestModel("one", "two", "three", 4, BigInteger.ONE)), (dummy, e) -> assertNull(e));
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testVersioned()
     {
         ModeledFramework<TestModel> client = ModeledFramework.wrap(async, modelSpec);
@@ -144,35 +149,35 @@ public class TestModeledFramework extends TestModeledFrameworkBase
 
         VersionedModeledFramework<TestModel> versioned = client.versioned();
         complete(versioned.read().whenComplete((v, e) -> {
-            Assert.assertNull(e);
-            Assert.assertTrue(v.version() > 0);
-        }).thenCompose(versioned::set), (s, e) -> Assert.assertNull(e)); // version is correct should succeed
+            assertNull(e);
+            assertTrue(v.version() > 0);
+        }).thenCompose(versioned::set), (s, e) -> assertNull(e)); // version is correct should succeed
         
         Versioned<TestModel> badVersion = Versioned.from(model, 100000);
-        complete(versioned.set(badVersion), (v, e) -> Assert.assertTrue(e instanceof KeeperException.BadVersionException));
+        complete(versioned.set(badVersion), (v, e) -> assertTrue(e instanceof KeeperException.BadVersionException));
         
         final Stat stat = new Stat();
         complete(client.read(stat));
         // wrong version, needs to fail
-        complete(client.delete(stat.getVersion() + 1), (v, e) -> Assert.assertTrue(e instanceof KeeperException.BadVersionException));
+        complete(client.delete(stat.getVersion() + 1), (v, e) -> assertTrue(e instanceof KeeperException.BadVersionException));
         // correct version
         complete(client.delete(stat.getVersion()));
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testAcl() throws NoSuchAlgorithmException
     {
         List<ACL> aclList = Collections.singletonList(new ACL(ZooDefs.Perms.WRITE, new Id("digest", DigestAuthenticationProvider.generateDigest("test:test"))));
         ModelSpec<TestModel> aclModelSpec = ModelSpec.builder(modelSpec.path(), modelSpec.serializer()).withAclList(aclList).build();
         ModeledFramework<TestModel> client = ModeledFramework.wrap(async, aclModelSpec);
         complete(client.set(new TestModel("John", "Galt", "Galt's Gulch", 21, BigInteger.valueOf(1010101))));
-        complete(client.update(new TestModel("John", "Galt", "Galt's Gulch", 54, BigInteger.valueOf(88))), (__, e) -> Assert.assertNotNull(e, "Should've gotten an auth failure"));
+        complete(client.update(new TestModel("John", "Galt", "Galt's Gulch", 54, BigInteger.valueOf(88))), (__, e) -> assertNotNull(e, "Should've gotten an auth failure"));
 
         try (CuratorFramework authCurator = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).authorization("digest", "test:test".getBytes()).build())
         {
             authCurator.start();
             ModeledFramework<TestModel> authClient = ModeledFramework.wrap(AsyncCuratorFramework.wrap(authCurator), aclModelSpec);
-            complete(authClient.update(new TestModel("John", "Galt", "Galt's Gulch", 42, BigInteger.valueOf(66))), (__, e) -> Assert.assertNull(e, "Should've succeeded"));
+            complete(authClient.update(new TestModel("John", "Galt", "Galt's Gulch", 42, BigInteger.valueOf(66))), (__, e) -> assertNull(e, "Should've succeeded"));
         }
     }
 }

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestModeledFrameworkBase.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestModeledFrameworkBase.java
@@ -26,8 +26,8 @@ import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.CompletableBaseClassForTests;
 import org.apache.curator.x.async.modeled.models.TestModel;
 import org.apache.curator.x.async.modeled.models.TestNewerModel;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class TestModeledFrameworkBase extends CompletableBaseClassForTests
 {
@@ -37,7 +37,7 @@ public class TestModeledFrameworkBase extends CompletableBaseClassForTests
     protected ModelSpec<TestNewerModel> newModelSpec;
     protected AsyncCuratorFramework async;
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setup() throws Exception
     {
@@ -54,7 +54,7 @@ public class TestModeledFrameworkBase extends CompletableBaseClassForTests
         newModelSpec = ModelSpec.builder(path, newSerializer).build();
     }
 
-    @AfterMethod
+    @AfterEach
     @Override
     public void teardown() throws Exception
     {

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestZPath.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestZPath.java
@@ -18,109 +18,114 @@
  */
 package org.apache.curator.x.async.modeled;
 
+import static org.apache.curator.x.async.modeled.ZPath.parameter;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.curator.x.async.modeled.details.ZPathImpl;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import static org.apache.curator.x.async.modeled.ZPath.parameter;
+import org.junit.jupiter.api.Test;
 
 public class TestZPath
 {
     @Test
     public void testRoot()
     {
-        Assert.assertEquals(ZPath.root.nodeName(), ZKPaths.PATH_SEPARATOR);
-        Assert.assertEquals(ZPath.root, ZPathImpl.root);
-        Assert.assertTrue(ZPath.root.isRoot());
-        Assert.assertEquals(ZPath.root.child("foo").parent(), ZPath.root);
-        Assert.assertTrue(ZPath.root.child("foo").parent().isRoot());
+        assertEquals(ZPath.root.nodeName(), ZKPaths.PATH_SEPARATOR);
+        assertEquals(ZPath.root, ZPathImpl.root);
+        assertTrue(ZPath.root.isRoot());
+        assertEquals(ZPath.root.child("foo").parent(), ZPath.root);
+        assertTrue(ZPath.root.child("foo").parent().isRoot());
     }
 
     @Test
     public void testBasic()
     {
         ZPath path = ZPath.root.child("one").child("two");
-        Assert.assertFalse(path.isRoot());
-        Assert.assertEquals(path, ZPath.root.child("one").child("two"));
-        Assert.assertNotEquals(path, ZPath.root.child("onex").child("two"));
-        Assert.assertEquals(path.nodeName(), "two");
-        Assert.assertEquals(path.fullPath(), "/one/two");
-        Assert.assertEquals(path.parent().fullPath(), "/one");
-        Assert.assertEquals(path.fullPath(), "/one/two");       // call twice to test the internal cache
-        Assert.assertEquals(path.parent().fullPath(), "/one");  // call twice to test the internal cache
+        assertFalse(path.isRoot());
+        assertEquals(path, ZPath.root.child("one").child("two"));
+        assertNotEquals(path, ZPath.root.child("onex").child("two"));
+        assertEquals(path.nodeName(), "two");
+        assertEquals(path.fullPath(), "/one/two");
+        assertEquals(path.parent().fullPath(), "/one");
+        assertEquals(path.fullPath(), "/one/two");       // call twice to test the internal cache
+        assertEquals(path.parent().fullPath(), "/one");  // call twice to test the internal cache
 
-        Assert.assertTrue(path.startsWith(ZPath.root.child("one")));
-        Assert.assertFalse(path.startsWith(ZPath.root.child("two")));
+        assertTrue(path.startsWith(ZPath.root.child("one")));
+        assertFalse(path.startsWith(ZPath.root.child("two")));
 
         ZPath checkIdLike = ZPath.parse("/one/{two}/three");
-        Assert.assertTrue(checkIdLike.isResolved());
+        assertTrue(checkIdLike.isResolved());
         checkIdLike = ZPath.parse("/one/" + ZPath.parameter() + "/three");
-        Assert.assertTrue(checkIdLike.isResolved());
+        assertTrue(checkIdLike.isResolved());
         checkIdLike = ZPath.parse("/one/" + ZPath.parameter("others") + "/three");
-        Assert.assertTrue(checkIdLike.isResolved());
+        assertTrue(checkIdLike.isResolved());
     }
 
     @Test
     public void testParsing()
     {
-        Assert.assertEquals(ZPath.parse("/"), ZPath.root);
-        Assert.assertEquals(ZPath.parse("/one/two/three"), ZPath.root.child("one").child("two").child("three"));
-        Assert.assertEquals(ZPath.parse("/one/two/three"), ZPath.from("one", "two", "three"));
-        Assert.assertEquals(ZPath.parseWithIds("/one/{id}/two/{id}"), ZPath.from("one", parameter(), "two", parameter()));
+        assertEquals(ZPath.parse("/"), ZPath.root);
+        assertEquals(ZPath.parse("/one/two/three"), ZPath.root.child("one").child("two").child("three"));
+        assertEquals(ZPath.parse("/one/two/three"), ZPath.from("one", "two", "three"));
+        assertEquals(ZPath.parseWithIds("/one/{id}/two/{id}"), ZPath.from("one", parameter(), "two", parameter()));
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test
     public void testUnresolvedPath()
     {
-        ZPath path = ZPath.from("one", parameter(), "two");
-        path.fullPath();
+        assertThrows(IllegalStateException.class, ()->{
+            ZPath path = ZPath.from("one", parameter(), "two");
+            path.fullPath();
+        });
     }
 
     @Test
     public void testResolvedPath()
     {
         ZPath path = ZPath.from("one", parameter(), "two", parameter());
-        Assert.assertEquals(path.resolved("a", "b"), ZPath.from("one", "a", "two", "b"));
+        assertEquals(path.resolved("a", "b"), ZPath.from("one", "a", "two", "b"));
     }
 
     @Test
     public void testSchema()
     {
         ZPath path = ZPath.from("one", parameter(), "two", parameter());
-        Assert.assertEquals(path.toSchemaPathPattern().toString(), "/one/.*/two/.*");
+        assertEquals(path.toSchemaPathPattern().toString(), "/one/.*/two/.*");
         path = ZPath.parse("/one/two/three");
-        Assert.assertEquals(path.toSchemaPathPattern().toString(), "/one/two/three");
+        assertEquals(path.toSchemaPathPattern().toString(), "/one/two/three");
         path = ZPath.parseWithIds("/one/{id}/three");
-        Assert.assertEquals(path.toSchemaPathPattern().toString(), "/one/.*/three");
+        assertEquals(path.toSchemaPathPattern().toString(), "/one/.*/three");
         path = ZPath.parseWithIds("/{id}/{id}/three");
-        Assert.assertEquals(path.toSchemaPathPattern().toString(), "/.*/.*/three");
+        assertEquals(path.toSchemaPathPattern().toString(), "/.*/.*/three");
     }
 
     @Test
     public void testCustomIds()
     {
-        Assert.assertEquals(ZPath.parseWithIds("/a/{a}/bee/{bee}/c/{c}").toString(), "/a/{a}/bee/{bee}/c/{c}");
-        Assert.assertEquals(ZPath.from("a", parameter(), "b", parameter()).toString(), "/a/{id}/b/{id}");
-        Assert.assertEquals(ZPath.from("a", parameter("foo"), "b", parameter("bar")).toString(), "/a/{foo}/b/{bar}");
+        assertEquals(ZPath.parseWithIds("/a/{a}/bee/{bee}/c/{c}").toString(), "/a/{a}/bee/{bee}/c/{c}");
+        assertEquals(ZPath.from("a", parameter(), "b", parameter()).toString(), "/a/{id}/b/{id}");
+        assertEquals(ZPath.from("a", parameter("foo"), "b", parameter("bar")).toString(), "/a/{foo}/b/{bar}");
     }
 
     @Test
     public void testPartialResolution()
     {
         ZPath path = ZPath.parseWithIds("/one/{1}/two/{2}");
-        Assert.assertFalse(path.parent().isResolved());
-        Assert.assertFalse(path.parent().parent().isResolved());
-        Assert.assertTrue(path.parent().parent().parent().isResolved());
-        Assert.assertFalse(path.isResolved());
+        assertFalse(path.parent().isResolved());
+        assertFalse(path.parent().parent().isResolved());
+        assertTrue(path.parent().parent().parent().isResolved());
+        assertFalse(path.isResolved());
 
         path = path.resolved("p1");
-        Assert.assertFalse(path.isResolved());
-        Assert.assertTrue(path.parent().isResolved());
-        Assert.assertEquals(path.toString(), "/one/p1/two/{2}");
+        assertFalse(path.isResolved());
+        assertTrue(path.parent().isResolved());
+        assertEquals(path.toString(), "/one/p1/two/{2}");
 
         path = path.resolved("p2");
-        Assert.assertTrue(path.isResolved());
-        Assert.assertEquals(path.toString(), "/one/p1/two/p2");
+        assertTrue(path.isResolved());
+        assertEquals(path.toString(), "/one/p1/two/p2");
     }
 }

--- a/curator-x-discovery-server/pom.xml
+++ b/curator-x-discovery-server/pom.xml
@@ -62,8 +62,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestMapsWithJersey.java
+++ b/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestMapsWithJersey.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.x.discovery.server.jetty_jersey;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -39,13 +40,12 @@ import org.apache.curator.x.discovery.server.entity.ServiceInstances;
 import org.apache.curator.x.discovery.server.entity.ServiceNames;
 import org.apache.curator.x.discovery.server.mocks.MockServiceDiscovery;
 import org.apache.curator.x.discovery.strategies.RandomStrategy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
@@ -60,7 +60,7 @@ public class TestMapsWithJersey
     private MapDiscoveryContext context;
     private int port;
 
-    @BeforeMethod
+    @BeforeEach
     public void         setup() throws Exception
     {
         context = new MapDiscoveryContext(new MockServiceDiscovery<Map<String, String>>(), new RandomStrategy<Map<String, String>>(), 1000);
@@ -98,7 +98,7 @@ public class TestMapsWithJersey
         server.start();
     }
     
-    @AfterMethod
+    @AfterEach
     public void         teardown() throws Exception
     {
         server.stop();
@@ -136,18 +136,18 @@ public class TestMapsWithJersey
         resource.path("/v1/service/test/" + service.getId()).type(MediaType.APPLICATION_JSON_TYPE).put(service);
 
         ServiceNames names = resource.path("/v1/service").get(ServiceNames.class);
-        Assert.assertEquals(names.getNames(), Lists.newArrayList("test"));
+        assertEquals(names.getNames(), Lists.newArrayList("test"));
 
         GenericType<ServiceInstances<Map<String, String>>> type = new GenericType<ServiceInstances<Map<String, String>>>(){};
         ServiceInstances<Map<String, String>>    instances = resource.path("/v1/service/test").get(type);
-        Assert.assertEquals(instances.getServices().size(), 1);
-        Assert.assertEquals(instances.getServices().get(0), service);
-        Assert.assertEquals(instances.getServices().get(0).getPayload(), payload);
+        assertEquals(instances.getServices().size(), 1);
+        assertEquals(instances.getServices().get(0), service);
+        assertEquals(instances.getServices().get(0).getPayload(), payload);
 
         // Retrieve a single instance
         GenericType<ServiceInstance<Map<String, String>>> singleInstanceType = new GenericType<ServiceInstance<Map<String, String>>>(){};
         ServiceInstance<Map<String, String>>    instance = resource.path("/v1/service/test/" + service.getId()).get(singleInstanceType);
-        Assert.assertEquals(instance, service);
+        assertEquals(instance, service);
 
     }
 }

--- a/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestMapsWithJersey.java
+++ b/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestMapsWithJersey.java
@@ -53,6 +53,7 @@ import java.util.Set;
 
 public class TestMapsWithJersey
 {
+    private static final String HOST = "127.0.0.1";
     private Server server;
     private JsonServiceNamesMarshaller serviceNamesMarshaller;
     private JsonServiceInstanceMarshaller<Map<String, String>> serviceInstanceMarshaller;
@@ -132,7 +133,7 @@ public class TestMapsWithJersey
             }
         };
         Client          client = Client.create(config);
-        WebResource     resource = client.resource("http://localhost:" + port);
+        WebResource     resource = client.resource("http://" + HOST + ":" + port);
         resource.path("/v1/service/test/" + service.getId()).type(MediaType.APPLICATION_JSON_TYPE).put(service);
 
         ServiceNames names = resource.path("/v1/service").get(ServiceNames.class);

--- a/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestObjectPayloadWithJersey.java
+++ b/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestObjectPayloadWithJersey.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.x.discovery.server.jetty_jersey;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.sun.jersey.api.client.Client;
@@ -37,13 +38,12 @@ import org.apache.curator.x.discovery.server.entity.ServiceInstances;
 import org.apache.curator.x.discovery.server.entity.ServiceNames;
 import org.apache.curator.x.discovery.server.mocks.MockServiceDiscovery;
 import org.apache.curator.x.discovery.strategies.RandomStrategy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import java.util.Set;
@@ -57,7 +57,7 @@ public class TestObjectPayloadWithJersey
     private ServiceDetailsDiscoveryContext context;
     private int port;
 
-    @BeforeMethod
+    @BeforeEach
     public void         setup() throws Exception
     {
         context = new ServiceDetailsDiscoveryContext(new MockServiceDiscovery<ServiceDetails>(), new RandomStrategy<ServiceDetails>(), 1000);
@@ -95,7 +95,7 @@ public class TestObjectPayloadWithJersey
         server.start();
     }
     
-    @AfterMethod
+    @AfterEach
     public void         teardown() throws Exception
     {
         server.stop();
@@ -134,18 +134,18 @@ public class TestObjectPayloadWithJersey
 	        resource.path("/v1/service/test/" + service.getId()).type(MediaType.APPLICATION_JSON_TYPE).put(service);
 
         ServiceNames names = resource.path("/v1/service").get(ServiceNames.class);
-        Assert.assertEquals(names.getNames(), Lists.newArrayList("test"));
+        assertEquals(names.getNames(), Lists.newArrayList("test"));
 
         GenericType<ServiceInstances<ServiceDetails>> type = new GenericType<ServiceInstances<ServiceDetails>>(){};
         ServiceInstances<ServiceDetails>    instances = resource.path("/v1/service/test").get(type);
-        Assert.assertEquals(instances.getServices().size(), 1);
-        Assert.assertEquals(instances.getServices().get(0), service);
-        Assert.assertEquals(instances.getServices().get(0).getPayload(), payload);
+        assertEquals(instances.getServices().size(), 1);
+        assertEquals(instances.getServices().get(0), service);
+        assertEquals(instances.getServices().get(0).getPayload(), payload);
 
         // Retrieve a single instance
         GenericType<ServiceInstance<ServiceDetails>> singleInstanceType = new GenericType<ServiceInstance<ServiceDetails>>(){};
         ServiceInstance<ServiceDetails>    instance = resource.path("/v1/service/test/" + service.getId()).get(singleInstanceType);
-        Assert.assertEquals(instance, service);
+        assertEquals(instance, service);
 
     }
 }

--- a/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestObjectPayloadWithJersey.java
+++ b/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestObjectPayloadWithJersey.java
@@ -50,6 +50,7 @@ import java.util.Set;
 
 public class TestObjectPayloadWithJersey
 {
+    private static final String HOST = "127.0.0.1";
     private Server server;
     private JsonServiceNamesMarshaller serviceNamesMarshaller;
     private JsonServiceInstanceMarshaller<ServiceDetails> serviceInstanceMarshaller;
@@ -130,7 +131,7 @@ public class TestObjectPayloadWithJersey
             }
         };
         Client          client = Client.create(config);
-        WebResource     resource = client.resource("http://localhost:" + port);
+        WebResource     resource = client.resource("http://" + HOST + ":" + port);
 	        resource.path("/v1/service/test/" + service.getId()).type(MediaType.APPLICATION_JSON_TYPE).put(service);
 
         ServiceNames names = resource.path("/v1/service").get(ServiceNames.class);

--- a/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestStringsWithJersey.java
+++ b/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestStringsWithJersey.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.x.discovery.server.jetty_jersey;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.sun.jersey.api.client.Client;
@@ -38,13 +39,12 @@ import org.apache.curator.x.discovery.server.entity.ServiceInstances;
 import org.apache.curator.x.discovery.server.entity.ServiceNames;
 import org.apache.curator.x.discovery.server.mocks.MockServiceDiscovery;
 import org.apache.curator.x.discovery.strategies.RandomStrategy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import java.util.Set;
@@ -58,7 +58,7 @@ public class TestStringsWithJersey
     private StringDiscoveryContext context;
     private int port;
 
-    @BeforeMethod
+    @BeforeEach
     public void         setup() throws Exception
     {
         context = new StringDiscoveryContext(new MockServiceDiscovery<String>(), new RandomStrategy<String>(), 1000);
@@ -96,7 +96,7 @@ public class TestStringsWithJersey
         server.start();
     }
     
-    @AfterMethod
+    @AfterEach
     public void         teardown() throws Exception
     {
         server.stop();
@@ -130,17 +130,17 @@ public class TestStringsWithJersey
         resource.path("/v1/service/test/" + service.getId()).type(MediaType.APPLICATION_JSON_TYPE).put(service);
 
         ServiceNames names = resource.path("/v1/service").get(ServiceNames.class);
-        Assert.assertEquals(names.getNames(), Lists.newArrayList("test"));
+        assertEquals(names.getNames(), Lists.newArrayList("test"));
 
         GenericType<ServiceInstances<String>> type = new GenericType<ServiceInstances<String>>(){};
         ServiceInstances<String> instances = resource.path("/v1/service/test").get(type);
-        Assert.assertEquals(instances.getServices().size(), 1);
-        Assert.assertEquals(instances.getServices().get(0), service);
+        assertEquals(instances.getServices().size(), 1);
+        assertEquals(instances.getServices().get(0), service);
 
         // Retrieve a single instance
         GenericType<ServiceInstance<String>> singleInstanceType = new GenericType<ServiceInstance<String>>(){};
         ServiceInstance<String>    instance = resource.path("/v1/service/test/" + service.getId()).get(singleInstanceType);
-        Assert.assertEquals(instance, service);
+        assertEquals(instance, service);
     }
 
     @Test
@@ -162,6 +162,6 @@ public class TestStringsWithJersey
         Client          client = Client.create(config);
         WebResource     resource = client.resource("http://localhost:" + port);
         ServiceNames names = resource.path("/v1/service").get(ServiceNames.class);
-        Assert.assertEquals(names.getNames(), Lists.<String>newArrayList());
+        assertEquals(names.getNames(), Lists.<String>newArrayList());
     }
 }

--- a/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestStringsWithJersey.java
+++ b/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_jersey/TestStringsWithJersey.java
@@ -51,6 +51,7 @@ import java.util.Set;
 
 public class TestStringsWithJersey
 {
+    private static final String HOST = "127.0.0.1";
     private Server server;
     private JsonServiceNamesMarshaller serviceNamesMarshaller;
     private JsonServiceInstanceMarshaller<String> serviceInstanceMarshaller;
@@ -126,7 +127,7 @@ public class TestStringsWithJersey
             }
         };
         Client          client = Client.create(config);
-        WebResource     resource = client.resource("http://localhost:" + port);
+        WebResource     resource = client.resource("http://" + HOST + ":" + port);
         resource.path("/v1/service/test/" + service.getId()).type(MediaType.APPLICATION_JSON_TYPE).put(service);
 
         ServiceNames names = resource.path("/v1/service").get(ServiceNames.class);
@@ -160,7 +161,7 @@ public class TestStringsWithJersey
             }
         };
         Client          client = Client.create(config);
-        WebResource     resource = client.resource("http://localhost:" + port);
+        WebResource     resource = client.resource("http://" + HOST + ":" + port);
         ServiceNames names = resource.path("/v1/service").get(ServiceNames.class);
         assertEquals(names.getNames(), Lists.<String>newArrayList());
     }

--- a/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_resteasy/TestStringsWithRestEasy.java
+++ b/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_resteasy/TestStringsWithRestEasy.java
@@ -18,6 +18,7 @@
  */
 package org.apache.curator.x.discovery.server.jetty_resteasy;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.Lists;
 import com.google.common.io.ByteSource;
 import com.google.common.io.CharStreams;
@@ -29,13 +30,12 @@ import org.apache.curator.x.discovery.server.entity.ServiceNames;
 import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 import javax.ws.rs.core.MediaType;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -53,7 +53,7 @@ public class TestStringsWithRestEasy
     private Server server;
     private int port;
 
-    @BeforeMethod
+    @BeforeEach
     public void         setup() throws Exception
     {
         RestEasyApplication.singletonsRef.set(new RestEasySingletons());
@@ -71,7 +71,7 @@ public class TestStringsWithRestEasy
         server.start();
     }
 
-    @AfterMethod
+    @AfterEach
     public void         teardown() throws Exception
     {
         server.stop();
@@ -96,17 +96,17 @@ public class TestStringsWithRestEasy
 
         String json = getJson("http://localhost:" + port + "/v1/service", null);
         ServiceNames names = restEasySingletons.serviceNamesMarshallerSingleton.readFrom(ServiceNames.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, new ByteArrayInputStream(json.getBytes()));
-        Assert.assertEquals(names.getNames(), Lists.newArrayList("test"));
+        assertEquals(names.getNames(), Lists.newArrayList("test"));
 
         json = getJson("http://localhost:" + port + "/v1/service/test", null);
         ServiceInstances<String> instances = restEasySingletons.serviceInstancesMarshallerSingleton.readFrom(null, null, null, null, null, new ByteArrayInputStream(json.getBytes()));
-        Assert.assertEquals(instances.getServices().size(), 1);
-        Assert.assertEquals(instances.getServices().get(0), service);
+        assertEquals(instances.getServices().size(), 1);
+        assertEquals(instances.getServices().get(0), service);
 
         // Retrieve single instance
         json = getJson("http://localhost:" + port + "/v1/service/test/" + service.getId(), null);
         ServiceInstance<String> instance = restEasySingletons.serviceInstanceMarshallerSingleton.readFrom(null, null, null, null, null, new ByteArrayInputStream(json.getBytes()));
-        Assert.assertEquals(instance, service);
+        assertEquals(instance, service);
 
     }
 
@@ -116,7 +116,7 @@ public class TestStringsWithRestEasy
         String          json = getJson("http://localhost:" + port + "/v1/service", null);
         ServiceNames    names = RestEasyApplication.singletonsRef.get().serviceNamesMarshallerSingleton.readFrom(ServiceNames.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, new ByteArrayInputStream(json.getBytes()));
 
-        Assert.assertEquals(names.getNames(), Lists.<String>newArrayList());
+        assertEquals(names.getNames(), Lists.<String>newArrayList());
     }
 
     private String getJson(String urlStr, String body) throws IOException

--- a/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_resteasy/TestStringsWithRestEasy.java
+++ b/curator-x-discovery-server/src/test/java/org/apache/curator/x/discovery/server/jetty_resteasy/TestStringsWithRestEasy.java
@@ -50,6 +50,7 @@ import java.net.URLConnection;
 @SuppressWarnings("unchecked")
 public class TestStringsWithRestEasy
 {
+    private static final String HOST = "127.0.0.1";
     private Server server;
     private int port;
 
@@ -92,19 +93,19 @@ public class TestStringsWithRestEasy
         ByteArrayOutputStream           out = new ByteArrayOutputStream();
         restEasySingletons.serviceInstanceMarshallerSingleton.writeTo(service, null, null, null, null, null, out);
 
-        getJson("http://localhost:" + port + "/v1/service/test/" + service.getId(), new String(out.toByteArray()));
+        getJson("http://" + HOST + ":" + port + "/v1/service/test/" + service.getId(), new String(out.toByteArray()));
 
-        String json = getJson("http://localhost:" + port + "/v1/service", null);
+        String json = getJson("http://" + HOST + ":" + port + "/v1/service", null);
         ServiceNames names = restEasySingletons.serviceNamesMarshallerSingleton.readFrom(ServiceNames.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, new ByteArrayInputStream(json.getBytes()));
         assertEquals(names.getNames(), Lists.newArrayList("test"));
 
-        json = getJson("http://localhost:" + port + "/v1/service/test", null);
+        json = getJson("http://" + HOST + ":" + port + "/v1/service/test", null);
         ServiceInstances<String> instances = restEasySingletons.serviceInstancesMarshallerSingleton.readFrom(null, null, null, null, null, new ByteArrayInputStream(json.getBytes()));
         assertEquals(instances.getServices().size(), 1);
         assertEquals(instances.getServices().get(0), service);
 
         // Retrieve single instance
-        json = getJson("http://localhost:" + port + "/v1/service/test/" + service.getId(), null);
+        json = getJson("http://" + HOST + ":" + port + "/v1/service/test/" + service.getId(), null);
         ServiceInstance<String> instance = restEasySingletons.serviceInstanceMarshallerSingleton.readFrom(null, null, null, null, null, new ByteArrayInputStream(json.getBytes()));
         assertEquals(instance, service);
 
@@ -113,7 +114,7 @@ public class TestStringsWithRestEasy
     @Test
     public void     testEmptyServiceNames() throws Exception
     {
-        String          json = getJson("http://localhost:" + port + "/v1/service", null);
+        String          json = getJson("http://" + HOST + ":" + port + "/v1/service", null);
         ServiceNames    names = RestEasyApplication.singletonsRef.get().serviceNamesMarshallerSingleton.readFrom(ServiceNames.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, new ByteArrayInputStream(json.getBytes()));
 
         assertEquals(names.getNames(), Lists.<String>newArrayList());

--- a/curator-x-discovery/pom.xml
+++ b/curator-x-discovery/pom.xml
@@ -63,8 +63,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.artsok</groupId>
+            <artifactId>rerunner-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/curator-x-discovery/pom.xml
+++ b/curator-x-discovery/pom.xml
@@ -69,12 +69,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.artsok</groupId>
-            <artifactId>rerunner-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/ServiceCacheLeakTester.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/ServiceCacheLeakTester.java
@@ -25,9 +25,9 @@ import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.x.discovery.strategies.RandomStrategy;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class ServiceCacheLeakTester
 {
     public static void main(String[] args) throws Exception

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestJsonInstanceSerializer.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestJsonInstanceSerializer.java
@@ -18,14 +18,15 @@
  */
 package org.apache.curator.x.discovery;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.curator.x.discovery.details.JsonInstanceSerializer;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestJsonInstanceSerializer
 {
@@ -37,15 +38,15 @@ public class TestJsonInstanceSerializer
         byte[]                          bytes = serializer.serialize(instance);
 
         ServiceInstance<String>         rhs = serializer.deserialize(bytes);
-        Assert.assertEquals(instance, rhs);
-        Assert.assertEquals(instance.getId(), rhs.getId());
-        Assert.assertEquals(instance.getName(), rhs.getName());
-        Assert.assertEquals(instance.getPayload(), rhs.getPayload());
-        Assert.assertEquals(instance.getAddress(), rhs.getAddress());
-        Assert.assertEquals(instance.getPort(), rhs.getPort());
-        Assert.assertEquals(instance.getSslPort(), rhs.getSslPort());
-        Assert.assertEquals(instance.getUriSpec(), rhs.getUriSpec());
-        Assert.assertEquals(instance.isEnabled(), rhs.isEnabled());
+        assertEquals(instance, rhs);
+        assertEquals(instance.getId(), rhs.getId());
+        assertEquals(instance.getName(), rhs.getName());
+        assertEquals(instance.getPayload(), rhs.getPayload());
+        assertEquals(instance.getAddress(), rhs.getAddress());
+        assertEquals(instance.getPort(), rhs.getPort());
+        assertEquals(instance.getSslPort(), rhs.getSslPort());
+        assertEquals(instance.getUriSpec(), rhs.getUriSpec());
+        assertEquals(instance.isEnabled(), rhs.isEnabled());
     }
 
     @Test
@@ -58,7 +59,7 @@ public class TestJsonInstanceSerializer
         try
         {
             doubleSerializer.deserialize(bytes);
-            Assert.fail();
+            fail();
         }
         catch ( ClassCastException e )
         {
@@ -74,15 +75,15 @@ public class TestJsonInstanceSerializer
         byte[]                          bytes = serializer.serialize(instance);
 
         ServiceInstance<Void>           rhs = serializer.deserialize(bytes);
-        Assert.assertEquals(instance, rhs);
-        Assert.assertEquals(instance.getId(), rhs.getId());
-        Assert.assertEquals(instance.getName(), rhs.getName());
-        Assert.assertEquals(instance.getPayload(), rhs.getPayload());
-        Assert.assertEquals(instance.getAddress(), rhs.getAddress());
-        Assert.assertEquals(instance.getPort(), rhs.getPort());
-        Assert.assertEquals(instance.getSslPort(), rhs.getSslPort());
-        Assert.assertEquals(instance.getUriSpec(), rhs.getUriSpec());
-        Assert.assertEquals(instance.isEnabled(), rhs.isEnabled());
+        assertEquals(instance, rhs);
+        assertEquals(instance.getId(), rhs.getId());
+        assertEquals(instance.getName(), rhs.getName());
+        assertEquals(instance.getPayload(), rhs.getPayload());
+        assertEquals(instance.getAddress(), rhs.getAddress());
+        assertEquals(instance.getPort(), rhs.getPort());
+        assertEquals(instance.getSslPort(), rhs.getSslPort());
+        assertEquals(instance.getUriSpec(), rhs.getUriSpec());
+        assertEquals(instance.isEnabled(), rhs.isEnabled());
     }
 
     @Test
@@ -92,7 +93,7 @@ public class TestJsonInstanceSerializer
         byte[]                          bytes = "{}".getBytes("utf-8");
 
         ServiceInstance<Void>           instance = serializer.deserialize(bytes);
-        Assert.assertTrue(instance.isEnabled(), "Instance that has no 'enabled' should be assumed enabled");
+        assertTrue(instance.isEnabled(), "Instance that has no 'enabled' should be assumed enabled");
     }
 
     @Test
@@ -106,15 +107,15 @@ public class TestJsonInstanceSerializer
         byte[]                            bytes = serializer.serialize(instance);
 
         ServiceInstance<Object>           rhs = serializer.deserialize(bytes);
-        Assert.assertEquals(instance, rhs);
-        Assert.assertEquals(instance.getId(), rhs.getId());
-        Assert.assertEquals(instance.getName(), rhs.getName());
-        Assert.assertEquals(instance.getPayload(), rhs.getPayload());
-        Assert.assertEquals(instance.getAddress(), rhs.getAddress());
-        Assert.assertEquals(instance.getPort(), rhs.getPort());
-        Assert.assertEquals(instance.getSslPort(), rhs.getSslPort());
-        Assert.assertEquals(instance.getUriSpec(), rhs.getUriSpec());
-        Assert.assertEquals(instance.isEnabled(), rhs.isEnabled());
+        assertEquals(instance, rhs);
+        assertEquals(instance.getId(), rhs.getId());
+        assertEquals(instance.getName(), rhs.getName());
+        assertEquals(instance.getPayload(), rhs.getPayload());
+        assertEquals(instance.getAddress(), rhs.getAddress());
+        assertEquals(instance.getPort(), rhs.getPort());
+        assertEquals(instance.getSslPort(), rhs.getSslPort());
+        assertEquals(instance.getUriSpec(), rhs.getUriSpec());
+        assertEquals(instance.isEnabled(), rhs.isEnabled());
     }
 
 
@@ -129,15 +130,15 @@ public class TestJsonInstanceSerializer
         byte[]                            bytes = serializer.serialize(instance);
 
         ServiceInstance<Object>           rhs = serializer.deserialize(bytes);
-        Assert.assertEquals(instance, rhs);
-        Assert.assertEquals(instance.getId(), rhs.getId());
-        Assert.assertEquals(instance.getName(), rhs.getName());
-        Assert.assertEquals(instance.getPayload(), rhs.getPayload());
-        Assert.assertEquals(instance.getAddress(), rhs.getAddress());
-        Assert.assertEquals(instance.getPort(), rhs.getPort());
-        Assert.assertEquals(instance.getSslPort(), rhs.getSslPort());
-        Assert.assertEquals(instance.getUriSpec(), rhs.getUriSpec());
-        Assert.assertEquals(instance.isEnabled(), rhs.isEnabled());
+        assertEquals(instance, rhs);
+        assertEquals(instance.getId(), rhs.getId());
+        assertEquals(instance.getName(), rhs.getName());
+        assertEquals(instance.getPayload(), rhs.getPayload());
+        assertEquals(instance.getAddress(), rhs.getAddress());
+        assertEquals(instance.getPort(), rhs.getPort());
+        assertEquals(instance.getSslPort(), rhs.getSslPort());
+        assertEquals(instance.getUriSpec(), rhs.getUriSpec());
+        assertEquals(instance.isEnabled(), rhs.isEnabled());
     }
 
     @Test
@@ -150,15 +151,15 @@ public class TestJsonInstanceSerializer
         byte[]                             bytes = serializer.serialize(instance);
 
         ServiceInstance<Payload>           rhs = serializer.deserialize(bytes);
-        Assert.assertEquals(instance, rhs);
-        Assert.assertEquals(instance.getId(), rhs.getId());
-        Assert.assertEquals(instance.getName(), rhs.getName());
-        Assert.assertEquals(instance.getPayload(), rhs.getPayload());
-        Assert.assertEquals(instance.getAddress(), rhs.getAddress());
-        Assert.assertEquals(instance.getPort(), rhs.getPort());
-        Assert.assertEquals(instance.getSslPort(), rhs.getSslPort());
-        Assert.assertEquals(instance.getUriSpec(), rhs.getUriSpec());
-        Assert.assertEquals(instance.isEnabled(), rhs.isEnabled());
+        assertEquals(instance, rhs);
+        assertEquals(instance.getId(), rhs.getId());
+        assertEquals(instance.getName(), rhs.getName());
+        assertEquals(instance.getPayload(), rhs.getPayload());
+        assertEquals(instance.getAddress(), rhs.getAddress());
+        assertEquals(instance.getPort(), rhs.getPort());
+        assertEquals(instance.getSslPort(), rhs.getSslPort());
+        assertEquals(instance.getUriSpec(), rhs.getUriSpec());
+        assertEquals(instance.isEnabled(), rhs.isEnabled());
     }
 
     public static class Payload {

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestLocalIpFilter.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestLocalIpFilter.java
@@ -18,9 +18,10 @@
  */
 package org.apache.curator.x.discovery;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -47,7 +48,7 @@ public class TestLocalIpFilter
                 );
 
             List<InetAddress> allLocalIPs = Lists.newArrayList(ServiceInstanceBuilder.getAllLocalIPs());
-            Assert.assertEquals(allLocalIPs.size(), 0);
+            assertEquals(allLocalIPs.size(), 0);
         }
         finally
         {
@@ -55,6 +56,6 @@ public class TestLocalIpFilter
         }
 
         List<InetAddress> allLocalIPs = Lists.newArrayList(ServiceInstanceBuilder.getAllLocalIPs());
-        Assert.assertTrue(allLocalIPs.size() > 0);
+        assertTrue(allLocalIPs.size() > 0);
     }
 }

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestServiceCache.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestServiceCache.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -36,6 +35,8 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.utils.Compatibility;
 import org.apache.curator.x.discovery.details.ServiceCacheListener;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.io.Closeable;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestServiceCache extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testInitialLoad() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();
@@ -107,7 +108,7 @@ public class TestServiceCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testViaProvider() throws Exception
     {
         Timing timing = new Timing();
@@ -156,7 +157,7 @@ public class TestServiceCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testUpdate() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();
@@ -208,7 +209,7 @@ public class TestServiceCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCache() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();
@@ -264,7 +265,7 @@ public class TestServiceCache extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testExecutorServiceIsInvoked() throws Exception
     {
         if ( Compatibility.hasPersistentWatchers() )

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestServiceCache.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestServiceCache.java
@@ -19,7 +19,11 @@
 
 package org.apache.curator.x.discovery;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -31,8 +35,7 @@ import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.utils.Compatibility;
 import org.apache.curator.x.discovery.details.ServiceCacheListener;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.io.Closeable;
 import java.util.Collection;
 import java.util.Collections;
@@ -42,10 +45,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestServiceCache extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testInitialLoad() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();
@@ -86,13 +89,13 @@ public class TestServiceCache extends BaseClassForTests
             discovery.registerService(instance2);
             discovery.registerService(instance3);
 
-            Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
 
             ServiceCache<String> cache2 = discovery.serviceCacheBuilder().name("test").build();
             closeables.add(cache2);
             cache2.start();
 
-            Assert.assertEquals(cache2.getInstances().size(), 3);
+            assertEquals(cache2.getInstances().size(), 3);
         }
         finally
         {
@@ -104,7 +107,7 @@ public class TestServiceCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testViaProvider() throws Exception
     {
         Timing timing = new Timing();
@@ -131,17 +134,17 @@ public class TestServiceCache extends BaseClassForTests
             ServiceInstance<String> foundInstance = null;
             while ( foundInstance == null )
             {
-                Assert.assertTrue(count++ < 5);
+                assertTrue(count++ < 5);
                 foundInstance = serviceProvider.getInstance();
                 timing.sleepABit();
             }
-            Assert.assertEquals(foundInstance, instance);
+            assertEquals(foundInstance, instance);
 
             ServiceInstance<String> instance2 = ServiceInstance.<String>builder().address("foo").payload("thing").name("test").port(10064).build();
             discovery.registerService(instance2);
             timing.sleepABit();
             Collection<ServiceInstance<String>> allInstances = serviceProvider.getAllInstances();
-            Assert.assertEquals(allInstances.size(), 2);
+            assertEquals(allInstances.size(), 2);
         }
         finally
         {
@@ -153,7 +156,7 @@ public class TestServiceCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testUpdate() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();
@@ -190,10 +193,10 @@ public class TestServiceCache extends BaseClassForTests
             instance = ServiceInstance.<String>builder().payload("changed").name("test").port(10064).id(instance.getId()).build();
             discovery.updateService(instance);
 
-            Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
 
-            Assert.assertEquals(cache.getInstances().size(), 1);
-            Assert.assertEquals(cache.getInstances().get(0).getPayload(), instance.getPayload());
+            assertEquals(cache.getInstances().size(), 1);
+            assertEquals(cache.getInstances().get(0).getPayload(), instance.getPayload());
         }
         finally
         {
@@ -205,7 +208,7 @@ public class TestServiceCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCache() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();
@@ -242,14 +245,14 @@ public class TestServiceCache extends BaseClassForTests
             ServiceInstance<String> instance1 = ServiceInstance.<String>builder().payload("thing").name("test").port(10064).build();
             ServiceInstance<String> instance2 = ServiceInstance.<String>builder().payload("thing").name("test").port(10065).build();
             discovery.registerService(instance1);
-            Assert.assertTrue(semaphore.tryAcquire(10, TimeUnit.SECONDS));
+            assertTrue(semaphore.tryAcquire(10, TimeUnit.SECONDS));
 
             discovery.registerService(instance2);
-            Assert.assertTrue(semaphore.tryAcquire(3, TimeUnit.SECONDS));
+            assertTrue(semaphore.tryAcquire(3, TimeUnit.SECONDS));
 
             ServiceInstance<String> instance3 = ServiceInstance.<String>builder().payload("thing").name("another").port(10064).build();
             discovery.registerService(instance3);
-            Assert.assertFalse(semaphore.tryAcquire(3, TimeUnit.SECONDS));  // should not get called for a different service
+            assertFalse(semaphore.tryAcquire(3, TimeUnit.SECONDS));  // should not get called for a different service
         }
         finally
         {
@@ -261,7 +264,7 @@ public class TestServiceCache extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testExecutorServiceIsInvoked() throws Exception
     {
         if ( Compatibility.hasPersistentWatchers() )
@@ -281,7 +284,7 @@ public class TestServiceCache extends BaseClassForTests
             discovery.start();
 
             ExecuteCalledWatchingExecutorService exec = new ExecuteCalledWatchingExecutorService(Executors.newSingleThreadExecutor());
-            Assert.assertFalse(exec.isExecuteCalled());
+            assertFalse(exec.isExecuteCalled());
 
             ServiceCache<String> cache = discovery.serviceCacheBuilder().name("test").executorService(exec).build();
             closeables.add(cache);
@@ -305,9 +308,9 @@ public class TestServiceCache extends BaseClassForTests
 
             ServiceInstance<String> instance1 = ServiceInstance.<String>builder().payload("thing").name("test").port(10064).build();
             discovery.registerService(instance1);
-            Assert.assertTrue(semaphore.tryAcquire(10, TimeUnit.SECONDS));
+            assertTrue(semaphore.tryAcquire(10, TimeUnit.SECONDS));
 
-            Assert.assertTrue(exec.isExecuteCalled());
+            assertTrue(exec.isExecuteCalled());
         }
         finally
         {

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestStrategies.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestStrategies.java
@@ -18,14 +18,16 @@
  */
 package org.apache.curator.x.discovery;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import org.apache.curator.x.discovery.details.InstanceProvider;
 import org.apache.curator.x.discovery.strategies.RandomStrategy;
 import org.apache.curator.x.discovery.strategies.RoundRobinStrategy;
 import org.apache.curator.x.discovery.strategies.StickyStrategy;
 import org.apache.commons.math.stat.descriptive.SummaryStatistics;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 import java.util.List;
 
 public class TestStrategies
@@ -78,7 +80,7 @@ public class TestStrategies
         {
             statistic.addValue(counts[i]);
         }
-        Assert.assertTrue(statistic.getStandardDeviation() <= (QTY * 2), "" + statistic.getStandardDeviation()); // meager check for even distribution
+        assertTrue(statistic.getStandardDeviation() <= (QTY * 2), "" + statistic.getStandardDeviation()); // meager check for even distribution
     }
 
     @Test
@@ -92,13 +94,13 @@ public class TestStrategies
         for ( int i = 0; i < QTY; ++i )
         {
             ServiceInstance<Void> instance = strategy.getInstance(instanceProvider);
-            Assert.assertEquals(instance.getId(), Integer.toString(i));
+            assertEquals(instance.getId(), Integer.toString(i));
         }
 
         for ( int i = 0; i < (1234 * QTY); ++i )
         {
             ServiceInstance<Void> instance = strategy.getInstance(instanceProvider);
-            Assert.assertEquals(instance.getId(), Integer.toString(i % QTY));
+            assertEquals(instance.getId(), Integer.toString(i % QTY));
         }
     }
 
@@ -114,18 +116,18 @@ public class TestStrategies
         int                             instanceNumber = strategy.getInstanceNumber();
         for ( int i = 0; i < 1000; ++i )
         {
-            Assert.assertEquals(strategy.getInstance(instanceProvider), theInstance);
+            assertEquals(strategy.getInstance(instanceProvider), theInstance);
         }
 
         // assert what happens when an instance goes down
         instanceProvider = new TestInstanceProvider(QTY, QTY);
-        Assert.assertFalse(strategy.getInstance(instanceProvider).equals(theInstance));
-        Assert.assertFalse(instanceNumber == strategy.getInstanceNumber());
+        assertFalse(strategy.getInstance(instanceProvider).equals(theInstance));
+        assertFalse(instanceNumber == strategy.getInstanceNumber());
 
         theInstance = strategy.getInstance(instanceProvider);
         for ( int i = 0; i < 1000; ++i )
         {
-            Assert.assertEquals(strategy.getInstance(instanceProvider), theInstance);
+            assertEquals(strategy.getInstance(instanceProvider), theInstance);
         }
     }
 }

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestUriSpec.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/TestUriSpec.java
@@ -18,9 +18,9 @@
  */
 package org.apache.curator.x.discovery;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.Maps;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -36,11 +36,11 @@ public class TestUriSpec
         builder.name("foo");
         builder.port(5);
         ServiceInstance<Void>               instance = builder.build();
-        Assert.assertEquals(spec.build(instance), "http://foo.com");
+        assertEquals(spec.build(instance), "http://foo.com");
 
         builder.sslPort(5);
         instance = builder.build();
-        Assert.assertEquals(spec.build(instance), "https://foo.com");
+        assertEquals(spec.build(instance), "https://foo.com");
     }
 
     @Test
@@ -60,7 +60,7 @@ public class TestUriSpec
 
         Map<String, Object>     m = Maps.newHashMap();
         m.put("scheme", "test");
-        Assert.assertEquals(spec.build(instance, m), "test://1.2.3.4:5:6/foo/bar/789/permanent");
+        assertEquals(spec.build(instance, m), "test://1.2.3.4:5:6/foo/bar/789/permanent");
     }
 
     @Test
@@ -79,7 +79,7 @@ public class TestUriSpec
         Map<String, Object>     m = Maps.newHashMap();
         m.put("one", 1);
         m.put("six", 6);
-        Assert.assertEquals(spec.build(m), "1two-three-{four}-five6");
+        assertEquals(spec.build(m), "1two-three-{four}-five6");
     }
 
     @Test
@@ -97,7 +97,7 @@ public class TestUriSpec
 
     private void    checkPart(UriSpec.Part p, String value, boolean isVariable)
     {
-        Assert.assertEquals(p.getValue(), value);
-        Assert.assertEquals(p.isVariable(), isVariable);
+        assertEquals(p.getValue(), value);
+        assertEquals(p.isVariable(), isVariable);
     }
 }

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestDownInstanceManager.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestDownInstanceManager.java
@@ -18,10 +18,11 @@
  */
 package org.apache.curator.x.discovery.details;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.curator.x.discovery.DownInstancePolicy;
 import org.apache.curator.x.discovery.ServiceInstance;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 import java.util.concurrent.TimeUnit;
 
 public class TestDownInstanceManager
@@ -36,12 +37,12 @@ public class TestDownInstanceManager
         ServiceInstance<Void> instance2 = ServiceInstance.<Void>builder().name("hey").id("2").build();
 
         DownInstanceManager<Void> downInstanceManager = new DownInstanceManager<Void>(debugDownInstancePolicy);
-        Assert.assertTrue(downInstanceManager.apply(instance1));
-        Assert.assertTrue(downInstanceManager.apply(instance2));
+        assertTrue(downInstanceManager.apply(instance1));
+        assertTrue(downInstanceManager.apply(instance2));
 
         downInstanceManager.add(instance1);
-        Assert.assertFalse(downInstanceManager.apply(instance1));
-        Assert.assertTrue(downInstanceManager.apply(instance2));
+        assertFalse(downInstanceManager.apply(instance1));
+        assertTrue(downInstanceManager.apply(instance2));
     }
 
     @Test
@@ -51,16 +52,16 @@ public class TestDownInstanceManager
         ServiceInstance<Void> instance2 = ServiceInstance.<Void>builder().name("hey").id("2").build();
 
         DownInstanceManager<Void> downInstanceManager = new DownInstanceManager<Void>(debugMultiDownInstancePolicy);
-        Assert.assertTrue(downInstanceManager.apply(instance1));
-        Assert.assertTrue(downInstanceManager.apply(instance2));
+        assertTrue(downInstanceManager.apply(instance1));
+        assertTrue(downInstanceManager.apply(instance2));
 
         downInstanceManager.add(instance1);
-        Assert.assertTrue(downInstanceManager.apply(instance1));
-        Assert.assertTrue(downInstanceManager.apply(instance2));
+        assertTrue(downInstanceManager.apply(instance1));
+        assertTrue(downInstanceManager.apply(instance2));
 
         downInstanceManager.add(instance1);
-        Assert.assertFalse(downInstanceManager.apply(instance1));
-        Assert.assertTrue(downInstanceManager.apply(instance2));
+        assertFalse(downInstanceManager.apply(instance1));
+        assertTrue(downInstanceManager.apply(instance2));
     }
 
     @Test
@@ -72,12 +73,12 @@ public class TestDownInstanceManager
         DownInstanceManager<Void> downInstanceManager = new DownInstanceManager<Void>(debugDownInstancePolicy);
 
         downInstanceManager.add(instance1);
-        Assert.assertFalse(downInstanceManager.apply(instance1));
-        Assert.assertTrue(downInstanceManager.apply(instance2));
+        assertFalse(downInstanceManager.apply(instance1));
+        assertTrue(downInstanceManager.apply(instance2));
 
         Thread.sleep(debugDownInstancePolicy.getTimeoutMs());
 
-        Assert.assertTrue(downInstanceManager.apply(instance1));
-        Assert.assertTrue(downInstanceManager.apply(instance2));
+        assertTrue(downInstanceManager.apply(instance1));
+        assertTrue(downInstanceManager.apply(instance2));
     }
 }

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestJsonInstanceSerializerCompatibility.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestJsonInstanceSerializerCompatibility.java
@@ -19,14 +19,16 @@
 
 package org.apache.curator.x.discovery.details;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.ServiceType;
 import org.apache.curator.x.discovery.TestJsonInstanceSerializer;
 import org.apache.curator.x.discovery.UriSpec;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.util.Date;
 
@@ -42,7 +44,7 @@ public class TestJsonInstanceSerializerCompatibility
         OldServiceInstance<TestJsonInstanceSerializer.Payload> oldInstance = new OldServiceInstance<TestJsonInstanceSerializer.Payload>("name", "id", "address", 10, 20, new TestJsonInstanceSerializer.Payload("test"), 0, ServiceType.DYNAMIC, new UriSpec("{a}/b/{c}"));
         ObjectMapper mapper = new ObjectMapper();
         byte[] oldBytes = mapper.writeValueAsBytes(oldInstance);
-        Assert.assertEquals(bytes, oldBytes, String.format("%s vs %s", new String(bytes), new String(oldBytes)));
+        assertArrayEquals(bytes, oldBytes, String.format("%s vs %s", new String(bytes), new String(oldBytes)));
     }
 
     @Test
@@ -53,7 +55,7 @@ public class TestJsonInstanceSerializerCompatibility
         byte[] bytes = serializer.serialize(instance);
 
         instance = serializer.deserialize(bytes);
-        Assert.assertTrue(instance.isEnabled());    // passed false for enabled in the ctor but that is lost with compatibleSerializationMode
+        assertTrue(instance.isEnabled());    // passed false for enabled in the ctor but that is lost with compatibleSerializationMode
 
         ObjectMapper mapper = new ObjectMapper();
         JavaType type = mapper.getTypeFactory().constructType(OldServiceInstance.class);
@@ -61,15 +63,15 @@ public class TestJsonInstanceSerializerCompatibility
         TestJsonInstanceSerializer.Payload.class.cast(rawServiceInstance.getPayload()); // just to verify that it's the correct type
         //noinspection unchecked
         OldServiceInstance<TestJsonInstanceSerializer.Payload> check = (OldServiceInstance<TestJsonInstanceSerializer.Payload>)rawServiceInstance;
-        Assert.assertEquals(check.getName(), instance.getName());
-        Assert.assertEquals(check.getId(), instance.getId());
-        Assert.assertEquals(check.getAddress(), instance.getAddress());
-        Assert.assertEquals(check.getPort(), instance.getPort());
-        Assert.assertEquals(check.getSslPort(), instance.getSslPort());
-        Assert.assertEquals(check.getPayload(), instance.getPayload());
-        Assert.assertEquals(check.getRegistrationTimeUTC(), instance.getRegistrationTimeUTC());
-        Assert.assertEquals(check.getServiceType(), instance.getServiceType());
-        Assert.assertEquals(check.getUriSpec(), instance.getUriSpec());
+        assertEquals(check.getName(), instance.getName());
+        assertEquals(check.getId(), instance.getId());
+        assertEquals(check.getAddress(), instance.getAddress());
+        assertEquals(check.getPort(), instance.getPort());
+        assertEquals(check.getSslPort(), instance.getSslPort());
+        assertEquals(check.getPayload(), instance.getPayload());
+        assertEquals(check.getRegistrationTimeUTC(), instance.getRegistrationTimeUTC());
+        assertEquals(check.getServiceType(), instance.getServiceType());
+        assertEquals(check.getUriSpec(), instance.getUriSpec());
     }
 
     @Test
@@ -81,16 +83,16 @@ public class TestJsonInstanceSerializerCompatibility
 
         JsonInstanceSerializer<TestJsonInstanceSerializer.Payload> serializer = new JsonInstanceSerializer<TestJsonInstanceSerializer.Payload>(TestJsonInstanceSerializer.Payload.class);
         ServiceInstance<TestJsonInstanceSerializer.Payload> instance = serializer.deserialize(oldJson);
-        Assert.assertEquals(oldInstance.getName(), instance.getName());
-        Assert.assertEquals(oldInstance.getId(), instance.getId());
-        Assert.assertEquals(oldInstance.getAddress(), instance.getAddress());
-        Assert.assertEquals(oldInstance.getPort(), instance.getPort());
-        Assert.assertEquals(oldInstance.getSslPort(), instance.getSslPort());
-        Assert.assertEquals(oldInstance.getPayload(), instance.getPayload());
-        Assert.assertEquals(oldInstance.getRegistrationTimeUTC(), instance.getRegistrationTimeUTC());
-        Assert.assertEquals(oldInstance.getServiceType(), instance.getServiceType());
-        Assert.assertEquals(oldInstance.getUriSpec(), instance.getUriSpec());
-        Assert.assertTrue(instance.isEnabled());
+        assertEquals(oldInstance.getName(), instance.getName());
+        assertEquals(oldInstance.getId(), instance.getId());
+        assertEquals(oldInstance.getAddress(), instance.getAddress());
+        assertEquals(oldInstance.getPort(), instance.getPort());
+        assertEquals(oldInstance.getSslPort(), instance.getSslPort());
+        assertEquals(oldInstance.getPayload(), instance.getPayload());
+        assertEquals(oldInstance.getRegistrationTimeUTC(), instance.getRegistrationTimeUTC());
+        assertEquals(oldInstance.getServiceType(), instance.getServiceType());
+        assertEquals(oldInstance.getUriSpec(), instance.getUriSpec());
+        assertTrue(instance.isEnabled());
     }
 
     @Test
@@ -100,8 +102,8 @@ public class TestJsonInstanceSerializerCompatibility
         byte[] newInstanceBytes = new ObjectMapper().writeValueAsBytes(newInstance);
         JsonInstanceSerializer<String> serializer = new JsonInstanceSerializer<String>(String.class);
         ServiceInstance<String> instance = serializer.deserialize(newInstanceBytes);
-        Assert.assertEquals(instance.getName(), "name");
-        Assert.assertEquals(instance.getPayload(), "hey");
-        Assert.assertEquals(instance.isEnabled(), false);
+        assertEquals(instance.getName(), "name");
+        assertEquals(instance.getPayload(), "hey");
+        assertEquals(instance.isEnabled(), false);
     }
 }

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceCacheRace.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceCacheRace.java
@@ -18,7 +18,9 @@
  */
 package org.apache.curator.x.discovery.details;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -32,22 +34,21 @@ import org.apache.curator.x.discovery.ServiceCache;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.ServiceInstance;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestServiceCacheRace extends BaseClassForTests
 {
     private final Timing timing = new Timing();
 
     // validates CURATOR-452 which exposed a race in ServiceCacheImpl's start() method caused by an optimization whereby it clears the dataBytes of its internal PathChildrenCache
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testRaceOnInitialLoad() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();
@@ -92,7 +93,7 @@ public class TestServiceCacheRace extends BaseClassForTests
                 }
             };
             closeableExecutorService.submit(proc);
-            Assert.assertTrue(timing.awaitLatch(cacheStartLatch));  // wait until ServiceCacheImpl's internal PathChildrenCache is started and primed
+            assertTrue(timing.awaitLatch(cacheStartLatch));  // wait until ServiceCacheImpl's internal PathChildrenCache is started and primed
 
             final CountDownLatch cacheChangedLatch = new CountDownLatch(1);
             ServiceCacheListener listener = new ServiceCacheListener()
@@ -112,11 +113,11 @@ public class TestServiceCacheRace extends BaseClassForTests
             cache.addListener(listener);
             ServiceInstance<String> instance2 = ServiceInstance.<String>builder().payload("test").name("test").port(10065).build();
             discovery.registerService(instance2);   // cause ServiceCacheImpl's internal PathChildrenCache listener to get called which will clear the dataBytes
-            Assert.assertTrue(timing.awaitLatch(cacheChangedLatch));
+            assertTrue(timing.awaitLatch(cacheChangedLatch));
 
             cacheWaitLatch.countDown();
 
-            Assert.assertTrue(timing.awaitLatch(startCompletedLatch));
+            assertTrue(timing.awaitLatch(startCompletedLatch));
         }
         finally
         {

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceCacheRace.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceCacheRace.java
@@ -20,7 +20,6 @@ package org.apache.curator.x.discovery.details;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.state.ConnectionState;
@@ -35,6 +34,7 @@ import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.Collections;
@@ -48,7 +48,7 @@ public class TestServiceCacheRace extends BaseClassForTests
     private final Timing timing = new Timing();
 
     // validates CURATOR-452 which exposed a race in ServiceCacheImpl's start() method caused by an optimization whereby it clears the dataBytes of its internal PathChildrenCache
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testRaceOnInitialLoad() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceDiscovery.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceDiscovery.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -36,6 +35,8 @@ import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -54,7 +55,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     };
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCrashedServerMultiInstances() throws Exception
     {
         CuratorFramework client = null;
@@ -98,7 +99,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCrashedServer() throws Exception
     {
         CuratorFramework client = null;
@@ -140,7 +141,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCrashedInstance() throws Exception
     {
         CuratorFramework client = null;
@@ -170,7 +171,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testMultipleInstances() throws Exception
     {
         final String SERVICE_ONE = "one";
@@ -222,7 +223,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         CuratorFramework client = null;
@@ -249,7 +250,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testNoServerOnStart() throws Exception
     {
         Timing timing = new Timing();
@@ -282,7 +283,7 @@ public class TestServiceDiscovery extends BaseClassForTests
     }
 
     // CURATOR-164
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testUnregisterService() throws Exception
     {
         final String name = "name";
@@ -342,7 +343,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testCleaning() throws Exception
     {
         CuratorFramework client = null;

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceDiscovery.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceDiscovery.java
@@ -19,8 +19,12 @@
 
 package org.apache.curator.x.discovery.details;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -31,15 +35,14 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.ServiceInstance;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestServiceDiscovery extends BaseClassForTests
 {
     private static final Comparator<ServiceInstance<Void>> comparator = new Comparator<ServiceInstance<Void>>()
@@ -51,7 +54,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     };
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCrashedServerMultiInstances() throws Exception
     {
         CuratorFramework client = null;
@@ -78,7 +81,7 @@ public class TestServiceDiscovery extends BaseClassForTests
             discovery.registerService(instance2);
 
             timing.acquireSemaphore(semaphore, 2);
-            Assert.assertEquals(discovery.queryForInstances("test").size(), 2);
+            assertEquals(discovery.queryForInstances("test").size(), 2);
 
             client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
             server.stop();
@@ -86,7 +89,7 @@ public class TestServiceDiscovery extends BaseClassForTests
             server.restart();
 
             timing.acquireSemaphore(semaphore, 2);
-            Assert.assertEquals(discovery.queryForInstances("test").size(), 2);
+            assertEquals(discovery.queryForInstances("test").size(), 2);
         }
         finally
         {
@@ -95,7 +98,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCrashedServer() throws Exception
     {
         CuratorFramework client = null;
@@ -120,7 +123,7 @@ public class TestServiceDiscovery extends BaseClassForTests
             discovery.start();
 
             timing.acquireSemaphore(semaphore);
-            Assert.assertEquals(discovery.queryForInstances("test").size(), 1);
+            assertEquals(discovery.queryForInstances("test").size(), 1);
 
             client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
             server.stop();
@@ -128,7 +131,7 @@ public class TestServiceDiscovery extends BaseClassForTests
             server.restart();
 
             timing.acquireSemaphore(semaphore);
-            Assert.assertEquals(discovery.queryForInstances("test").size(), 1);
+            assertEquals(discovery.queryForInstances("test").size(), 1);
         }
         finally
         {
@@ -137,7 +140,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCrashedInstance() throws Exception
     {
         CuratorFramework client = null;
@@ -153,12 +156,12 @@ public class TestServiceDiscovery extends BaseClassForTests
             discovery = new ServiceDiscoveryImpl<String>(client, "/test", new JsonInstanceSerializer<String>(String.class), instance, false);
             discovery.start();
 
-            Assert.assertEquals(discovery.queryForInstances("test").size(), 1);
+            assertEquals(discovery.queryForInstances("test").size(), 1);
 
             client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
             Thread.sleep(timing.multiple(1.5).session());
 
-            Assert.assertEquals(discovery.queryForInstances("test").size(), 1);
+            assertEquals(discovery.queryForInstances("test").size(), 1);
         }
         finally
         {
@@ -167,7 +170,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testMultipleInstances() throws Exception
     {
         final String SERVICE_ONE = "one";
@@ -193,7 +196,7 @@ public class TestServiceDiscovery extends BaseClassForTests
             discovery.registerService(s2_i1);
             discovery.registerService(s2_i2);
 
-            Assert.assertEquals(Sets.newHashSet(discovery.queryForNames()), Sets.newHashSet(SERVICE_ONE, SERVICE_TWO));
+            assertEquals(Sets.newHashSet(discovery.queryForNames()), Sets.newHashSet(SERVICE_ONE, SERVICE_TWO));
 
             List<ServiceInstance<Void>> list = Lists.newArrayList();
             list.add(s1_i1);
@@ -201,7 +204,7 @@ public class TestServiceDiscovery extends BaseClassForTests
             Collections.sort(list, comparator);
             List<ServiceInstance<Void>> queriedInstances = Lists.newArrayList(discovery.queryForInstances(SERVICE_ONE));
             Collections.sort(queriedInstances, comparator);
-            Assert.assertEquals(queriedInstances, list, String.format("Not equal l: %s - d: %s", list, queriedInstances));
+            assertEquals(queriedInstances, list, String.format("Not equal l: %s - d: %s", list, queriedInstances));
 
             list.clear();
 
@@ -210,7 +213,7 @@ public class TestServiceDiscovery extends BaseClassForTests
             Collections.sort(list, comparator);
             queriedInstances = Lists.newArrayList(discovery.queryForInstances(SERVICE_TWO));
             Collections.sort(queriedInstances, comparator);
-            Assert.assertEquals(queriedInstances, list, String.format("Not equal 2: %s - d: %s", list, queriedInstances));
+            assertEquals(queriedInstances, list, String.format("Not equal 2: %s - d: %s", list, queriedInstances));
         }
         finally
         {
@@ -219,7 +222,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         CuratorFramework client = null;
@@ -233,11 +236,11 @@ public class TestServiceDiscovery extends BaseClassForTests
             discovery = ServiceDiscoveryBuilder.builder(String.class).basePath("/test").client(client).thisInstance(instance).build();
             discovery.start();
 
-            Assert.assertEquals(discovery.queryForNames(), Collections.singletonList("test"));
+            assertEquals(discovery.queryForNames(), Collections.singletonList("test"));
 
             List<ServiceInstance<String>> list = Lists.newArrayList();
             list.add(instance);
-            Assert.assertEquals(discovery.queryForInstances("test"), list);
+            assertEquals(discovery.queryForInstances("test"), list);
         }
         finally
         {
@@ -246,7 +249,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testNoServerOnStart() throws Exception
     {
         Timing timing = new Timing();
@@ -265,11 +268,11 @@ public class TestServiceDiscovery extends BaseClassForTests
 
             server.restart();
             timing.sleepABit();
-            Assert.assertEquals(discovery.queryForNames(), Collections.singletonList("test"));
+            assertEquals(discovery.queryForNames(), Collections.singletonList("test"));
 
             List<ServiceInstance<String>> list = Lists.newArrayList();
             list.add(instance);
-            Assert.assertEquals(discovery.queryForInstances("test"), list);
+            assertEquals(discovery.queryForInstances("test"), list);
         }
         finally
         {
@@ -279,7 +282,7 @@ public class TestServiceDiscovery extends BaseClassForTests
     }
 
     // CURATOR-164
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testUnregisterService() throws Exception
     {
         final String name = "name";
@@ -320,7 +323,7 @@ public class TestServiceDiscovery extends BaseClassForTests
             discovery = ServiceDiscoveryBuilder.builder(String.class).basePath("/test").client(client).thisInstance(instance).serializer(slowSerializer).watchInstances(true).build();
             discovery.start();
 
-            Assert.assertFalse(discovery.queryForInstances(name).isEmpty(), "Service should start registered.");
+            assertFalse(discovery.queryForInstances(name).isEmpty(), "Service should start registered.");
 
             server.stop();
             server.restart();
@@ -330,7 +333,7 @@ public class TestServiceDiscovery extends BaseClassForTests
 
             new Timing().sleepABit(); // Wait for the rest of registration to finish.
 
-            Assert.assertTrue(discovery.queryForInstances(name).isEmpty(), "Service should have unregistered.");
+            assertTrue(discovery.queryForInstances(name).isEmpty(), "Service should have unregistered.");
         }
         finally
         {
@@ -339,7 +342,7 @@ public class TestServiceDiscovery extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testCleaning() throws Exception
     {
         CuratorFramework client = null;
@@ -354,7 +357,7 @@ public class TestServiceDiscovery extends BaseClassForTests
             discovery.start();
             discovery.unregisterService(instance);
 
-            Assert.assertEquals(((ServiceDiscoveryImpl)discovery).debugServicesQty(), 0);
+            assertEquals(((ServiceDiscoveryImpl)discovery).debugServicesQty(), 0);
         }
         finally
         {

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceDiscoveryBuilder.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceDiscoveryBuilder.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -31,11 +30,12 @@ import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestServiceDiscoveryBuilder extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDefaultSerializer()
     {        
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -46,7 +46,7 @@ public class TestServiceDiscoveryBuilder extends BaseClassForTests
         assertTrue(discovery.getSerializer() instanceof JsonInstanceSerializer, "default serializer not JSON");
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testSetSerializer()
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceDiscoveryBuilder.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceDiscoveryBuilder.java
@@ -18,6 +18,11 @@
  */
 package org.apache.curator.x.discovery.details;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -25,24 +30,23 @@ import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.ServiceInstance;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestServiceDiscoveryBuilder extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDefaultSerializer()
     {        
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
         ServiceDiscoveryBuilder<Object> builder = ServiceDiscoveryBuilder.builder(Object.class).client(client);
         ServiceDiscoveryImpl<?> discovery = (ServiceDiscoveryImpl<?>) builder.basePath("/path").build();
 
-        Assert.assertNotNull(discovery.getSerializer(), "default serializer not set");
-        Assert.assertTrue(discovery.getSerializer() instanceof JsonInstanceSerializer, "default serializer not JSON");
+        assertNotNull(discovery.getSerializer(), "default serializer not set");
+        assertTrue(discovery.getSerializer() instanceof JsonInstanceSerializer, "default serializer not JSON");
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testSetSerializer()
     {
         CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
@@ -63,7 +67,7 @@ public class TestServiceDiscoveryBuilder extends BaseClassForTests
         });
 
         ServiceDiscoveryImpl<?> discovery = (ServiceDiscoveryImpl<?>) builder.basePath("/path").build();
-        Assert.assertNotNull(discovery.getSerializer(), "default serializer not set");
-        Assert.assertFalse(discovery.getSerializer() instanceof JsonInstanceSerializer, "set serializer is JSON");
+        assertNotNull(discovery.getSerializer(), "default serializer not set");
+        assertFalse(discovery.getSerializer() instanceof JsonInstanceSerializer, "set serializer is JSON");
     }
 }

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceProvider.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceProvider.java
@@ -18,10 +18,13 @@
  */
 package org.apache.curator.x.discovery.details;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -32,16 +35,14 @@ import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.ServiceProvider;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Tag;
 
-@Test(groups = CuratorTestBase.zk35TestCompatibilityGroup)
+@Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestServiceProvider extends BaseClassForTests
 {
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testBasic() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();
@@ -60,11 +61,11 @@ public class TestServiceProvider extends BaseClassForTests
             closeables.add(provider);
             provider.start();
 
-            Assert.assertEquals(provider.getInstance(), instance);
+            assertEquals(provider.getInstance(), instance);
 
             List<ServiceInstance<String>> list = Lists.newArrayList();
             list.add(instance);
-            Assert.assertEquals(provider.getAllInstances(), list);
+            assertEquals(provider.getAllInstances(), list);
         }
         finally
         {
@@ -76,7 +77,7 @@ public class TestServiceProvider extends BaseClassForTests
         }
     }
 
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testDisabledInstance() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();
@@ -96,8 +97,8 @@ public class TestServiceProvider extends BaseClassForTests
             closeables.add(provider);
             provider.start();
 
-            Assert.assertEquals(provider.getInstance(), null);
-            Assert.assertTrue(provider.getAllInstances().isEmpty(), "Disabled instance still appears available via service provider");
+            assertEquals(provider.getInstance(), null);
+            assertTrue(provider.getAllInstances().isEmpty(), "Disabled instance still appears available via service provider");
         }
         finally
         {

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceProvider.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestServiceProvider.java
@@ -24,7 +24,6 @@ import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -37,12 +36,13 @@ import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.ServiceProvider;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 @Tag(CuratorTestBase.zk35TestCompatibilityGroup)
 public class TestServiceProvider extends BaseClassForTests
 {
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testBasic() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();
@@ -77,7 +77,7 @@ public class TestServiceProvider extends BaseClassForTests
         }
     }
 
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testDisabledInstance() throws Exception
     {
         List<Closeable> closeables = Lists.newArrayList();

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestWatchedInstances.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestWatchedInstances.java
@@ -18,7 +18,10 @@
  */
 package org.apache.curator.x.discovery.details;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.google.common.collect.Lists;
+import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -28,8 +31,6 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.ServiceInstance;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import java.io.Closeable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,7 +38,7 @@ import java.util.List;
 
 public class TestWatchedInstances extends BaseClassForTests
 {
-    @Test
+    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
     public void testWatchedInstances() throws Exception
     {
         Timing timing = new Timing();
@@ -59,11 +60,11 @@ public class TestWatchedInstances extends BaseClassForTests
             closeables.add(discovery);
             discovery.start();
 
-            Assert.assertEquals(discovery.queryForNames(), Arrays.asList("test"));
+            assertEquals(discovery.queryForNames(), Arrays.asList("test"));
 
             List<ServiceInstance<String>> list = Lists.newArrayList();
             list.add(instance);
-            Assert.assertEquals(discovery.queryForInstances("test"), list);
+            assertEquals(discovery.queryForInstances("test"), list);
 
             ServiceDiscoveryImpl<String> discoveryImpl = (ServiceDiscoveryImpl<String>)discovery;
             ServiceInstance<String> changedInstance = ServiceInstance.<String>builder()
@@ -79,8 +80,8 @@ public class TestWatchedInstances extends BaseClassForTests
             timing.sleepABit();
 
             ServiceInstance<String> registeredService = discoveryImpl.getRegisteredService(instance.getId());
-            Assert.assertNotNull(registeredService);
-            Assert.assertEquals(registeredService.getPayload(), "different");
+            assertNotNull(registeredService);
+            assertEquals(registeredService.getPayload(), "different");
         }
         finally
         {

--- a/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestWatchedInstances.java
+++ b/curator-x-discovery/src/test/java/org/apache/curator/x/discovery/details/TestWatchedInstances.java
@@ -21,7 +21,6 @@ package org.apache.curator.x.discovery.details;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.google.common.collect.Lists;
-import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -31,6 +30,8 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.ServiceInstance;
+import org.junit.jupiter.api.Test;
+
 import java.io.Closeable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,7 +39,7 @@ import java.util.List;
 
 public class TestWatchedInstances extends BaseClassForTests
 {
-    @RepeatedIfExceptionsTest(repeats = BaseClassForTests.REPEATS)
+    @Test
     public void testWatchedInstances() throws Exception
     {
         Timing timing = new Timing();

--- a/pom.xml
+++ b/pom.xml
@@ -585,12 +585,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.github.artsok</groupId>
-                <artifactId>rerunner-jupiter</artifactId>
-                <version>LATEST</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.facebook.swift</groupId>
                 <artifactId>swift-codec</artifactId>
                 <version>${swift-version}</version>
@@ -774,11 +768,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <threadCount>1</threadCount>
                     <reuseForks>false</reuseForks>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <rerunFailingTestsCount>2</rerunFailingTestsCount>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
     </organization>
 
     <properties>
+        <!-- maven properties -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <dependency.locations.enabled>false</dependency.locations.enabled>
+
         <currentStableVersion>5.1.0</currentStableVersion>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -85,7 +90,7 @@
         <guava-version>27.0.1-jre</guava-version>
         <guava-listenablefuture-version>1.0</guava-listenablefuture-version>
         <guava-failureaccess-version>1.0.1</guava-failureaccess-version>
-        <testng-version>6.14.3</testng-version>
+        <junit-version>5.6.2</junit-version>
         <swift-version>0.23.1</swift-version>
         <maven-shade-plugin-version>3.2.1</maven-shade-plugin-version>
         <slf4j-version>1.7.25</slf4j-version>
@@ -568,9 +573,21 @@
             </dependency>
 
             <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${testng-version}</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.github.artsok</groupId>
+                <artifactId>rerunner-jupiter</artifactId>
+                <version>LATEST</version>
             </dependency>
 
             <dependency>
@@ -658,6 +675,12 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.commonjava.maven.plugins</groupId>
+                    <artifactId>directory-maven-plugin</artifactId>
+                    <version>0.1</version>
+                </plugin>
+
+                <plugin>
                     <groupId>com.mycila.maven-license-plugin</groupId>
                     <artifactId>maven-license-plugin</artifactId>
                     <version>${maven-license-plugin-version}</version>
@@ -690,6 +713,12 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${build-helper-maven-plugin-version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.1.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -745,6 +774,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
                 <configuration>
                     <threadCount>1</threadCount>
                     <reuseForks>false</reuseForks>
@@ -807,11 +837,30 @@
                 </executions>
             </plugin>
 
+            <!-- Directory plugin to find parent root directory absolute path -->
+            <plugin>
+                <groupId>org.commonjava.maven.plugins</groupId>
+                <artifactId>directory-maven-plugin</artifactId>
+                <version>0.1</version>
+                <executions>
+                    <execution>
+                        <id>directories</id>
+                        <goals>
+                            <goal>highest-basedir</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <property>main.basedir</property>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>com.mycila.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
                 <configuration>
-                    <header>src/etc/header.txt</header>
+                    <header>${main.basedir}/src/etc/header.txt</header>
                     <excludes>
                         <exclude>**/*.confluence</exclude>
                         <exclude>**/*.confluence.vm</exclude>
@@ -995,6 +1044,12 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Migrated the code from TestNG 6.14.3 to jUnit 5.6.2.

Change-Id: I745eab08c1fafa8bda7f9ead73c8af2e1817d878