### PR TITLE
CURATOR-581. fix OSGi export pattern

### DIFF
--- a/curator-client/pom.xml
+++ b/curator-client/pom.xml
@@ -39,7 +39,7 @@
             org.apache.zookeeper.*;version="[3.4,4.0)", *
         </osgi.import.package>
         <osgi.export.package>
-            org.apache.curator*;version="${project.version}";-noimport:=true
+            org.apache.curator.*;version="${project.version}";-noimport:=true
         </osgi.export.package>
     </properties>
 

--- a/curator-framework/pom.xml
+++ b/curator-framework/pom.xml
@@ -40,7 +40,7 @@
             org.apache.zookeeper.*;version="[3.4,4.0)", *
         </osgi.import.package>
         <osgi.export.package>
-            org.apache.curator.framework*;version="${project.version}";-noimport:=true
+            org.apache.curator.framework.*;version="${project.version}";-noimport:=true
         </osgi.export.package>
     </properties>
 

--- a/curator-recipes/pom.xml
+++ b/curator-recipes/pom.xml
@@ -40,7 +40,7 @@
             org.apache.zookeeper.*;version="[3.4,4.0)", *
         </osgi.import.package>
         <osgi.export.package>
-            org.apache.curator.framework.recipes*;version="${project.version}";-noimport:=true
+            org.apache.curator.framework.recipes.*;version="${project.version}";-noimport:=true
         </osgi.export.package>
     </properties>
 

--- a/curator-x-discovery-server/pom.xml
+++ b/curator-x-discovery-server/pom.xml
@@ -40,7 +40,7 @@
             org.apache.zookeeper.*;version="[3.4,4.0)", *
         </osgi.import.package>
         <osgi.export.package>
-            org.apache.curator.x.discovery.server*;version="${project.version}";-noimport:=true
+            org.apache.curator.x.discovery.server.*;version="${project.version}";-noimport:=true
         </osgi.export.package>
     </properties>
 

--- a/curator-x-discovery/pom.xml
+++ b/curator-x-discovery/pom.xml
@@ -40,7 +40,7 @@
             org.apache.zookeeper.*;version="[3.4,4.0)", *
         </osgi.import.package>
         <osgi.export.package>
-            org.apache.curator.x.discovery*;version="${project.version}";-noimport:=true
+            org.apache.curator.x.discovery.*;version="${project.version}";-noimport:=true
         </osgi.export.package>
     </properties>
 


### PR DESCRIPTION
According to https://access.redhat.com/documentation/en-us/red_hat_fuse/7.2/html/deploying_into_apache_karaf/buildbundle this is the correct pattern for wildcard in export package config. Also it fixes the problem that IDEA complains with `The package 'org.apache.curator.framework.api' is not exported by the bundle dependencies`

cc @Randgalt @eolivelli @cammckenzie 