### PR TITLE
CURATOR-583: Fix ArrayIndexOutOfBoundsException when passing empty li…

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ReconfigBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ReconfigBuilderImpl.java
@@ -130,7 +130,7 @@ public class ReconfigBuilderImpl implements ReconfigBuilder, BackgroundOperation
     @Override
     public StatConfigureEnsembleable withNewMembers(List<String> servers)
     {
-        newMembers = (servers != null) ? ImmutableList.copyOf(servers) : ImmutableList.<String>of();
+        newMembers = (servers != null && !servers.isEmpty()) ? ImmutableList.copyOf(servers) : null;
         return new StatConfigureEnsembleable()
         {
             @Override
@@ -164,7 +164,7 @@ public class ReconfigBuilderImpl implements ReconfigBuilder, BackgroundOperation
     @Override
     public LeaveStatConfigEnsembleable joining(List<String> servers)
     {
-        joining = (servers != null) ? ImmutableList.copyOf(servers) : ImmutableList.<String>of();
+        joining = (servers != null && !servers.isEmpty()) ? ImmutableList.copyOf(servers) : null;
 
         return new LeaveStatConfigEnsembleable()
         {
@@ -211,7 +211,7 @@ public class ReconfigBuilderImpl implements ReconfigBuilder, BackgroundOperation
     @Override
     public JoinStatConfigEnsembleable leaving(List<String> servers)
     {
-        leaving = (servers != null) ? ImmutableList.copyOf(servers) : ImmutableList.<String>of();
+        leaving = (servers != null && !servers.isEmpty()) ? ImmutableList.copyOf(servers) : null;
 
         return new JoinStatConfigEnsembleable()
         {


### PR DESCRIPTION
Whenever I add zookeeper servers by using reconfig API of the curator client, it always throw ArrayIndexOutOfBoundsException.

If there are no servers to add or remove when using reconfigure API of ZooKeeperAdmin, I think it must pass not empty list parameter but null to reconfigure API. Because ZooKeeperAdmin tries to join strings by accessing first index of the server list.

Please refer to the link below. 

https://github.com/apache/zookeeper/blob/release-3.6.2/zookeeper-server/src/main/java/org/apache/zookeeper/admin/ZooKeeperAdmin.java#L267-L269

https://github.com/apache/zookeeper/blob/release-3.6.2/zookeeper-server/src/main/java/org/apache/zookeeper/common/StringUtils.java#L57