### PR TITLE
CURATOR-591 - Update the PersistentNode documentation

### DIFF
--- a/curator-recipes/src/site/confluence/persistent-node.confluence
+++ b/curator-recipes/src/site/confluence/persistent-node.confluence
@@ -13,13 +13,15 @@ public PersistentNode(CuratorFramework client,
                                CreateMode mode,
                                boolean useProtection,
                                String basePath,
-                               byte[] data)
+                               byte[] data,
+                               boolean useParentCreation)
 Parameters:
 client - client instance
 mode - creation mode
 useProtection - if true, call CreateBuilder.withProtection()
 basePath - the base path for the node
 data - data for the node
+useParentCreation - if true, call CreateBuilder.creatingParentContainersIfNeeded()
 {code}
 
 h3. General Usage


### PR DESCRIPTION
As a follow up of https://github.com/apache/curator/pull/380, we should update the `PersistentNode` doc.