### PR TITLE
CURATOR-526 drop log level for message to debug

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -211,7 +211,7 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
             }
             else
             {
-                log.error("Invalid config event received: {}", properties);
+                log.debug("Invalid config event received: {}", properties);
             }
         }
         else


### PR DESCRIPTION
ZooKeeper is backwards compatible and accepts older config
string formats, albeit without dynamic configuration
support. Since the older format is acceptable, we should not
log at error when we see the older format and should
instead simply log at debug.