### PR TITLE
CURATOR-599 Configurable ZookeeperFactory by ZKClientConfig

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/utils/ConfigurableZookeeperFactory.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/ConfigurableZookeeperFactory.java
@@ -1,0 +1,38 @@
+/**
+ * Configurable ZookeeperFactory, by using org.apache.zookeeper.client.ZKClientConfig.
+ * 
+ * @author Liran Mendelovich
+ * 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.utils;
+
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.admin.ZooKeeperAdmin;
+import org.apache.zookeeper.client.ZKClientConfig;
+
+public class ConfigurableZookeeperFactory extends DefaultZookeeperFactory
+{
+	
+    public ZooKeeper newZooKeeper(String connectString, int sessionTimeout, Watcher watcher, 
+		boolean canBeReadOnly, ZKClientConfig zkClientConfig) throws Exception
+    {
+		return new ZooKeeperAdmin(connectString, sessionTimeout, watcher, canBeReadOnly, zkClientConfig);
+    }
+}

--- a/curator-client/src/main/java/org/apache/curator/utils/ConfigurableZookeeperFactory.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/ConfigurableZookeeperFactory.java
@@ -1,8 +1,4 @@
 /**
- * Configurable ZookeeperFactory, by using org.apache.zookeeper.client.ZKClientConfig.
- * 
- * @author Liran Mendelovich
- * 
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.curator.utils;
 
 import org.apache.zookeeper.Watcher;
@@ -27,6 +24,12 @@ import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.admin.ZooKeeperAdmin;
 import org.apache.zookeeper.client.ZKClientConfig;
 
+/**
+ * Configurable ZookeeperFactory, by using org.apache.zookeeper.client.ZKClientConfig.
+ * 
+ * @author Liran Mendelovich
+ *
+ */
 public class ConfigurableZookeeperFactory extends DefaultZookeeperFactory
 {
 	

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
@@ -19,8 +19,16 @@
 
 package org.apache.curator.framework;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
@@ -36,20 +44,16 @@ import org.apache.curator.framework.schema.SchemaSet;
 import org.apache.curator.framework.state.ConnectionStateErrorPolicy;
 import org.apache.curator.framework.state.ConnectionStateListenerManagerFactory;
 import org.apache.curator.framework.state.StandardConnectionStateErrorPolicy;
+import org.apache.curator.utils.ConfigurableZookeeperFactory;
 import org.apache.curator.utils.DefaultZookeeperFactory;
 import org.apache.curator.utils.ZookeeperFactory;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import org.apache.curator.CuratorZookeeperClient;
+import org.apache.zookeeper.client.ZKClientConfig;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Factory methods for creating framework-style clients
@@ -108,6 +112,28 @@ public class CuratorFrameworkFactory
             retryPolicy(retryPolicy).
             build();
     }
+    
+    /**
+     * Create a new client
+     *
+     * @param connectString       list of servers to connect to
+     * @param sessionTimeoutMs    session timeout
+     * @param connectionTimeoutMs connection timeout
+     * @param retryPolicy         retry policy to use
+     * @param zkClientConfig      ZKClientConfig
+     * @return client
+     */
+    public static CuratorFramework newClient(String connectString, int sessionTimeoutMs, int connectionTimeoutMs, RetryPolicy retryPolicy, ZKClientConfig zkClientConfig)
+    {
+        return builder().
+            connectString(connectString).
+            sessionTimeoutMs(sessionTimeoutMs).
+            connectionTimeoutMs(connectionTimeoutMs).
+            retryPolicy(retryPolicy).
+            zkClientConfig(zkClientConfig).
+            zookeeperFactory(new ConfigurableZookeeperFactory()).
+            build();
+    }
 
     /**
      * Return the local address as bytes that can be used as a node payload
@@ -150,6 +176,7 @@ public class CuratorFrameworkFactory
         private Executor runSafeService = null;
         private ConnectionStateListenerManagerFactory connectionStateListenerManagerFactory = ConnectionStateListenerManagerFactory.standard;
         private int simulatedSessionExpirationPercent = 100;
+        private ZKClientConfig zkClientConfig;
 
         /**
          * Apply the current values and build a new CuratorFramework
@@ -466,6 +493,11 @@ public class CuratorFrameworkFactory
             this.simulatedSessionExpirationPercent = simulatedSessionExpirationPercent;
             return this;
         }
+        
+        public Builder zkClientConfig(ZKClientConfig zkClientConfig) {
+        	this.zkClientConfig = zkClientConfig;
+        	return this;
+        }
 
         /**
          * Add an enforced schema set
@@ -583,6 +615,10 @@ public class CuratorFrameworkFactory
 
         public int getSimulatedSessionExpirationPercent() {
             return simulatedSessionExpirationPercent;
+        }
+        
+        public ZKClientConfig getZkClientConfig() {
+            return zkClientConfig;
         }
 
         public SchemaSet getSchemaSet()

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -19,9 +19,25 @@
 
 package org.apache.curator.framework.imps;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.curator.CuratorConnectionLossException;
 import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.RetryLoop;
@@ -30,7 +46,25 @@ import org.apache.curator.framework.AuthInfo;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.WatcherRemoveCuratorFramework;
-import org.apache.curator.framework.api.*;
+import org.apache.curator.framework.api.ACLProvider;
+import org.apache.curator.framework.api.CompressionProvider;
+import org.apache.curator.framework.api.CreateBuilder;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.api.CuratorListener;
+import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.framework.api.ExistsBuilder;
+import org.apache.curator.framework.api.GetACLBuilder;
+import org.apache.curator.framework.api.GetChildrenBuilder;
+import org.apache.curator.framework.api.GetConfigBuilder;
+import org.apache.curator.framework.api.GetDataBuilder;
+import org.apache.curator.framework.api.ReconfigBuilder;
+import org.apache.curator.framework.api.RemoveWatchesBuilder;
+import org.apache.curator.framework.api.SetACLBuilder;
+import org.apache.curator.framework.api.SetDataBuilder;
+import org.apache.curator.framework.api.SyncBuilder;
+import org.apache.curator.framework.api.UnhandledErrorListener;
+import org.apache.curator.framework.api.WatchesBuilder;
 import org.apache.curator.framework.api.transaction.CuratorMultiTransaction;
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
 import org.apache.curator.framework.api.transaction.TransactionOp;
@@ -42,6 +76,7 @@ import org.apache.curator.framework.state.ConnectionStateErrorPolicy;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.framework.state.ConnectionStateManager;
 import org.apache.curator.utils.Compatibility;
+import org.apache.curator.utils.ConfigurableZookeeperFactory;
 import org.apache.curator.utils.DebugUtils;
 import org.apache.curator.utils.EnsurePath;
 import org.apache.curator.utils.ThreadUtils;
@@ -51,17 +86,14 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 public class CuratorFrameworkImpl implements CuratorFramework
 {
@@ -108,7 +140,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
 
     public CuratorFrameworkImpl(CuratorFrameworkFactory.Builder builder)
     {
-        ZookeeperFactory localZookeeperFactory = makeZookeeperFactory(builder.getZookeeperFactory());
+        ZookeeperFactory localZookeeperFactory = makeZookeeperFactory(builder.getZookeeperFactory(), builder.getZkClientConfig());
         this.client = new CuratorZookeeperClient
             (
                 localZookeeperFactory,
@@ -200,23 +232,39 @@ public class CuratorFrameworkImpl implements CuratorFramework
         return (ensembleTracker != null) ? ensembleTracker.getCurrentConfig() : null;
     }
 
-    private ZookeeperFactory makeZookeeperFactory(final ZookeeperFactory actualZookeeperFactory)
+    private ZookeeperFactory makeZookeeperFactory(final ZookeeperFactory actualZookeeperFactory, ZKClientConfig zkClientConfig)
     {
+    	if (actualZookeeperFactory instanceof ConfigurableZookeeperFactory) {
+    		return new ZookeeperFactory()
+            {
+                @Override
+                public ZooKeeper newZooKeeper(String connectString, int sessionTimeout, Watcher watcher, boolean canBeReadOnly) throws Exception
+                {
+                    ZooKeeper zooKeeper = ((ConfigurableZookeeperFactory) actualZookeeperFactory).newZooKeeper(connectString, sessionTimeout, watcher, canBeReadOnly, zkClientConfig);
+                    addAuthInfos(zooKeeper);
+                    return zooKeeper;
+                }
+            };
+    	}
+    	
         return new ZookeeperFactory()
         {
             @Override
             public ZooKeeper newZooKeeper(String connectString, int sessionTimeout, Watcher watcher, boolean canBeReadOnly) throws Exception
             {
                 ZooKeeper zooKeeper = actualZookeeperFactory.newZooKeeper(connectString, sessionTimeout, watcher, canBeReadOnly);
-                for ( AuthInfo auth : authInfos )
-                {
-                    zooKeeper.addAuthInfo(auth.getScheme(), auth.getAuth());
-                }
-
+                addAuthInfos(zooKeeper);
                 return zooKeeper;
             }
         };
     }
+    
+    private void addAuthInfos(ZooKeeper zooKeeper) {
+		for ( AuthInfo auth: authInfos)
+		{
+		    zooKeeper.addAuthInfo(auth.getScheme(), auth.getAuth());
+		}
+	}
 
     private ThreadFactory getThreadFactory(CuratorFrameworkFactory.Builder builder)
     {
@@ -1061,4 +1109,5 @@ public class CuratorFrameworkImpl implements CuratorFramework
             }
         });
     }
+	
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <jdk-version>1.${short-jdk-version}</jdk-version>
 
         <!-- versions -->
-        <zookeeper-version>3.6.0</zookeeper-version>
+        <zookeeper-version>3.6.1</zookeeper-version>
         <maven-bundle-plugin-version>5.1.1</maven-bundle-plugin-version>
         <maven-javadoc-plugin-version>3.0.1</maven-javadoc-plugin-version>
         <doxia-module-confluence-version>1.8</doxia-module-confluence-version>
@@ -285,7 +285,7 @@
         </developer>
 
         <developer>
-            <name>Enis Söztutar</name>
+            <name>Enis SÃ¶ztutar</name>
             <email>enis@apache.org</email>
             <roles>
                 <role>PMC Member</role>


### PR DESCRIPTION
Option to use ZooKeeper client config.

This seems mandatory for using zookeeper.request.timeout for preventing the potential race condition of hanging indefinitely, as described at the ticket. 
