### PR TITLE
Use Awaitility to instead of Thread sheep method.

### DIFF
--- a/curator-client/pom.xml
+++ b/curator-client/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/curator-client/src/test/java/org/apache/curator/BasicTests.java
+++ b/curator-client/src/test/java/org/apache/curator/BasicTests.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import java.time.Duration;
 import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
@@ -31,13 +31,13 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.utils.ZookeeperFactory;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -47,14 +47,8 @@ public class BasicTests extends BaseClassForTests
     public void     testFactory() throws Exception
     {
         final ZooKeeper         mockZookeeper = Mockito.mock(ZooKeeper.class);
-        ZookeeperFactory        zookeeperFactory = new ZookeeperFactory()
-        {
-            @Override
-            public ZooKeeper newZooKeeper(String connectString, int sessionTimeout, Watcher watcher, boolean canBeReadOnly) throws Exception
-            {
-                return mockZookeeper;
-            }
-        };
+        ZookeeperFactory        zookeeperFactory =
+                (connectString, sessionTimeout, watcher, canBeReadOnly) -> mockZookeeper;
         CuratorZookeeperClient  client = new CuratorZookeeperClient(zookeeperFactory, new FixedEnsembleProvider(server.getConnectString()), 10000, 10000, null, new RetryOneTime(1), false);
         client.start();
         assertEquals(client.getZooKeeper(), mockZookeeper);
@@ -68,15 +62,10 @@ public class BasicTests extends BaseClassForTests
         final Timing                  timing = new Timing();
 
         final CountDownLatch    latch = new CountDownLatch(1);
-        Watcher                 watcher = new Watcher()
-        {
-            @Override
-            public void process(WatchedEvent event)
+        Watcher                 watcher = event -> {
+            if ( event.getState() == Watcher.Event.KeeperState.Expired )
             {
-                if ( event.getState() == Event.KeeperState.Expired )
-                {
-                    latch.countDown();
-                }
+                latch.countDown();
             }
         };
 
@@ -88,11 +77,7 @@ public class BasicTests extends BaseClassForTests
             RetryLoop.callWithRetry
             (
                 client,
-                new Callable<Object>()
-                {
-                    @Override
-                    public Object call() throws Exception
-                    {
+                    () -> {
                         if ( firstTime.compareAndSet(true, false) )
                         {
                             try
@@ -113,7 +98,6 @@ public class BasicTests extends BaseClassForTests
                         assertNotNull(zooKeeper.exists("/foo", false));
                         return null;
                     }
-                }
             );
         }
         finally
@@ -166,34 +150,16 @@ public class BasicTests extends BaseClassForTests
     }
 
     @Test
-    public void     testBackgroundConnect() throws Exception
+    public void  testBackgroundConnect() throws Exception
     {
         final int CONNECTION_TIMEOUT_MS = 4000;
-
-        CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000, CONNECTION_TIMEOUT_MS, null, new RetryOneTime(1));
-        try
-        {
+        try (CuratorZookeeperClient client = new CuratorZookeeperClient(server.getConnectString(), 10000,
+                CONNECTION_TIMEOUT_MS, null, new RetryOneTime(1))) {
             assertFalse(client.isConnected());
             client.start();
-
-            outer: do
-            {
-                for ( int i = 0; i < (CONNECTION_TIMEOUT_MS / 1000); ++i )
-                {
-                    if ( client.isConnected() )
-                    {
-                        break outer;
-                    }
-
-                    Thread.sleep(CONNECTION_TIMEOUT_MS);
-                }
-
-                fail();
-            } while ( false );
-        }
-        finally
-        {
-            client.close();
+            Awaitility.await()
+                    .atMost(Duration.ofMillis(CONNECTION_TIMEOUT_MS))
+                    .untilAsserted(() -> Assertions.assertTrue(client.isConnected()));
         }
     }
 }

--- a/curator-client/src/test/java/org/apache/curator/utils/TestCloseableExecutorService.java
+++ b/curator-client/src/test/java/org/apache/curator/utils/TestCloseableExecutorService.java
@@ -22,6 +22,7 @@ package org.apache.curator.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,11 +90,7 @@ public class TestCloseableExecutorService
         {
             service.submit
             (
-                new Callable<Void>()
-                {
-                    @Override
-                    public Void call() throws Exception
-                    {
+                    (Callable<Void>) () -> {
                         try
                         {
                             startLatch.countDown();
@@ -109,7 +106,6 @@ public class TestCloseableExecutorService
                         }
                         return null;
                     }
-                }
             );
         }
 
@@ -128,11 +124,7 @@ public class TestCloseableExecutorService
         {
             Future<?> future = service.submit
             (
-                new Runnable()
-                {
-                    @Override
-                    public void run()
-                    {
+                    () -> {
                         try
                         {
                             startLatch.countDown();
@@ -143,7 +135,6 @@ public class TestCloseableExecutorService
                             Thread.currentThread().interrupt();
                         }
                     }
-                }
             );
             futures.add(future);
         }
@@ -168,11 +159,7 @@ public class TestCloseableExecutorService
         {
             Future<?> future = service.submit
             (
-                new Callable<Void>()
-                {
-                    @Override
-                    public Void call() throws Exception
-                    {
+                    (Callable<Void>) () -> {
                         try
                         {
                             startLatch.countDown();
@@ -184,7 +171,6 @@ public class TestCloseableExecutorService
                         }
                         return null;
                     }
-                }
             );
             futures.add(future);
         }
@@ -204,11 +190,7 @@ public class TestCloseableExecutorService
         final CountDownLatch outsideLatch = new CountDownLatch(1);
         executorService.submit
         (
-            new Runnable()
-            {
-                @Override
-                public void run()
-                {
+                () -> {
                     try
                     {
                         Thread.currentThread().join();
@@ -222,7 +204,6 @@ public class TestCloseableExecutorService
                         outsideLatch.countDown();
                     }
                 }
-            }
         );
 
         CloseableExecutorService service = new CloseableExecutorService(executorService);
@@ -233,10 +214,7 @@ public class TestCloseableExecutorService
             submitRunnable(service, startLatch, latch);
         }
 
-        while ( service.size() < QTY )
-        {
-            Thread.sleep(100);
-        }
+        Awaitility.await().until(()-> service.size() >= QTY);
 
         assertTrue(startLatch.await(3, TimeUnit.SECONDS));
         service.close();
@@ -248,11 +226,7 @@ public class TestCloseableExecutorService
     {
         service.submit
             (
-                new Runnable()
-                {
-                    @Override
-                    public void run()
-                    {
+                    () -> {
                         try
                         {
                             startLatch.countDown();
@@ -267,7 +241,6 @@ public class TestCloseableExecutorService
                             latch.countDown();
                         }
                     }
-                }
             );
     }
 }

--- a/curator-framework/pom.xml
+++ b/curator-framework/pom.xml
@@ -86,6 +86,11 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCleanState.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCleanState.java
@@ -24,6 +24,7 @@ import org.apache.curator.test.compatibility.Timing2;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.ZooKeeper;
 import java.util.concurrent.Callable;
+import org.awaitility.Awaitility;
 
 public class TestCleanState
 {
@@ -43,10 +44,8 @@ public class TestCleanState
             EnsembleTracker ensembleTracker = internalClient.getEnsembleTracker();
             if ( ensembleTracker != null )
             {
-                while ( ensembleTracker.hasOutstanding() )
-                {
-                    Thread.sleep(100);
-                }
+                Awaitility.await()
+                        .until(() -> !ensembleTracker.hasOutstanding());
                 ensembleTracker.close();
             }
             ZooKeeper zooKeeper = internalClient.getZooKeeper();

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <dropwizard-version>3.2.5</dropwizard-version>
         <snappy-version>1.1.7</snappy-version>
         <build-helper-maven-plugin-version>3.1.0</build-helper-maven-plugin-version>
+        <awaitility-version>4.1.0</awaitility-version>
 
         <!-- OSGi Properties -->
         <osgi.export.package />
@@ -625,6 +626,14 @@
                 <artifactId>snappy-java</artifactId>
                 <version>${snappy-version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility-version}</version>
+                <scope>test</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
- Use Awaitility to avoid busy waiting.
- Refactor some code to Java8