### PR TITLE
CURATOR-606: ModeledFrameworkImpl.update(T model, int version): Use version in all cases.

### DIFF
--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
@@ -33,6 +33,7 @@ import org.apache.curator.x.async.WatchMode;
 import org.apache.curator.x.async.api.AsyncCuratorFrameworkDsl;
 import org.apache.curator.x.async.api.AsyncPathAndBytesable;
 import org.apache.curator.x.async.api.AsyncPathable;
+import org.apache.curator.x.async.api.AsyncSetDataBuilder;
 import org.apache.curator.x.async.api.AsyncTransactionSetDataBuilder;
 import org.apache.curator.x.async.api.CreateOption;
 import org.apache.curator.x.async.api.WatchableAsyncCuratorFramework;
@@ -205,7 +206,8 @@ public class ModeledFrameworkImpl<T> implements ModeledFramework<T>
         try
         {
             byte[] bytes = modelSpec.serializer().serialize(item);
-            AsyncPathAndBytesable<AsyncStage<Stat>> next = isCompressed() ? dslClient.setData().compressedWithVersion(version) : dslClient.setData();
+            AsyncSetDataBuilder dataBuilder = dslClient.setData();
+            AsyncPathAndBytesable<AsyncStage<Stat>> next = isCompressed() ? dataBuilder.compressedWithVersion(version) : dataBuilder.withVersion(version);
             return next.forPath(resolveForSet(item), bytes);
         }
         catch ( Exception e )
@@ -462,7 +464,7 @@ public class ModeledFrameworkImpl<T> implements ModeledFramework<T>
         return modelSpec.path().resolved(model).fullPath();
     }
 
-    private List<ACL> fixAclList(List<ACL> aclList)
+    private static List<ACL> fixAclList(List<ACL> aclList)
     {
         return (aclList.size() > 0) ? aclList : null;   // workaround for old, bad design. empty list not accepted
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
@@ -464,7 +464,7 @@ public class ModeledFrameworkImpl<T> implements ModeledFramework<T>
         return modelSpec.path().resolved(model).fullPath();
     }
 
-    private static List<ACL> fixAclList(List<ACL> aclList)
+    private List<ACL> fixAclList(List<ACL> aclList)
     {
         return (aclList.size() > 0) ? aclList : null;   // workaround for old, bad design. empty list not accepted
     }


### PR DESCRIPTION
Aside from the description, which captures the major issue:
- The ```fixAclList()``` change is unrelated, but jumped out as a build warning in my environment.
- There were no existing tests that exercised this class, so I didn't have any obvious place to hang a new unit test. Am I missing something obvious?