### PR TITLE
CURATOR-608 - ZPath's check for "isParameter()" is too simplistic, leading to isResolved() false negatives

### DIFF
--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/ZPath.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/ZPath.java
@@ -31,9 +31,6 @@ import static org.apache.curator.utils.ZKPaths.PATH_SEPARATOR;
  */
 public interface ZPath extends Resolvable
 {
-    String PARAMETER_OPENING_DELIMITER = "{";
-    String PARAMETER_CLOSING_DELIMITER = "}";
-
     /**
      * The root path: "/"
      */
@@ -55,11 +52,14 @@ public interface ZPath extends Resolvable
      */
     static String parameter(String name)
     {
-        return PATH_SEPARATOR + PARAMETER_OPENING_DELIMITER + name + PARAMETER_CLOSING_DELIMITER;
+        return PATH_SEPARATOR + "{" + name + "}";
     }
 
     /**
-     * Take a string path and return a ZPath
+     * Take a string path and return a ZPath.
+     * <p>
+     * Note: This method always produces a fully resolved path despite the presence of any parameter-like elements (i.e, {@code {one}}).
+     * For substituting parameter elements and for proper parameter resolution status checks, use {@code parseWithIds()} instead.
      *
      * @param fullPath the path to parse
      * @return ZPath
@@ -82,7 +82,7 @@ public interface ZPath extends Resolvable
      */
     static ZPath parseWithIds(String fullPath)
     {
-        return ZPathImpl.parse(fullPath, s -> isId(s) ? (PATH_SEPARATOR + s) : s); // TODO
+        return ZPathImpl.parse(fullPath, s -> isId(s) ? (PATH_SEPARATOR + s) : s);
     }
 
     /**
@@ -244,7 +244,13 @@ public interface ZPath extends Resolvable
     boolean isRoot();
 
     /**
-     * Return true if this path is fully resolved (i.e. has no unresolved parameters)
+     * Return true if this path is fully resolved (i.e. has no unresolved parameters).
+     * <p>
+     * Note: ZPath's returned by the {@code parse()} method are always considered fully resolved, despite if there are
+     * remaining elements in the path which appear to be parameters (but are not, i.e. {@code {one}}).
+     * <p>
+     * When working with parameters, use the {@code parseWithIds()} method, which returns a ZPath with a
+     * resolved state based on the presence of unresolved parameter elements in the ZPath.
      *
      * @return true/false
      */

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/ZPath.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/ZPath.java
@@ -31,6 +31,9 @@ import static org.apache.curator.utils.ZKPaths.PATH_SEPARATOR;
  */
 public interface ZPath extends Resolvable
 {
+    String PARAMETER_OPENING_DELIMITER = "{";
+    String PARAMETER_CLOSING_DELIMITER = "}";
+
     /**
      * The root path: "/"
      */
@@ -52,7 +55,7 @@ public interface ZPath extends Resolvable
      */
     static String parameter(String name)
     {
-        return PATH_SEPARATOR + "{" + name + "}";
+        return PATH_SEPARATOR + PARAMETER_OPENING_DELIMITER + name + PARAMETER_CLOSING_DELIMITER;
     }
 
     /**
@@ -241,7 +244,7 @@ public interface ZPath extends Resolvable
     boolean isRoot();
 
     /**
-     * Return true if this path is fully resolved (i.e. has no unresoled parameters)
+     * Return true if this path is fully resolved (i.e. has no unresolved parameters)
      *
      * @return true/false
      */

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ZPathImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ZPathImpl.java
@@ -210,9 +210,7 @@ public class ZPathImpl implements ZPath
             .map(name -> {
                 if ( isParameter(name) && iterator.hasNext() )
                 {
-                    // Eliminate any leading path separator from substituted parameters, as ZPathImpl() will
-                    // add in all required path separators as part of it's build operation.
-                    return NodeName.nameFrom(iterator.next()).replaceAll(String.format("^%s+", PATH_SEPARATOR), "");
+                    return NodeName.nameFrom(iterator.next());
                 }
                 return name;
             })
@@ -228,8 +226,7 @@ public class ZPathImpl implements ZPath
 
     private static boolean isParameter(String name)
     {
-        return name.matches(String.format(".*\\%s.*\\%s", PARAMETER_OPENING_DELIMITER,
-            PARAMETER_CLOSING_DELIMITER));
+        return (name.length() > 1) && name.startsWith(PATH_SEPARATOR);
     }
 
     private ZPathImpl(List<String> nodes, String child)

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ZPathImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ZPathImpl.java
@@ -210,7 +210,9 @@ public class ZPathImpl implements ZPath
             .map(name -> {
                 if ( isParameter(name) && iterator.hasNext() )
                 {
-                    return NodeName.nameFrom(iterator.next());
+                    // Eliminate any leading path separator from substituted parameters, as ZPathImpl() will
+                    // add in all required path separators as part of it's build operation.
+                    return NodeName.nameFrom(iterator.next()).replaceAll(String.format("^%s+", PATH_SEPARATOR), "");
                 }
                 return name;
             })
@@ -226,7 +228,8 @@ public class ZPathImpl implements ZPath
 
     private static boolean isParameter(String name)
     {
-        return (name.length() > 1) && name.startsWith(PATH_SEPARATOR);
+        return name.matches(String.format(".*\\%s.*\\%s", PARAMETER_OPENING_DELIMITER,
+            PARAMETER_CLOSING_DELIMITER));
     }
 
     private ZPathImpl(List<String> nodes, String child)

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestZPath.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestZPath.java
@@ -57,11 +57,11 @@ public class TestZPath
         assertFalse(path.startsWith(ZPath.root.child("two")));
 
         ZPath checkIdLike = ZPath.parse("/one/{two}/three");
-        assertTrue(checkIdLike.isResolved());
+        assertFalse(checkIdLike.isResolved());
         checkIdLike = ZPath.parse("/one/" + ZPath.parameter() + "/three");
-        assertTrue(checkIdLike.isResolved());
+        assertFalse(checkIdLike.isResolved());
         checkIdLike = ZPath.parse("/one/" + ZPath.parameter("others") + "/three");
-        assertTrue(checkIdLike.isResolved());
+        assertFalse(checkIdLike.isResolved());
     }
 
     @Test
@@ -71,6 +71,13 @@ public class TestZPath
         assertEquals(ZPath.parse("/one/two/three"), ZPath.root.child("one").child("two").child("three"));
         assertEquals(ZPath.parse("/one/two/three"), ZPath.from("one", "two", "three"));
         assertEquals(ZPath.parseWithIds("/one/{id}/two/{id}"), ZPath.from("one", parameter(), "two", parameter()));
+
+        final ZPath rootPath = ZPath.parse("/root");
+        ZPath path = ZPath.parseWithIds("{root}/one/{id}/two/{id}");
+        assertFalse(path.isResolved());
+        path = path.resolved(rootPath.toString(), "foo", "bar");
+        assertEquals(ZPath.from("root", "one", "foo", "two", "bar").toString(), path.toString());
+        assertTrue(path.isResolved());
     }
 
     @Test

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestZPath.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestZPath.java
@@ -56,12 +56,15 @@ public class TestZPath
         assertTrue(path.startsWith(ZPath.root.child("one")));
         assertFalse(path.startsWith(ZPath.root.child("two")));
 
+        // Despite these paths containing elements which appear to be parameters, ZPath.parse() always returns
+        // a ZPath which is considered fully resolved.  This allows users to include parameter-like elements in their
+        // ZPath's that aren't treated as parameters.
         ZPath checkIdLike = ZPath.parse("/one/{two}/three");
-        assertFalse(checkIdLike.isResolved());
+        assertTrue(checkIdLike.isResolved(), "parse method always returns a fully resolved ZPath");
         checkIdLike = ZPath.parse("/one/" + ZPath.parameter() + "/three");
-        assertFalse(checkIdLike.isResolved());
+        assertTrue(checkIdLike.isResolved(), "parse method always returns a fully resolved ZPath");
         checkIdLike = ZPath.parse("/one/" + ZPath.parameter("others") + "/three");
-        assertFalse(checkIdLike.isResolved());
+        assertTrue(checkIdLike.isResolved(), "parse method always returns a fully resolved ZPath");
     }
 
     @Test
@@ -71,13 +74,6 @@ public class TestZPath
         assertEquals(ZPath.parse("/one/two/three"), ZPath.root.child("one").child("two").child("three"));
         assertEquals(ZPath.parse("/one/two/three"), ZPath.from("one", "two", "three"));
         assertEquals(ZPath.parseWithIds("/one/{id}/two/{id}"), ZPath.from("one", parameter(), "two", parameter()));
-
-        final ZPath rootPath = ZPath.parse("/root");
-        ZPath path = ZPath.parseWithIds("{root}/one/{id}/two/{id}");
-        assertFalse(path.isResolved());
-        path = path.resolved(rootPath.toString(), "foo", "bar");
-        assertEquals(ZPath.from("root", "one", "foo", "two", "bar").toString(), path.toString());
-        assertTrue(path.isResolved());
     }
 
     @Test


### PR DESCRIPTION
ZPaths support parameters, which are special path elements in parenthesis (i.e., {one}) that may be substituted with values at runtime.

ZPaths also have a resolved state, which checks if a ZPath parsed with `parseWithIds()` still contains any parameters left to be substituted.

Additionally, ZPaths may be created with `parse()` which contain string elements which appear to be parameters (elements in parenthesis) but are not treated as such, always resulting in a path which is considered fully-resolved.

The documentation for these methods should be updated to better indicate this behavior difference, clearly stating what "resolved" state indicates based on the method that generated the ZPath.