### PR TITLE
CURATOR-625 Bump directory maven plugin version to 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <maven-javadoc-plugin-version>3.0.1</maven-javadoc-plugin-version>
         <doxia-module-confluence-version>1.8</doxia-module-confluence-version>
         <maven-license-plugin-version>1.9.0</maven-license-plugin-version>
+        <directory-maven-plugin-version>1.0</directory-maven-plugin-version>
         <javassist-version>3.24.1-GA</javassist-version>
         <commons-math-version>2.2</commons-math-version>
         <jackson-mapper-asl-version>1.9.13</jackson-mapper-asl-version>
@@ -682,7 +683,7 @@
                 <plugin>
                     <groupId>org.commonjava.maven.plugins</groupId>
                     <artifactId>directory-maven-plugin</artifactId>
-                    <version>0.1</version>
+                    <version>${directory-maven-plugin-version}</version>
                 </plugin>
 
                 <plugin>
@@ -847,7 +848,6 @@
             <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
-                <version>0.1</version>
                 <executions>
                     <execution>
                         <id>directories</id>


### PR DESCRIPTION
When running `mvn clean install -DskipTests` on my Mac i get:

`Failed to execute goal org.commonjava.maven.plugins:directory-maven-plugin:0.1:highest-basedir (directories) on project apache-curator: Cannot find a single highest directory for this project set. First two candidates directories don't share a common root. -> [Help 1]`


Upgrading the plugin, I'm able to compile