### PR TITLE
CURATOR-537: Fix effective path can be used as a fencing token of LeaderLatch

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -70,6 +70,7 @@ public class LeaderLatch implements Closeable
     private final AtomicReference<State> state = new AtomicReference<State>(State.LATENT);
     private final AtomicBoolean hasLeadership = new AtomicBoolean(false);
     private final AtomicReference<String> ourPath = new AtomicReference<String>();
+    private final AtomicReference<String> lastPathIsLeader = new AtomicReference<String>();
     private final StandardListenerManager<LeaderLatchListener> listeners = StandardListenerManager.standard();
     private final CloseMode closeMode;
     private final AtomicReference<Future<?>> startTask = new AtomicReference<Future<?>>();
@@ -480,17 +481,17 @@ public class LeaderLatch implements Closeable
     }
 
     /**
-     * Return this instance's lock node path. IMPORTANT: this instance
-     * owns the path returned. This method is meant for reference only. Also,
-     * it is possible for <code>null</code> to be returned. The path, if any,
-     * returned is not guaranteed to be valid at any point in the future as internal
-     * state changes might require the instance to delete and create a new path.
+     * Return last of this instance's lock node path that was leader ever.
+     * IMPORTANT: this instance owns the path returned. This method is meant for reference only.
+     * Also, it is possible for <code>null</code> to be returned (for this instance never becomes
+     * a leader). The path, if any, returned is not guaranteed to be valid at any point in the future
+     * as internal state changes might require the instance to delete the path.
      *
-     * @return lock node path or <code>null</code>
+     * @return last lock node path that was leader ever or <code>null</code>
      */
-    public String getOurPath()
+    public String getLastPathIsLeader()
     {
-        return ourPath.get();
+        return lastPathIsLeader.get();
     }
 
     @VisibleForTesting
@@ -571,6 +572,7 @@ public class LeaderLatch implements Closeable
         }
         else if ( ourIndex == 0 )
         {
+            lastPathIsLeader.set(localOurPath);
             setLeadership(true);
         }
         else


### PR DESCRIPTION
This is a follow up to #324.

ourPath can be modified after it's retrived in checkLeadership and before isLeader saves it by ourPath.get() again - if the connection reset and node be recreated.

To avoid handling multiple concurrent cases, this patch simply saves the last node is leader as the localOurPath so that it's always the last valid fencing token - it can be verified as invalid later, but never false valid.

Signed-off-by: tison <wander4096@gmail.com>

cc @Randgalt @eolivelli @cammckenzie I'm unsure whether I get the data race possibility right. It seems that ourPath can be false valid only if it's `reset` concurrently. Other ops are synced by the node, but handle state on reconnect can be async.