### PR TITLE
shutdown runSafeService

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -425,7 +425,12 @@ public class CuratorFrameworkImpl implements CuratorFramework
                     Thread.currentThread().interrupt();
                 }
             }
-
+            
+            if ( runSafeService != null )
+            {
+            	runSafeService.shutdownNow();
+            }
+            
             if ( ensembleTracker != null )
             {
                 ensembleTracker.close();


### PR DESCRIPTION
shutdown runSafeService to fix stop tomcat or other containerd .

警告 [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.clearReferencesThreads Web应用程序[game-api]似乎启动了一个名为[Curator-SafeNotifyService-0]的线程，但未能停止它。这很可能会造成内存泄漏。线程的堆栈跟踪：[
 sun.misc.Unsafe.park(Native Method)
 java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
 java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
 java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
 java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1074)
 java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1134)
 java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
 java.lang.Thread.run(Thread.java:750)]