### PR TITLE
Fix DistributedDoubleBarrier enter and leave methods because using the same watcher affects each other

### DIFF
--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/barriers/TestDistributedDoubleBarrier.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/barriers/TestDistributedDoubleBarrier.java
@@ -18,32 +18,28 @@
  */
 package org.apache.curator.framework.recipes.barriers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
-import org.apache.curator.test.BaseClassForTests;
-import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
+import org.apache.curator.utils.CloseableUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.Closeable;
+import java.lang.reflect.Field;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestDistributedDoubleBarrier extends BaseClassForTests
 {
     private static final int           QTY = 5;
+    private static final int           ENTER_AFFECT_LEAVE_TEST_COUNT = 10;
 
     @Test
     public void     testMultiClient() throws Exception
@@ -165,6 +161,84 @@ public class TestDistributedDoubleBarrier extends BaseClassForTests
             service.shutdown();
             CloseableUtils.closeQuietly(client);
         }
+    }
+
+    @Test
+    public void     testEnterAffectLeaveByWatcher() throws Exception
+    {
+        for (int count = 0; count < ENTER_AFFECT_LEAVE_TEST_COUNT; count++) {
+            final Timing            timing = new Timing();
+            List<Future<Void>>      futures = Lists.newArrayList();
+            CountDownLatch          leaveLatch = new CountDownLatch(1);
+            ExecutorService         service = Executors.newCachedThreadPool();
+
+            for ( int i = 0; i < QTY-1; ++i )
+            {
+                final int       index = i;
+                Future<Void>    future = service.submit
+                        (
+                                new Callable<Void>()
+                                {
+                                    @Override
+                                    public Void call() throws Exception
+                                    {
+                                        CuratorFramework                client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+                                        try
+                                        {
+                                            client.start();
+                                            DistributedDoubleBarrier        barrier = new DistributedDoubleBarrier(client, "/barrier", QTY);
+
+                                            assertTrue(barrier.enter(timing.seconds(), TimeUnit.SECONDS));
+
+                                            assertTrue(barrier.leave(timing.seconds(), TimeUnit.SECONDS));
+
+                                        }
+                                        finally
+                                        {
+                                            CloseableUtils.closeQuietly(client);
+                                        }
+
+                                        return null;
+                                    }
+                                }
+                        );
+                futures.add(future);
+            }
+
+
+            CuratorFramework                client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+            client.start();
+            DistributedDoubleBarrier        barrier = new DistributedDoubleBarrier(client, "/barrier", QTY);
+            barrier.enter();
+
+            AtomicBoolean error = new AtomicBoolean(true);
+
+            Future<Void> leaveFuture = service.submit(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    Field ourPathField = barrier.getClass().getDeclaredField("ourPath");
+                    ourPathField.setAccessible(true);
+                    String ourPath = (String) ourPathField.get(barrier);
+                    leaveLatch.await(timing.seconds()/2,TimeUnit.SECONDS);
+                    client.delete().forPath(ourPath);
+                    error.set(false);
+                    return null;
+                }
+            });
+
+            for ( Future<Void> f : futures )
+            {
+                f.get();
+            }
+
+            assertFalse(error.get());
+            leaveLatch.countDown();
+            leaveFuture.get();
+            List<String> children = client.getChildren().forPath("/barrier");
+            assertTrue(children.isEmpty());
+        }
+
+
     }
 
     @Test


### PR DESCRIPTION
Scenario: QTY clients call the enter method, QTY-1 clients call the leave method, the number of clients is not enough so it blocks, and the working directory leaves the smallest node. At this time, the smallest node client receives the notification that the ready node is created to wake up the thread , it is checked that only one node deletes the node, and other clients are woken up
Solution: use different watchers for enter and leaver methods
Test case: TestDistributedDoubleBarrier.testEnterAffectLeaveByWatcher