### PR TITLE
CURATOR-642 Upgrade Guava from 27.0.1 to 31.1

### DIFF
--- a/curator-test/src/main/java/org/apache/curator/test/DirectoryUtils.java
+++ b/curator-test/src/main/java/org/apache/curator/test/DirectoryUtils.java
@@ -23,6 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 // copied from Google Guava as these methods are now deprecated
 // NOTE: removed the line of code documented: Symbolic links will have different canonical and absolute paths
@@ -30,6 +33,15 @@ import java.io.IOException;
 public class DirectoryUtils
 {
     private static final Logger log = LoggerFactory.getLogger(DirectoryUtils.class);
+
+    public static File createTempDirectory() {
+        try {
+            final Path tempDirectory = Files.createTempDirectory(DirectoryUtils.class.getSimpleName());
+            return tempDirectory.toFile();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 
     public static void deleteRecursively(File file) throws IOException
     {

--- a/curator-test/src/main/java/org/apache/curator/test/InstanceSpec.java
+++ b/curator-test/src/main/java/org/apache/curator/test/InstanceSpec.java
@@ -21,12 +21,9 @@ package org.apache.curator.test;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -171,7 +168,7 @@ public class InstanceSpec
      */
     public InstanceSpec(File dataDirectory, int port, int electionPort, int quorumPort, boolean deleteDataDirectoryOnClose, int serverId, int tickTime, int maxClientCnxns, Map<String,Object> customProperties,String hostname)
     {
-        this.dataDirectory = (dataDirectory != null) ? dataDirectory : createTempDirectory();
+        this.dataDirectory = (dataDirectory != null) ? dataDirectory : DirectoryUtils.createTempDirectory();
         this.port = (port >= 0) ? port : getRandomPort();
         this.electionPort = (electionPort >= 0) ? electionPort : getRandomPort();
         this.quorumPort = (quorumPort >= 0) ? quorumPort : getRandomPort();
@@ -275,14 +272,5 @@ public class InstanceSpec
     public int hashCode()
     {
         return hostname.hashCode() + port;
-    }
-
-    private static File createTempDirectory() {
-        try {
-            final Path tempDirectory = Files.createTempDirectory(InstanceSpec.class.getSimpleName());
-            return tempDirectory.toFile();
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 }

--- a/curator-test/src/main/java/org/apache/curator/test/InstanceSpec.java
+++ b/curator-test/src/main/java/org/apache/curator/test/InstanceSpec.java
@@ -19,12 +19,14 @@
 
 package org.apache.curator.test;
 
-import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -169,7 +171,7 @@ public class InstanceSpec
      */
     public InstanceSpec(File dataDirectory, int port, int electionPort, int quorumPort, boolean deleteDataDirectoryOnClose, int serverId, int tickTime, int maxClientCnxns, Map<String,Object> customProperties,String hostname)
     {
-        this.dataDirectory = (dataDirectory != null) ? dataDirectory : Files.createTempDir();
+        this.dataDirectory = (dataDirectory != null) ? dataDirectory : createTempDirectory();
         this.port = (port >= 0) ? port : getRandomPort();
         this.electionPort = (electionPort >= 0) ? electionPort : getRandomPort();
         this.quorumPort = (quorumPort >= 0) ? quorumPort : getRandomPort();
@@ -273,5 +275,14 @@ public class InstanceSpec
     public int hashCode()
     {
         return hostname.hashCode() + port;
+    }
+
+    private static File createTempDirectory() {
+        try {
+            final Path tempDirectory = Files.createTempDirectory(InstanceSpec.class.getSimpleName());
+            return tempDirectory.toFile();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <scannotation-version>1.0.2</scannotation-version>
         <!-- resteasy-jaxrs dependency cannot be higher than 2.x for compatibility with Jersey 1.x -->
         <resteasy-jaxrs-version>2.3.5.Final</resteasy-jaxrs-version>
-        <guava-version>27.0.1-jre</guava-version>
+        <guava-version>31.1-jre</guava-version>
         <guava-listenablefuture-version>1.0</guava-listenablefuture-version>
         <guava-failureaccess-version>1.0.1</guava-failureaccess-version>
         <junit-version>5.6.2</junit-version>


### PR DESCRIPTION
CURATOR-642 Upgrades Guava from 27.0.1 to 31.1 and replaces usage of Guava `Files.createTempDir()` with Java NIO `Files.createTempDirectory()`