### PR TITLE
CURATOR-638: Use getHostString() to build connection string in EnsembleTracker

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -186,7 +186,7 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
             }
             else
             {
-                hostAddress = server.clientAddr.getAddress().getHostAddress();
+                hostAddress = server.clientAddr.getHostString();
             }
             sb.append(hostAddress).append(":").append(server.clientAddr.getPort());
         }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
@@ -477,6 +477,14 @@ public class TestReconfiguration extends CuratorTestBase
     }
 
     @Test
+    public void testHostname() throws Exception
+    {
+        String config = "server.1=localhost:2888:3888:participant;localhost:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("localhost:2181", configString);
+    }
+
+    @Test
     public void testIPv6Wildcard1() throws Exception
     {
         String config = "server.1=[2001:db8:85a3:0:0:8a2e:370:7334]:2888:3888:participant;[::]:2181";


### PR DESCRIPTION
In Kubernetes, IP addresses are not resistant to pod restart. `InetSocketAddress.getAddress().getHostAddress()` could target to non ZooKeeper pods and causes curator fail to reach ZooKeeper ensemble.

Further more, this is compatible with `QuorumVerifier.toString` and `QuorumServer.toString`.