### PR TITLE
CURATOR-644. CURATOR-645. Fix livelock in LeaderLatch

### DIFF
--- a/curator-recipes/pom.xml
+++ b/curator-recipes/pom.xml
@@ -86,6 +86,12 @@
             <artifactId>commons-math</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -609,7 +609,7 @@ public class LeaderLatch implements Closeable
         List<String> sortedChildren = LockInternals.getSortedChildren(LOCK_NAME, sorter, children);
         int ourIndex = (localOurPath != null) ? sortedChildren.indexOf(ZKPaths.getNodeFromPath(localOurPath)) : -1;
 
-        log.debug("checkLeadership with id: {},ourPath: {}, children: {}", id, localOurPath, sortedChildren);
+        log.debug("checkLeadership with id: {}, ourPath: {}, children: {}", id, localOurPath, sortedChildren);
 
         if ( ourIndex < 0 )
         {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -576,7 +576,7 @@ public class LeaderLatch implements Closeable
     @VisibleForTesting
     volatile CountDownLatch debugCheckLeaderShipLatch = null;
 
-    private synchronized void checkLeadership(List<String> children) throws Exception
+    private void checkLeadership(List<String> children) throws Exception
     {
         if ( debugCheckLeaderShipLatch != null )
         {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -587,7 +587,7 @@ public class LeaderLatch implements Closeable
         List<String> sortedChildren = LockInternals.getSortedChildren(LOCK_NAME, sorter, children);
         int ourIndex = (localOurPath != null) ? sortedChildren.indexOf(ZKPaths.getNodeFromPath(localOurPath)) : -1;
 
-        log.debug("checkLeadership with ourPath: {}, children: {}", localOurPath, sortedChildren);
+        log.debug("checkLeadership with id: {},ourPath: {}, children: {}", id, localOurPath, sortedChildren);
 
         if ( ourIndex < 0 )
         {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -692,7 +692,7 @@ public class LeaderLatch implements Closeable
             {
                 try
                 {
-                    if ( client.getConnectionStateErrorPolicy().isErrorState(ConnectionState.SUSPENDED) )
+                    if ( client.getConnectionStateErrorPolicy().isErrorState(ConnectionState.SUSPENDED) || !hasLeadership.get() )
                     {
                         getChildren();
                     }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -576,7 +576,7 @@ public class LeaderLatch implements Closeable
     @VisibleForTesting
     volatile CountDownLatch debugCheckLeaderShipLatch = null;
 
-    private void checkLeadership(List<String> children) throws Exception
+    private synchronized void checkLeadership(List<String> children) throws Exception
     {
         if ( debugCheckLeaderShipLatch != null )
         {

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -190,7 +190,7 @@ public class LeaderLatch implements Closeable
         close(closeMode);
     }
 
-    // for testing
+    @VisibleForTesting
     void closeOnDemand() throws IOException
     {
         internalClose(closeMode, false);

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -667,9 +667,9 @@ public class LeaderLatch implements Closeable
             {
                 try
                 {
-                    if ( client.getConnectionStateErrorPolicy().isErrorState(ConnectionState.SUSPENDED) || !hasLeadership.get() )
+                    if ( client.getConnectionStateErrorPolicy().isErrorState(ConnectionState.SUSPENDED) )
                     {
-                        reset();
+                        getChildren();
                     }
                 }
                 catch ( Exception e )

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -586,6 +586,9 @@ public class LeaderLatch implements Closeable
         final String localOurPath = ourPath.get();
         List<String> sortedChildren = LockInternals.getSortedChildren(LOCK_NAME, sorter, children);
         int ourIndex = (localOurPath != null) ? sortedChildren.indexOf(ZKPaths.getNodeFromPath(localOurPath)) : -1;
+
+        log.debug("checkLeadership with ourPath: {}, children: {}", localOurPath, sortedChildren);
+
         if ( ourIndex < 0 )
         {
             log.error("Can't find our node. Resetting. Index: " + ourIndex);
@@ -717,6 +720,7 @@ public class LeaderLatch implements Closeable
     private void setNode(String newValue) throws Exception
     {
         String oldPath = ourPath.getAndSet(newValue);
+        log.debug("setNode with oldPath: {}, newValue: {}", oldPath, newValue);
         if ( oldPath != null )
         {
             client.delete().guaranteed().inBackground().forPath(oldPath);

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -604,7 +604,7 @@ public class LeaderLatch implements Closeable
                 @Override
                 public void process(WatchedEvent event)
                 {
-                    if ( (state.get() == State.STARTED) && (event.getType() == Event.EventType.NodeDeleted) && (localOurPath != null) )
+                    if ( state.get() == State.STARTED && event.getType() == Event.EventType.NodeDeleted )
                     {
                         try
                         {
@@ -626,8 +626,8 @@ public class LeaderLatch implements Closeable
                 {
                     if ( event.getResultCode() == KeeperException.Code.NONODE.intValue() )
                     {
-                        // previous node is gone - reset
-                        reset();
+                        // previous node is gone - retry getChildren
+                        getChildren();
                     }
                 }
             };

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -720,7 +720,7 @@ public class LeaderLatch implements Closeable
     private void setNode(String newValue) throws Exception
     {
         String oldPath = ourPath.getAndSet(newValue);
-        log.debug("setNode with oldPath: {}, newValue: {}", oldPath, newValue);
+        log.debug("setNode with id: {}, oldPath: {}, newValue: {}", id, oldPath, newValue);
         if ( oldPath != null )
         {
             client.delete().guaranteed().inBackground().forPath(oldPath);

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
@@ -21,25 +21,6 @@ package org.apache.curator.framework.recipes.leader;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.WatcherRemoveCuratorFramework;
-import org.apache.curator.framework.api.BackgroundCallback;
-import org.apache.curator.framework.api.CuratorEvent;
-import org.apache.curator.framework.listen.StandardListenerManager;
-import org.apache.curator.framework.recipes.AfterConnectionEstablished;
-import org.apache.curator.framework.recipes.locks.LockInternals;
-import org.apache.curator.framework.recipes.locks.LockInternalsSorter;
-import org.apache.curator.framework.recipes.locks.StandardLockInternalsDriver;
-import org.apache.curator.framework.state.ConnectionState;
-import org.apache.curator.framework.state.ConnectionStateListener;
-import org.apache.curator.utils.ThreadUtils;
-import org.apache.curator.utils.ZKPaths;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
@@ -51,7 +32,24 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.WatcherRemoveCuratorFramework;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.listen.StandardListenerManager;
+import org.apache.curator.framework.recipes.AfterConnectionEstablished;
+import org.apache.curator.framework.recipes.locks.LockInternals;
+import org.apache.curator.framework.recipes.locks.LockInternalsSorter;
+import org.apache.curator.framework.recipes.locks.StandardLockInternalsDriver;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.PathUtils;
+import org.apache.curator.utils.ThreadUtils;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -61,42 +59,24 @@ import org.apache.curator.utils.PathUtils;
  * group will randomly be chosen
  * </p>
  */
-public class LeaderLatch implements Closeable
-{
-    private final Logger log = LoggerFactory.getLogger(getClass());
+public class LeaderLatch implements Closeable {
+    private static final String LOCK_NAME = "latch-";
+    private static final LockInternalsSorter sorter = StandardLockInternalsDriver::standardFixForSorting;
+    private static final Logger log = LoggerFactory.getLogger(LeaderLatch.class);
+
     private final WatcherRemoveCuratorFramework client;
     private final String latchPath;
     private final String id;
-    private final AtomicReference<State> state = new AtomicReference<State>(State.LATENT);
+    private final AtomicReference<State> state = new AtomicReference<>(State.LATENT);
     private final AtomicBoolean hasLeadership = new AtomicBoolean(false);
-    private final AtomicReference<String> ourPath = new AtomicReference<String>();
-    private final AtomicReference<String> lastPathIsLeader = new AtomicReference<String>();
+    private final AtomicReference<String> ourPath = new AtomicReference<>();
+    private final AtomicReference<String> lastPathIsLeader = new AtomicReference<>();
     private final StandardListenerManager<LeaderLatchListener> listeners = StandardListenerManager.standard();
     private final CloseMode closeMode;
-    private final AtomicReference<Future<?>> startTask = new AtomicReference<Future<?>>();
+    private final AtomicReference<Future<?>> startTask = new AtomicReference<>();
+    private final ConnectionStateListener listener = (client, newState) -> handleStateChange(newState);
 
-    private final ConnectionStateListener listener = new ConnectionStateListener()
-    {
-        @Override
-        public void stateChanged(CuratorFramework client, ConnectionState newState)
-        {
-            handleStateChange(newState);
-        }
-    };
-
-    private static final String LOCK_NAME = "latch-";
-
-    private static final LockInternalsSorter sorter = new LockInternalsSorter()
-    {
-        @Override
-        public String fixForSorting(String str, String lockName)
-        {
-            return StandardLockInternalsDriver.standardFixForSorting(str, lockName);
-        }
-    };
-
-    public enum State
-    {
+    public enum State {
         LATENT,
         STARTED,
         CLOSED
@@ -105,8 +85,7 @@ public class LeaderLatch implements Closeable
     /**
      * How to handle listeners when the latch is closed
      */
-    public enum CloseMode
-    {
+    public enum CloseMode {
         /**
          * When the latch is closed, listeners will *not* be notified (default behavior)
          */
@@ -122,8 +101,7 @@ public class LeaderLatch implements Closeable
      * @param client    the client
      * @param latchPath the path for this leadership group
      */
-    public LeaderLatch(CuratorFramework client, String latchPath)
-    {
+    public LeaderLatch(CuratorFramework client, String latchPath) {
         this(client, latchPath, "", CloseMode.SILENT);
     }
 
@@ -132,8 +110,7 @@ public class LeaderLatch implements Closeable
      * @param latchPath the path for this leadership group
      * @param id        participant ID
      */
-    public LeaderLatch(CuratorFramework client, String latchPath, String id)
-    {
+    public LeaderLatch(CuratorFramework client, String latchPath, String id) {
         this(client, latchPath, id, CloseMode.SILENT);
     }
 
@@ -143,8 +120,7 @@ public class LeaderLatch implements Closeable
      * @param id        participant ID
      * @param closeMode behaviour of listener on explicit close.
      */
-    public LeaderLatch(CuratorFramework client, String latchPath, String id, CloseMode closeMode)
-    {
+    public LeaderLatch(CuratorFramework client, String latchPath, String id, CloseMode closeMode) {
         this.client = Preconditions.checkNotNull(client, "client cannot be null").newWatcherRemoveCuratorFramework();
         this.latchPath = PathUtils.validatePath(latchPath);
         this.id = Preconditions.checkNotNull(id, "id cannot be null");
@@ -156,23 +132,14 @@ public class LeaderLatch implements Closeable
      *
      * @throws Exception errors
      */
-    public void start() throws Exception
-    {
+    public void start() throws Exception {
         Preconditions.checkState(state.compareAndSet(State.LATENT, State.STARTED), "Cannot be started more than once");
 
-        startTask.set(AfterConnectionEstablished.execute(client, new Runnable()
-        {
-            @Override
-            public void run()
-            {
-                try
-                {
-                    internalStart();
-                }
-                finally
-                {
-                    startTask.set(null);
-                }
+        startTask.set(AfterConnectionEstablished.execute(client, () -> {
+            try {
+                internalStart();
+            } finally {
+                startTask.set(null);
             }
         }));
     }
@@ -185,8 +152,7 @@ public class LeaderLatch implements Closeable
      * @throws IOException errors
      */
     @Override
-    public void close() throws IOException
-    {
+    public void close() throws IOException {
         close(closeMode);
     }
 
@@ -198,52 +164,41 @@ public class LeaderLatch implements Closeable
      * @param closeMode allows the default close mode to be overridden at the time the latch is closed.
      * @throws IOException errors
      */
-    public synchronized void close(CloseMode closeMode) throws IOException
-    {
+    public synchronized void close(CloseMode closeMode) throws IOException {
         Preconditions.checkState(state.compareAndSet(State.STARTED, State.CLOSED), "Already closed or has not been started");
         Preconditions.checkNotNull(closeMode, "closeMode cannot be null");
 
         cancelStartTask();
 
-        try
-        {
+        try {
             setNode(null);
             client.removeWatchers();
-        }
-        catch ( Exception e )
-        {
+        } catch (Exception e) {
             ThreadUtils.checkInterrupted(e);
             throw new IOException(e);
-        }
-        finally
-        {
+        } finally {
             client.getConnectionStateListenable().removeListener(listener);
 
-            switch ( closeMode )
-            {
-            case NOTIFY_LEADER:
-            {
-                setLeadership(false);
-                listeners.clear();
-                break;
-            }
+            switch (closeMode) {
+                case NOTIFY_LEADER: {
+                    setLeadership(false);
+                    listeners.clear();
+                    break;
+                }
 
-            default:
-            {
-                listeners.clear();
-                setLeadership(false);
-                break;
-            }
+                case SILENT: {
+                    listeners.clear();
+                    setLeadership(false);
+                    break;
+                }
             }
         }
     }
 
     @VisibleForTesting
-    protected boolean cancelStartTask()
-    {
+    protected boolean cancelStartTask() {
         Future<?> localStartTask = startTask.getAndSet(null);
-        if ( localStartTask != null )
-        {
+        if (localStartTask != null) {
             localStartTask.cancel(true);
             return true;
         }
@@ -262,8 +217,7 @@ public class LeaderLatch implements Closeable
      *
      * @param listener the listener to attach
      */
-    public void addListener(LeaderLatchListener listener)
-    {
+    public void addListener(LeaderLatchListener listener) {
         listeners.addListener(listener);
     }
 
@@ -280,8 +234,7 @@ public class LeaderLatch implements Closeable
      * @param listener the listener to attach
      * @param executor An executor to run the methods for the listener on.
      */
-    public void addListener(LeaderLatchListener listener, Executor executor)
-    {
+    public void addListener(LeaderLatchListener listener, Executor executor) {
         listeners.addListener(listener, executor);
     }
 
@@ -290,8 +243,7 @@ public class LeaderLatch implements Closeable
      *
      * @param listener the listener to remove
      */
-    public void removeListener(LeaderLatchListener listener)
-    {
+    public void removeListener(LeaderLatchListener listener) {
         listeners.removeListener(listener);
     }
 
@@ -322,17 +274,13 @@ public class LeaderLatch implements Closeable
      * @throws EOFException         if the instance is {@linkplain #close() closed}
      *                              while waiting
      */
-    public void await() throws InterruptedException, EOFException
-    {
-        synchronized(this)
-        {
-            while ( (state.get() == State.STARTED) && !hasLeadership.get() )
-            {
+    public void await() throws InterruptedException, EOFException {
+        synchronized (this) {
+            while ((state.get() == State.STARTED) && !hasLeadership.get()) {
                 wait();
             }
         }
-        if ( state.get() != State.STARTED )
-        {
+        if (state.get() != State.STARTED) {
             throw new EOFException();
         }
     }
@@ -375,26 +323,20 @@ public class LeaderLatch implements Closeable
      * @throws InterruptedException if the current thread is interrupted
      *                              while waiting
      */
-    public boolean await(long timeout, TimeUnit unit) throws InterruptedException
-    {
+    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
         long waitNanos = TimeUnit.NANOSECONDS.convert(timeout, unit);
 
-        synchronized(this)
-        {
-            while ( true )
-            {
-                if ( state.get() != State.STARTED )
-                {
+        synchronized (this) {
+            while (true) {
+                if (state.get() != State.STARTED) {
                     return false;
                 }
 
-                if ( hasLeadership() )
-                {
+                if (hasLeadership()) {
                     return true;
                 }
 
-                if ( waitNanos <= 0 )
-                {
+                if (waitNanos <= 0) {
                     return false;
                 }
 
@@ -411,8 +353,7 @@ public class LeaderLatch implements Closeable
      *
      * @return participant Id
      */
-    public String getId()
-    {
+    public String getId() {
         return id;
     }
 
@@ -424,8 +365,7 @@ public class LeaderLatch implements Closeable
      *
      * @return the state of the current instance
      */
-    public State getState()
-    {
+    public State getState() {
         return state.get();
     }
 
@@ -443,8 +383,7 @@ public class LeaderLatch implements Closeable
      * @return participants
      * @throws Exception ZK errors, interruptions, etc.
      */
-    public Collection<Participant> getParticipants() throws Exception
-    {
+    public Collection<Participant> getParticipants() throws Exception {
         Collection<String> participantNodes = LockInternals.getParticipantNodes(client, latchPath, LOCK_NAME, sorter);
         return LeaderSelector.getParticipants(client, participantNodes);
     }
@@ -464,8 +403,7 @@ public class LeaderLatch implements Closeable
      * @return leader
      * @throws Exception ZK errors, interruptions, etc.
      */
-    public Participant getLeader() throws Exception
-    {
+    public Participant getLeader() throws Exception {
         Collection<String> participantNodes = LockInternals.getParticipantNodes(client, latchPath, LOCK_NAME, sorter);
         return LeaderSelector.getLeader(client, participantNodes);
     }
@@ -475,8 +413,7 @@ public class LeaderLatch implements Closeable
      *
      * @return true/false
      */
-    public boolean hasLeadership()
-    {
+    public boolean hasLeadership() {
         return (state.get() == State.STARTED) && hasLeadership.get();
     }
 
@@ -494,8 +431,7 @@ public class LeaderLatch implements Closeable
      *
      * @return lock node path or <code>null</code>
      */
-    public String getOurPath()
-    {
+    public String getOurPath() {
         return ourPath.get();
     }
 
@@ -510,8 +446,7 @@ public class LeaderLatch implements Closeable
      *
      * @return last lock node path that was leader ever or <code>null</code>
      */
-    public String getLastPathIsLeader()
-    {
+    public String getLastPathIsLeader() {
         return lastPathIsLeader.get();
     }
 
@@ -519,54 +454,36 @@ public class LeaderLatch implements Closeable
     volatile CountDownLatch debugResetWaitLatch = null;
 
     @VisibleForTesting
-    void reset() throws Exception
-    {
+    void reset() throws Exception {
         setLeadership(false);
         setNode(null);
 
-        BackgroundCallback callback = new BackgroundCallback()
-        {
-            @Override
-            public void processResult(CuratorFramework client, CuratorEvent event) throws Exception
-            {
-                if ( debugResetWaitLatch != null )
-                {
-                    debugResetWaitLatch.await();
-                    debugResetWaitLatch = null;
-                }
+        BackgroundCallback callback = (client, event) -> {
+            if (debugResetWaitLatch != null) {
+                debugResetWaitLatch.await();
+                debugResetWaitLatch = null;
+            }
 
-                if ( event.getResultCode() == KeeperException.Code.OK.intValue() )
-                {
-                    setNode(event.getName());
-                    if ( state.get() == State.CLOSED )
-                    {
-                        setNode(null);
-                    }
-                    else
-                    {
-                        getChildren();
-                    }
+            if (event.getResultCode() == KeeperException.Code.OK.intValue()) {
+                setNode(event.getName());
+                if (state.get() == State.CLOSED) {
+                    setNode(null);
+                } else {
+                    getChildren();
                 }
-                else
-                {
-                    log.error("getChildren() failed. rc = " + event.getResultCode());
-                }
+            } else {
+                log.error("getChildren() failed. rc = " + event.getResultCode());
             }
         };
         client.create().creatingParentContainersIfNeeded().withProtection().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).inBackground(callback).forPath(ZKPaths.makePath(latchPath, LOCK_NAME), LeaderSelector.getIdBytes(id));
     }
 
-    private synchronized void internalStart()
-    {
-        if ( state.get() == State.STARTED )
-        {
+    private synchronized void internalStart() {
+        if (state.get() == State.STARTED) {
             client.getConnectionStateListenable().addListener(listener);
-            try
-            {
+            try {
                 reset();
-            }
-            catch ( Exception e )
-            {
+            } catch (Exception e) {
                 ThreadUtils.checkInterrupted(e);
                 log.error("An error occurred checking resetting leadership.", e);
             }
@@ -576,59 +493,37 @@ public class LeaderLatch implements Closeable
     @VisibleForTesting
     volatile CountDownLatch debugCheckLeaderShipLatch = null;
 
-    private synchronized void checkLeadership(List<String> children) throws Exception
-    {
-        if ( debugCheckLeaderShipLatch != null )
-        {
+    private synchronized void checkLeadership(List<String> children) throws Exception {
+        if (debugCheckLeaderShipLatch != null) {
             debugCheckLeaderShipLatch.await();
         }
 
         final String localOurPath = ourPath.get();
         List<String> sortedChildren = LockInternals.getSortedChildren(LOCK_NAME, sorter, children);
         int ourIndex = (localOurPath != null) ? sortedChildren.indexOf(ZKPaths.getNodeFromPath(localOurPath)) : -1;
-        if ( ourIndex < 0 )
-        {
+        if (ourIndex < 0) {
             log.error("Can't find our node. Resetting. Index: " + ourIndex);
             reset();
-        }
-        else if ( ourIndex == 0 )
-        {
+        } else if (ourIndex == 0) {
             lastPathIsLeader.set(localOurPath);
             setLeadership(true);
-        }
-        else
-        {
+        } else {
             String watchPath = sortedChildren.get(ourIndex - 1);
-            Watcher watcher = new Watcher()
-            {
-                @Override
-                public void process(WatchedEvent event)
-                {
-                    if ( state.get() == State.STARTED && event.getType() == Event.EventType.NodeDeleted )
-                    {
-                        try
-                        {
-                            getChildren();
-                        }
-                        catch ( Exception ex )
-                        {
-                            ThreadUtils.checkInterrupted(ex);
-                            log.error("An error occurred checking the leadership.", ex);
-                        }
+            Watcher watcher = event -> {
+                if (state.get() == State.STARTED && event.getType() == Watcher.Event.EventType.NodeDeleted) {
+                    try {
+                        getChildren();
+                    } catch (Exception ex) {
+                        ThreadUtils.checkInterrupted(ex);
+                        log.error("An error occurred checking the leadership.", ex);
                     }
                 }
             };
 
-            BackgroundCallback callback = new BackgroundCallback()
-            {
-                @Override
-                public void processResult(CuratorFramework client, CuratorEvent event) throws Exception
-                {
-                    if ( event.getResultCode() == KeeperException.Code.NONODE.intValue() )
-                    {
-                        // previous node is gone - retry getChildren
-                        getChildren();
-                    }
+            BackgroundCallback callback = (client, event) -> {
+                if (event.getResultCode() == KeeperException.Code.NONODE.intValue()) {
+                    // previous node is gone - retry getChildren
+                    getChildren();
                 }
             };
             // use getData() instead of exists() to avoid leaving unneeded watchers which is a type of resource leak
@@ -636,44 +531,29 @@ public class LeaderLatch implements Closeable
         }
     }
 
-    private void getChildren() throws Exception
-    {
-        BackgroundCallback callback = new BackgroundCallback()
-        {
-            @Override
-            public void processResult(CuratorFramework client, CuratorEvent event) throws Exception
-            {
-                if ( event.getResultCode() == KeeperException.Code.OK.intValue() )
-                {
-                    checkLeadership(event.getChildren());
-                }
+    private void getChildren() throws Exception {
+        BackgroundCallback callback = (client, event) -> {
+            if (event.getResultCode() == KeeperException.Code.OK.intValue()) {
+                checkLeadership(event.getChildren());
             }
         };
         client.getChildren().inBackground(callback).forPath(ZKPaths.makePath(latchPath, null));
     }
 
     @VisibleForTesting
-    protected void handleStateChange(ConnectionState newState)
-    {
-        switch ( newState )
-        {
-            default:
-            {
+    protected void handleStateChange(ConnectionState newState) {
+        switch (newState) {
+            default: {
                 // NOP
                 break;
             }
 
-            case RECONNECTED:
-            {
-                try
-                {
-                    if ( client.getConnectionStateErrorPolicy().isErrorState(ConnectionState.SUSPENDED) )
-                    {
+            case RECONNECTED: {
+                try {
+                    if (client.getConnectionStateErrorPolicy().isErrorState(ConnectionState.SUSPENDED)) {
                         getChildren();
                     }
-                }
-                catch ( Exception e )
-                {
+                } catch (Exception e) {
                     ThreadUtils.checkInterrupted(e);
                     log.error("Could not reset leader latch", e);
                     setLeadership(false);
@@ -681,44 +561,35 @@ public class LeaderLatch implements Closeable
                 break;
             }
 
-            case SUSPENDED:
-            {
-                if ( client.getConnectionStateErrorPolicy().isErrorState(ConnectionState.SUSPENDED) )
-                {
+            case SUSPENDED: {
+                if (client.getConnectionStateErrorPolicy().isErrorState(ConnectionState.SUSPENDED)) {
                     setLeadership(false);
                 }
                 break;
             }
 
-            case LOST:
-            {
+            case LOST: {
                 setLeadership(false);
                 break;
             }
         }
     }
 
-    private synchronized void setLeadership(boolean newValue)
-    {
+    private synchronized void setLeadership(boolean newValue) {
         boolean oldValue = hasLeadership.getAndSet(newValue);
 
-        if ( oldValue && !newValue )
-        { // Lost leadership, was true, now false
+        if (oldValue && !newValue) { // Lost leadership, was true, now false
             listeners.forEach(LeaderLatchListener::notLeader);
-        }
-        else if ( !oldValue && newValue )
-        { // Gained leadership, was false, now true
+        } else if (!oldValue && newValue) { // Gained leadership, was false, now true
             listeners.forEach(LeaderLatchListener::isLeader);
         }
 
         notifyAll();
     }
 
-    private void setNode(String newValue) throws Exception
-    {
+    private void setNode(String newValue) throws Exception {
         String oldPath = ourPath.getAndSet(newValue);
-        if ( oldPath != null )
-        {
+        if (oldPath != null) {
             client.delete().guaranteed().inBackground().forPath(oldPath);
         }
     }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatch.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatch.java
@@ -270,10 +270,7 @@ public class TestLeaderLatch extends BaseClassForTests
             {
                 for (LeaderLatch latchToClose : Arrays.asList(latchInitialLeader, latchCandidate0, latchCandidate1))
                 {
-                    if ( latchToClose.getState() != LeaderLatch.State.CLOSED )
-                    {
-                        latchToClose.close();
-                    }
+                    latchToClose.closeOnDemand();
                 }
             }
         }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatch.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatch.java
@@ -234,7 +234,7 @@ public class TestLeaderLatch extends BaseClassForTests
             {
                 latchInitialLeader.start();
 
-                // we want to make sure that the leader gets leadership before other instances joining the party
+                // we want to make sure that the leader gets leadership before other instances are joining the party
                 waitForALeader(Collections.singletonList(latchInitialLeader), new Timing());
 
                 // candidate #0 will wait for the leader to go away - this should happen after the child nodes are retrieved by candidate #0
@@ -243,7 +243,7 @@ public class TestLeaderLatch extends BaseClassForTests
                 latchCandidate0.start();
                 timing.sleepABit();
 
-                // no extract CountDownLatch needs to be set here because candidate #1 will rely on candidate #0
+                // no extra CountDownLatch needs to be set here because candidate #1 will rely on candidate #0
                 latchCandidate1.start();
                 timing.sleepABit();
 

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatch.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderLatch.java
@@ -306,7 +306,8 @@ public class TestLeaderLatch extends BaseClassForTests
                 client.getConnectionStateListenable().addListener(stateListener);
                 client.start();
 
-                latch = new LeaderLatch(client, "/test");
+                final String latchPatch = "/test";
+                latch = new LeaderLatch(client, latchPatch);
                 LeaderLatchListener listener = new LeaderLatchListener()
                 {
                     @Override
@@ -325,6 +326,7 @@ public class TestLeaderLatch extends BaseClassForTests
                 latch.start();
                 assertEquals(states.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.CONNECTED.name());
                 assertEquals(states.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), "true");
+                final List<String> beforeResetChildren = client.getChildren().forPath(latchPatch);
                 server.stop();
                 if ( isSessionIteration )
                 {
@@ -342,6 +344,8 @@ public class TestLeaderLatch extends BaseClassForTests
                     server.restart();
                     assertEquals(states.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), ConnectionState.RECONNECTED.name());
                     assertEquals(states.poll(timing.forWaiting().milliseconds(), TimeUnit.MILLISECONDS), "true");
+                    final List<String> afterResetChildren = client.getChildren().forPath(latchPatch);
+                    assertEquals(beforeResetChildren, afterResetChildren);
                 }
             }
             finally

--- a/curator-test-zk35/pom.xml
+++ b/curator-test-zk35/pom.xml
@@ -166,6 +166,12 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
See also:

* https://issues.apache.org/jira/browse/CURATOR-644
* https://issues.apache.org/jira/browse/CURATOR-645

## Livelock in details

Here we have two race conditions to cause livelock:

Case 1. Suppose there are two participants, p0 and p1:

T0. p1 is going to watch on preceding node belongs to p0.
T1. p0 gets reconnected, and thus reset its node, and create a new node to prepare watch on p1's node.
T2. p1 find preceding node has gone, and reset itself.

At the moment, p0 and p1 can be in the livelock that never see each other's node and infinitely reset themselves. This is the case reported by CURATOR-645.

Case 2. The similar case can happen even if there is only one participant:

![image](https://user-images.githubusercontent.com/18818196/178650065-c70357a6-91e7-4c12-a342-b0224e70d012.png)

~~If we still call `reset` when preceding node deleted by latter set new node, it's a live lock.~~

I cannot find a live lock here. If only the background in the same client are executed in serial, there are always three nodes to create, while with this patch, there are two nodes to create. But it should not create millions of nodes. If it's in case 1, it's possible since there's no guarantee between different clients.

This is the case reported by CURATOR-644.

## Solution

I make two significant changes to resolve these livelock cases:

1. Call `getChildren` instead of `reset` when preceding node not found in callback. This is previously reported in https://github.com/apache/curator/commit/ff4ec29f5958cc9162f0302c02f4ec50c0e796cd#r31770630. I don't find a reason we perform different between callback and watcher for the same condition. And concurrent `reset`s are the trigger for these livelock.
2. Call `getChildren` instead of `reset` when recovered from connection loss. The reason is similar to 1, while if a connection loss or session expire cause our node to be deleted, when `checkLeadership` we can see the condition and call `reset`.

These changes should fix CURATOR-645 and CURATOR-644.

I'm trying to add test cases and such changes must involve more eyes.