### PR TITLE
CURATOR-648: Fixed CuratorFramework#blockUntilConnected documentation

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
@@ -290,7 +290,7 @@ public interface CuratorFramework extends Closeable
 
     /**
      * Block until a connection to ZooKeeper is available or the maxWaitTime has been exceeded
-     * @param maxWaitTime The maximum wait time. Specify a value &lt;= 0 to wait indefinitely
+     * @param maxWaitTime The maximum wait time. Specify a value &lt;= 0 to return immediately
      * @param units The time units for the maximum wait time.
      * @return True if connection has been established, false otherwise.
      * @throws InterruptedException If interrupted while waiting


### PR DESCRIPTION
Addresses https://issues.apache.org/jira/browse/CURATOR-648 

In my opinion the most likely resolution for this case is simply to fix the documentation, the changes in this PR do just that.