### PR TITLE
CURATOR-538: address from InetSocketAddress could be null as it means unresolved address

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/utils/Compatibility.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/Compatibility.java
@@ -113,7 +113,7 @@ public class Compatibility
                 log.error("Could not call addrField.get({})", server, e);
             }
         }
-        return (address != null) ? address.getAddress().getHostAddress() : "unknown";
+        return (address != null && address.getAddress() != null) ? address.getAddress().getHostAddress() : "unknown";
     }
 
     public static boolean hasPersistentWatchers()


### PR DESCRIPTION
To be aligned with contract of `java.net.InetSocketAddress` it should take into account that `java.net.InetSocketAddress#getAddress` could return `null` which will mean unresolved address