### PR TITLE
Add Support for TLS-enabled `TestingZooKeeperMain`

### DIFF
--- a/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java
+++ b/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java
@@ -243,9 +243,15 @@ public class TestingZooKeeperMain implements ZooKeeperMainFace
 
             try
             {
+                boolean secure = config.getSecureClientPortAddress() != null;
                 cnxnFactory = ServerCnxnFactory.createFactory();
-                cnxnFactory.configure(config.getClientPortAddress(),
-                    config.getMaxClientCnxns());
+                if (secure) {
+                    cnxnFactory.configure(config.getSecureClientPortAddress(),
+                            config.getMaxClientCnxns(), config.getClientPortListenBacklog(), true);
+                } else {
+                    cnxnFactory.configure(config.getClientPortAddress(),
+                            config.getMaxClientCnxns(), config.getClientPortListenBacklog());
+                }
             }
             catch ( IOException e )
             {


### PR DESCRIPTION
When `ServerConfig#getSecureClientPortAddress` is not `null` then user has indicated the use of TLS. In this case, we will configure the Server factory to use TLS.