### PR TITLE
Upgrade jackson version from 2.10.0 to 2.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <javassist-version>3.24.1-GA</javassist-version>
         <commons-math-version>2.2</commons-math-version>
         <jackson-mapper-asl-version>1.9.13</jackson-mapper-asl-version>
-        <jackson-version>2.10.0</jackson-version>
+        <jackson-version>2.14.0</jackson-version>
         <assertj-version>3.23.1</assertj-version>
         <!-- Upgrading to Jersey 2.x is difficult and of unclear benefits, see
              https://stackoverflow.com/questions/17098341#22033825 -->


### PR DESCRIPTION
This commit upgrades the jackson-core and jackson-databind dependencies to 2.14.0. The following vulnerabilities are resolved with this commit:

- [CVE-2022-42004] In FasterXML jackson-databind before 2.13.4, resource exhaustion can occur because of a lack of a check in BeanDeserializer._deserializeFromArray to prevent use of deeply nested arrays. An application is vulnerable only with certain customized choices for deserialization.
- [CVE-2022-42003] In FasterXML jackson-databind before 2.14.0-rc1, resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled. Additional fix version in 2.13.4.1 and 2.12.17.1
- [CVE-2020-36518] jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.
- [CVE-2020-25649] A flaw was found in FasterXML Jackson Databind, where it did not have entity expansion secured properly. This flaw allows vulnerability to XML external entity (XXE) attacks. The highest threat from this vulnerability is data integrity.