### PR TITLE
CURATOR-664: Use getHostString() to build connection string in EnsembleTracker even for wildcard addresses

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/utils/Compatibility.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/Compatibility.java
@@ -88,7 +88,7 @@ public class Compatibility
         return (addrField != null);
     }
 
-    public static String getHostAddress(QuorumPeer.QuorumServer server)
+    public static String getHostString(QuorumPeer.QuorumServer server)
     {
         InetSocketAddress address = null;
         if ( getReachableOrOneMethod != null )
@@ -113,7 +113,7 @@ public class Compatibility
                 log.error("Could not call addrField.get({})", server, e);
             }
         }
-        return (address != null && address.getAddress() != null) ? address.getAddress().getHostAddress() : "unknown";
+        return address != null ? address.getHostString() : "unknown";
     }
 
     public static boolean hasPersistentWatchers()

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -42,6 +42,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -179,19 +181,23 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
             {
                 sb.append(",");
             }
-            String hostAddress;
-            if ( server.clientAddr.getAddress().isAnyLocalAddress() )
-            {
-                hostAddress = Compatibility.getHostAddress(server);
-            }
-            else
-            {
-                hostAddress = server.clientAddr.getHostString();
-            }
-            sb.append(hostAddress).append(":").append(server.clientAddr.getPort());
+            sb.append(getHostString(server)).append(":").append(server.clientAddr.getPort());
         }
 
         return sb.toString();
+    }
+
+    private static String getHostString(QuorumPeer.QuorumServer server) {
+        InetSocketAddress clientAddr = server.clientAddr;
+        InetAddress clientIpAddr = clientAddr.getAddress();
+        if ( clientIpAddr != null && clientIpAddr.isAnyLocalAddress() )
+        {
+            return Compatibility.getHostString(server);
+        }
+        else
+        {
+            return clientAddr.getHostString();
+        }
     }
 
     private void processConfigData(byte[] data) throws Exception

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
@@ -477,11 +477,35 @@ public class TestReconfiguration extends CuratorTestBase
     }
 
     @Test
-    public void testHostname() throws Exception
+    public void testConfigToConnectionStringPreservesHostnameNormal() throws Exception
     {
-        String config = "server.1=localhost:2888:3888:participant;localhost:2181";
+        String config = "server.1=server.addr:2888:3888:participant;client.addr:2181";
         String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
-        assertEquals("localhost:2181", configString);
+        assertEquals("client.addr:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringPreservesHostnameNoClientAddr() throws Exception
+    {
+        String config = "server.1=server.addr:2888:3888:participant;2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("server.addr:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringPreservesHostnameIPv4Wildcard() throws Exception
+    {
+        String config = "server.1=server.addr:2888:3888:participant;0.0.0.0:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("server.addr:2181", configString);
+    }
+
+    @Test
+    public void testConfigToConnectionStringPreservesHostnameIPv6Wildcard() throws Exception
+    {
+        String config = "server.1=server.addr:2888:3888:participant;[::]:2181";
+        String configString = EnsembleTracker.configToConnectionString(toQuorumVerifier(config.getBytes()));
+        assertEquals("server.addr:2181", configString);
     }
 
     @Test


### PR DESCRIPTION
This is an additional fix for [CURATOR-638](https://issues.apache.org/jira/browse/CURATOR-638) based on PR #425.