### PR TITLE
CURATOR-666: Fix twice unfixForNamespace in background create

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -797,9 +797,8 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
                 {
                     if ( !client.getZookeeperClient().getRetryPolicy().allowRetry(e) )
                     {
-                        final CuratorEvent event = makeCuratorEvent(client, e.code().intValue(), e.getPath(), null, null, null);
-                        client.processBackgroundOperation(mainOperationAndData, event);
-                        throw e;
+                        sendBackgroundResponse(client, e.code().intValue(), e.getPath(), null, null, null, mainOperationAndData);
+                        return;
                     }
                     // otherwise safe to ignore as it will get retried
                 }
@@ -895,12 +894,13 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
 
     private void sendBackgroundResponse(int rc, String path, Object ctx, String name, Stat stat, OperationAndData<PathAndBytes> operationAndData)
     {
-        client.processBackgroundOperation(operationAndData, makeCuratorEvent(client, rc, path, ctx, name, stat));
+        sendBackgroundResponse(client, rc, path, ctx, name, stat, operationAndData);
     }
 
-    private static CuratorEvent makeCuratorEvent(CuratorFrameworkImpl client, int rc, String path, Object ctx, String name, Stat stat)
+    private static <T> void sendBackgroundResponse(CuratorFrameworkImpl client, int rc, String path, Object ctx, String name, Stat stat, OperationAndData<T> operationAndData)
     {
-        return new CuratorEventImpl(client, CuratorEventType.CREATE, rc, path, name, ctx, stat, null, null, null, null, null);
+        CuratorEvent event = new CuratorEventImpl(client, CuratorEventType.CREATE, rc, path, name, ctx, stat, null, null, null, null, null);
+        client.processBackgroundOperation(operationAndData, event);
     }
 
     private ACLCreateModePathAndBytesable<String> asACLCreateModePathAndBytesable()

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -900,8 +900,6 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
 
     private static CuratorEvent makeCuratorEvent(CuratorFrameworkImpl client, int rc, String path, Object ctx, String name, Stat stat)
     {
-        path = client.unfixForNamespace(path);
-        name = client.unfixForNamespace(name);
         return new CuratorEventImpl(client, CuratorEventType.CREATE, rc, path, name, ctx, stat, null, null, null, null, null);
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -798,7 +798,7 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
                     if ( !client.getZookeeperClient().getRetryPolicy().allowRetry(e) )
                     {
                         sendBackgroundResponse(client, e.code().intValue(), e.getPath(), null, null, null, mainOperationAndData);
-                        return;
+                        throw e;
                     }
                     // otherwise safe to ignore as it will get retried
                 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -797,7 +797,7 @@ public class CreateBuilderImpl implements CreateBuilder, CreateBuilder2, Backgro
                 {
                     if ( !client.getZookeeperClient().getRetryPolicy().allowRetry(e) )
                     {
-                        final CuratorEvent event = makeCuratorEvent(client, e.code().intValue(), e.getPath(), null, e.getPath(), null);
+                        final CuratorEvent event = makeCuratorEvent(client, e.code().intValue(), e.getPath(), null, null, null);
                         client.processBackgroundOperation(mainOperationAndData, event);
                         throw e;
                     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
@@ -133,7 +133,7 @@ class CuratorEventImpl implements CuratorEvent
         this.resultCode = resultCode;
         this.opResults = (opResults != null) ? ImmutableList.copyOf(opResults) : null;
         this.path = client.unfixForNamespace(path);
-        this.name = name;
+        this.name = client.unfixForNamespace(name);
         this.context = context;
         this.stat = stat;
         this.data = data;


### PR DESCRIPTION
Previously, `unfixForNamespace` was called twice in background create. This will accidentally unfix node path if it happens to contain namespace in its prefix. Say, creating "/zoo/a" in namespace "/zoo" will get path "/a".