### PR TITLE
CURATOR-593: Append chroot for EnsembleProvider::setConnectionString in EnsembleTracker

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/EnsembleTracker.java
@@ -209,10 +209,17 @@ public class EnsembleTracker implements Closeable, CuratorWatcher
         if (!properties.isEmpty())
         {
             QuorumMaj newConfig = new QuorumMaj(properties);
-            String connectionString = configToConnectionString(newConfig);
-            if (connectionString.trim().length() > 0)
+            String connectionString = configToConnectionString(newConfig).trim();
+            if (!connectionString.isEmpty())
             {
                 currentConfig.set(newConfig);
+                String oldConnectionString = ensembleProvider.getConnectionString();
+                int i = oldConnectionString.indexOf('/');
+                if (i >= 0)
+                {
+                    String chroot = oldConnectionString.substring(i);
+                    connectionString += chroot;
+                }
                 ensembleProvider.setConnectionString(connectionString);
             }
             else


### PR DESCRIPTION
Curator uses `EnsembleProvider::getConnectionString` as connection string to `ZooKeeper`. `EnsembleTracker` subscribes to config node to construct up to date connection string for `EnsembleProvider`. This is great.

But, currently, `EnsembleTracker` omits chroot part of connection string which could cause curator locating at ZooKeeper root after reconnection. This could damage clients' data hierarchy in unexpected manner.