### PR TITLE
CURATOR-675: Fix AsyncCuratorFramework's UnhandledErrorListener hang AsyncStage

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/api/ErrorListenerEnsembleable.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/ErrorListenerEnsembleable.java
@@ -23,10 +23,11 @@ public interface ErrorListenerEnsembleable<T> extends Ensembleable<T> {
     /**
      * Set an error listener for this background operation. If an exception
      * occurs while processing the call in the background, this listener will
-     * be called
+     * be called.
      *
      * @param listener the listener
      * @return this for chaining
+     * @apiNote swallow the exception will prevent {@link BackgroundCallback} from completion
      */
     Ensembleable<T> withUnhandledErrorListener(UnhandledErrorListener listener);
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/ErrorListenerMultiTransactionMain.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/ErrorListenerMultiTransactionMain.java
@@ -25,10 +25,11 @@ public interface ErrorListenerMultiTransactionMain extends CuratorMultiTransacti
     /**
      * Set an error listener for this background operation. If an exception
      * occurs while processing the call in the background, this listener will
-     * be called
+     * be called.
      *
      * @param listener the listener
      * @return this for chaining
+     * @apiNote swallow the exception will prevent {@link BackgroundCallback} from completion
      */
     CuratorMultiTransactionMain withUnhandledErrorListener(UnhandledErrorListener listener);
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/ErrorListenerPathAndBytesable.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/ErrorListenerPathAndBytesable.java
@@ -23,10 +23,11 @@ public interface ErrorListenerPathAndBytesable<T> extends PathAndBytesable<T> {
     /**
      * Set an error listener for this background operation. If an exception
      * occurs while processing the call in the background, this listener will
-     * be called
+     * be called.
      *
      * @param listener the listener
      * @return this for chaining
+     * @apiNote swallow the exception will prevent {@link BackgroundCallback} from completion
      */
     PathAndBytesable<T> withUnhandledErrorListener(UnhandledErrorListener listener);
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/ErrorListenerPathable.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/ErrorListenerPathable.java
@@ -23,10 +23,11 @@ public interface ErrorListenerPathable<T> extends Pathable<T> {
     /**
      * Set an error listener for this background operation. If an exception
      * occurs while processing the call in the background, this listener will
-     * be called
+     * be called.
      *
      * @param listener the listener
      * @return this for chaining
+     * @apiNote swallow the exception will prevent {@link BackgroundCallback} from completion
      */
     Pathable<T> withUnhandledErrorListener(UnhandledErrorListener listener);
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/ErrorListenerReconfigBuilderMain.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/ErrorListenerReconfigBuilderMain.java
@@ -23,10 +23,11 @@ public interface ErrorListenerReconfigBuilderMain extends ReconfigBuilderMain {
     /**
      * Set an error listener for this background operation. If an exception
      * occurs while processing the call in the background, this listener will
-     * be called
+     * be called.
      *
      * @param listener the listener
      * @return this for chaining
+     * @apiNote swallow the exception will prevent {@link BackgroundCallback} from completion
      */
     ReconfigBuilderMain withUnhandledErrorListener(UnhandledErrorListener listener);
 }

--- a/curator-test/src/main/java/org/apache/curator/test/compatibility/Timing2.java
+++ b/curator-test/src/main/java/org/apache/curator/test/compatibility/Timing2.java
@@ -20,7 +20,9 @@
 package org.apache.curator.test.compatibility;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -104,6 +106,12 @@ public class Timing2 {
      */
     public int seconds() {
         return (int) value;
+    }
+
+    public <T> T getFuture(CompletableFuture<T> future)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        Timing2 m = forWaiting();
+        return future.get(m.value, m.unit);
     }
 
     /**

--- a/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
+++ b/curator-x-async/src/test/java/org/apache/curator/framework/imps/TestFrameworkBackground.java
@@ -37,17 +37,18 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.curator.x.async.AsyncStage;
+import org.apache.curator.x.async.CompletableBaseClassForTests;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.ACL;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TestFrameworkBackground extends BaseClassForTests {
+public class TestFrameworkBackground extends CompletableBaseClassForTests {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Test
@@ -91,8 +92,9 @@ public class TestFrameworkBackground extends BaseClassForTests {
                     errorLatch.countDown();
                 }
             };
-            async.with(listener).create().forPath("/foo");
-            assertTrue(new Timing().awaitLatch(errorLatch));
+            AsyncStage<String> stage = async.with(listener).create().forPath("/foo");
+            assertTrue(timing.awaitLatch(errorLatch));
+            exceptional(stage, UnsupportedOperationException.class);
         } finally {
             CloseableUtils.closeQuietly(client);
         }

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/CompletableBaseClassForTests.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/CompletableBaseClassForTests.java
@@ -35,7 +35,7 @@ public abstract class CompletableBaseClassForTests extends BaseClassForTests {
 
     protected void joinThrowable(CompletionStage<?> stage) throws Throwable {
         try {
-            stage.toCompletableFuture().get();
+            timing.getFuture(stage.toCompletableFuture());
         } catch (Exception ex) {
             throw Throwables.getRootCause(ex);
         }


### PR DESCRIPTION
`AsyncCuratorFramework` binds its `UnhandledErrorListener` to operation level which could prevent `AsyncStage` from completion if exception is swallowed by that listener.

In any cases, a framework level error listener should not prevent an operation future from completion.