### PR TITLE
CURATOR-41: Suppress secondary exception in LockInternals.attemptLock

### DIFF
--- a/curator-test/src/main/java/org/apache/curator/test/BaseClassForTests.java
+++ b/curator-test/src/main/java/org/apache/curator/test/BaseClassForTests.java
@@ -125,7 +125,7 @@ public class BaseClassForTests {
         closeServer();
     }
 
-    private void closeServer() {
+    protected void closeServer() {
         if (server != null) {
             try {
                 server.close();


### PR DESCRIPTION
Suppress exception from `deleteOurPath` if we are throwing.