### PR TITLE
CURATOR-677: Complete BackgroundCallback if sub operation failed or cancelled

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
@@ -230,8 +230,7 @@ public class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<Str
                 return CuratorEventType.DELETE;
             }
         };
-        OperationAndData<String> parentOperation = new OperationAndData<String>(
-                operation, mainOperationAndData.getData(), null, null, backgrounding.getContext(), null);
+        OperationAndData<String> parentOperation = new OperationAndData<>(operation, mainOperationAndData);
         client.queueOperation(parentOperation);
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
@@ -193,7 +193,6 @@ public class ExistsBuilderImpl
                         client,
                         operationAndData,
                         operationAndData.getData(),
-                        backgrounding,
                         acling.getACLProviderForParents(),
                         createParentContainersIfNeeded);
             } else {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/OperationAndData.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/OperationAndData.java
@@ -36,7 +36,7 @@ class OperationAndData<T> implements Delayed, RetrySleeper {
     private final BackgroundCallback callback;
     private final long startTimeMs = System.currentTimeMillis();
     private final ErrorCallback<T> errorCallback;
-    private final AtomicInteger retryCount = new AtomicInteger(0);
+    private final AtomicInteger retryCount;
     private final AtomicLong sleepUntilTimeMs = new AtomicLong(0);
     private final AtomicLong ordinal = new AtomicLong();
     private final Object context;
@@ -44,6 +44,16 @@ class OperationAndData<T> implements Delayed, RetrySleeper {
 
     interface ErrorCallback<T> {
         void retriesExhausted(OperationAndData<T> operationAndData);
+    }
+
+    OperationAndData(BackgroundOperation<T> operation, OperationAndData<T> main) {
+        this.operation = operation;
+        this.data = main.data;
+        this.callback = main.callback;
+        this.errorCallback = main.errorCallback;
+        this.context = main.context;
+        this.connectionRequired = main.connectionRequired;
+        this.retryCount = main.retryCount;
     }
 
     OperationAndData(
@@ -59,6 +69,7 @@ class OperationAndData<T> implements Delayed, RetrySleeper {
         this.errorCallback = errorCallback;
         this.context = context;
         this.connectionRequired = connectionRequired;
+        this.retryCount = new AtomicInteger(0);
         reset();
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
@@ -229,12 +229,7 @@ public class SetDataBuilderImpl
         BackgroundOperation<PathAndBytes> operation = new BackgroundOperation<PathAndBytes>() {
             @Override
             public void performBackgroundOperation(OperationAndData<PathAndBytes> op) throws Exception {
-                try {
-                    client.getZooKeeper().getData(path, false, dataCallback, backgrounding.getContext());
-                } catch (KeeperException e) {
-                    // ignore
-                    client.logError("Unexpected exception in async idempotent check for, ignoring: " + path, e);
-                }
+                client.getZooKeeper().getData(path, false, dataCallback, backgrounding.getContext());
             }
 
             @Override
@@ -242,7 +237,7 @@ public class SetDataBuilderImpl
                 return CuratorEventType.SET_DATA;
             }
         };
-        client.queueOperation(new OperationAndData<>(operation, null, null, null, null, null));
+        client.queueOperation(new OperationAndData<>(operation, mainOperationAndData));
     }
 
     @Override


### PR DESCRIPTION
Currently, some background operations use auxiliary sub operations to
complete task in case of primary conditions are not satisfied. But most
of these sub operations count only success path, so they will hang
`BackgroundCallback` if they are failed or cancelled due to framework
closed.

This is the leftover of [CURATOR-673][](https://github.com/apache/curator/pull/464).

[CURATOR-673]: https://issues.apache.org/jira/browse/CURATOR-673