### PR TITLE
CURATOR-681: Fix flaky TestInterProcessMutex.testReentrantSingleLock

### DIFF
--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMutexBase.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/locks/TestInterProcessMutexBase.java
@@ -283,8 +283,8 @@ public abstract class TestInterProcessMutexBase extends BaseClassForTests {
                                 Thread.sleep(100);
                             }
                         } finally {
-                            mutex.release();
                             hasLock.set(false);
+                            mutex.release();
                         }
                         return null;
                     }


### PR DESCRIPTION
Placing `Thread.sleep(550)` after `mutex.release()` and before `hasLock.set(false)` will fail this test more frequently.