### PR TITLE
CURATOR-682: Use Gradle Enterprise Maven Extension to normalize Bnd-LastModified

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -743,6 +743,24 @@
                     <artifactId>spotless-maven-plugin</artifactId>
                     <version>${spotless.version}</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                            <normalization>
+                                <runtimeClassPath>
+                                    <metaInf>
+                                        <ignoredAttributes>
+                                            <ignore>Bnd-LastModified</ignore>
+                                        </ignoredAttributes>
+                                    </metaInf>
+                                </runtimeClassPath>
+                            </normalization>
+                        </gradleEnterprise>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
This change uses the [Runtime classpath normalization](https://docs.gradle.com/enterprise/maven-extension/#normalization) feature of the Gradle Enterprise Maven Extension in order to better receive cache hits on surefire goals when the only change is to the Bnd-LastModified attribute of jar manifests.

To see the full impact of this change, one can run an experiment from this project's master branch, then from this project's branch. For this experiment, run two `clean verify` builds. The first build should populate the cache, while the second should read from the cache. On master, the experiment will show a cache miss. With this change, the experiment will show a cache hit.