### PR TITLE
CURATOR-683: com.fasterxml.jackson.core version 2.13.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <javassist-version>3.24.1-GA</javassist-version>
         <commons-math-version>2.2</commons-math-version>
         <jackson-mapper-asl-version>1.9.13</jackson-mapper-asl-version>
-        <jackson-version>2.10.0</jackson-version>
+        <jackson-version>2.13.5</jackson-version>
         <assertj-version>3.23.1</assertj-version>
         <!-- Upgrading to Jersey 2.x is difficult and of unclear benefits, see
              https://stackoverflow.com/questions/17098341#22033825 -->


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CURATOR-683

Resolves CVEs:
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42004 (resource exhaustion)
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42003 (resource exhaustion)
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46877 (denial of service)
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518 (denial of service)
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25649 (data integrity)