### PR TITLE
CURATOR-667: Fix abnormal event config path from getConfig

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetConfigBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetConfigBuilderImpl.java
@@ -39,15 +39,15 @@ public class GetConfigBuilderImpl
     private Stat stat;
 
     public GetConfigBuilderImpl(CuratorFrameworkImpl client) {
-        this.client = client;
+        this.client = (CuratorFrameworkImpl) client.usingNamespace(null);
         backgrounding = new Backgrounding();
-        watching = new Watching(client);
+        watching = new Watching(this.client);
     }
 
     public GetConfigBuilderImpl(CuratorFrameworkImpl client, Backgrounding backgrounding, Watcher watcher, Stat stat) {
-        this.client = client;
+        this.client = (CuratorFrameworkImpl) client.usingNamespace(null);
         this.backgrounding = backgrounding;
-        this.watching = new Watching(client, watcher);
+        this.watching = new Watching(this.client, watcher);
         this.stat = stat;
     }
 


### PR DESCRIPTION
`getConfig` will read data from path "/zookeeper/config" which belongs to no namespace nor chroot in ZooKeeper side. Path in background event or watch event should stick to "/zookeeper/config".

See also:
* https://issues.apache.org/jira/browse/ZOOKEEPER-4601
* https://lists.apache.org/thread/2tsg1hcopl80zot12tqrynrbg2h792jf