### PR TITLE
CURATOR-626: Postpone null namespace facade creation to avoid partial initialization

### DIFF
--- a/curator-framework/pom.xml
+++ b/curator-framework/pom.xml
@@ -100,7 +100,13 @@
 	      <artifactId>mockito-core</artifactId>
 	      <scope>test</scope>
         </dependency>
-        
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -283,14 +283,14 @@ public class CuratorFrameworkImpl implements CuratorFramework {
         compressionProvider = parent.compressionProvider;
         aclProvider = parent.aclProvider;
         namespaceFacadeCache = parent.namespaceFacadeCache;
-        namespace = new NamespaceImpl(this, null);
+        namespace = parent.namespace;
         state = parent.state;
         authInfos = parent.authInfos;
         useContainerParentsIfAvailable = parent.useContainerParentsIfAvailable;
         connectionStateErrorPolicy = parent.connectionStateErrorPolicy;
         internalConnectionHandler = parent.internalConnectionHandler;
         schemaSet = parent.schemaSet;
-        ensembleTracker = null;
+        ensembleTracker = parent.ensembleTracker;
         runSafeService = parent.runSafeService;
     }
 

--- a/curator-test-zk35/pom.xml
+++ b/curator-test-zk35/pom.xml
@@ -172,6 +172,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>

--- a/curator-test-zk36/pom.xml
+++ b/curator-test-zk36/pom.xml
@@ -191,6 +191,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito-version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj-version}</version>


### PR DESCRIPTION
In construction of `CuratorFrameworkImpl`, it constructs a sub class `NamespaceFacade` for commonly used `nullNamespace`. Due to this recursive construction, `nullNamespace` has uninitialized fields which cause NPT in certain cases.

This commit solves this by postponing `nullNamespace` creation.