### PR TITLE
Curator 690. curator cache fails to load the cache if there are more than 64 k child z nodes

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/CuratorCacheImpl.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/CuratorCacheImpl.java
@@ -19,9 +19,19 @@
 
 package org.apache.curator.framework.recipes.cache;
 
+import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type.*;
+import static org.apache.zookeeper.KeeperException.Code.NONODE;
+import static org.apache.zookeeper.KeeperException.Code.OK;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
@@ -35,20 +45,8 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.Phaser;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
 
-import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type.*;
-import static org.apache.zookeeper.KeeperException.Code.NONODE;
-import static org.apache.zookeeper.KeeperException.Code.OK;
-
-class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge
-{
+class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge {
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final AtomicReference<State> state = new AtomicReference<>(State.LATENT);
     private final PersistentWatcher persistentWatcher;
@@ -61,26 +59,21 @@ class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge
     private final StandardListenerManager<CuratorCacheListener> listenerManager = StandardListenerManager.standard();
     private final Consumer<Exception> exceptionHandler;
 
-    private final Phaser rootPhaser = new Phaser()
-    {
+    private final Phaser rootPhaser = new Phaser() {
         @Override
-        protected boolean onAdvance(int phase, int registeredParties)
-        {
-            callListeners(CuratorCacheListener::initialized); 
-            synchronized (CuratorCacheImpl.this)
-            {
+        protected boolean onAdvance(int phase, int registeredParties) {
+            callListeners(CuratorCacheListener::initialized);
+            synchronized (CuratorCacheImpl.this) {
                 currentChildPhaser = rootPhaser; 
             } 
-            return true; 
+            return true;
         }
     };
 
     private Phaser currentChildPhaser = new Phaser(rootPhaser);
 
-    private synchronized Phaser getPhaserAndRegister()
-    {
-        if (currentChildPhaser.getRegisteredParties() >= 0xffff)
-        {
+    private synchronized Phaser getPhaserAndRegister() {
+        if (currentChildPhaser.getRegisteredParties() >= 0xffff) {
             currentChildPhaser = new Phaser(rootPhaser);
         }
 
@@ -89,15 +82,18 @@ class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge
         return currentChildPhaser;
     }
 
-    private enum State
-    {
+    private enum State {
         LATENT,
         STARTED,
         CLOSED
     }
 
-    CuratorCacheImpl(CuratorFramework client, CuratorCacheStorage storage, String path, Options[] optionsArg, Consumer<Exception> exceptionHandler)
-    {
+    CuratorCacheImpl(
+            CuratorFramework client,
+            CuratorCacheStorage storage,
+            String path,
+            Options[] optionsArg,
+            Consumer<Exception> exceptionHandler) {
         Set<Options> options = (optionsArg != null) ? Sets.newHashSet(optionsArg) : Collections.emptySet();
         this.client = client;
         this.storage = (storage != null) ? storage : CuratorCacheStorage.standard();
@@ -112,65 +108,53 @@ class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge
     }
 
     @Override
-    public void start()
-    {
+    public void start() {
         Preconditions.checkState(state.compareAndSet(State.LATENT, State.STARTED), "Already started");
         persistentWatcher.start();
     }
 
     @Override
-    public void close()
-    {
-        if ( state.compareAndSet(State.STARTED, State.CLOSED) )
-        {
+    public void close() {
+        if (state.compareAndSet(State.STARTED, State.CLOSED)) {
             persistentWatcher.close();
-            if ( clearOnClose )
-            {
+            if (clearOnClose) {
                 storage.clear();
             }
         }
     }
 
     @Override
-    public boolean isCuratorCache()
-    {
+    public boolean isCuratorCache() {
         return true;
     }
 
     @Override
-    public Listenable<CuratorCacheListener> listenable()
-    {
+    public Listenable<CuratorCacheListener> listenable() {
         return listenerManager;
     }
 
     @Override
-    public Optional<ChildData> get(String path)
-    {
+    public Optional<ChildData> get(String path) {
         return storage.get(path);
     }
 
     @Override
-    public int size()
-    {
+    public int size() {
         return storage.size();
     }
 
     @Override
-    public Stream<ChildData> stream()
-    {
+    public Stream<ChildData> stream() {
         return storage.stream();
     }
 
     @VisibleForTesting
-    CuratorCacheStorage storage()
-    {
+    CuratorCacheStorage storage() {
         return storage;
     }
 
-    private void rebuild()
-    {
-        if ( state.get() != State.STARTED )
-        {
+    private void rebuild() {
+        if (state.get() != State.STARTED) {
             return;
         }
 
@@ -180,158 +164,118 @@ class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge
         // rebuild remaining nodes - note: this may cause some nodes to be queried twice
         // (though versions checks will minimize that). If someone can think of a better
         // way let us know
-        storage.stream()
-            .map(ChildData::getPath)
-            .filter(p -> !p.equals(path))
-            .forEach(this::nodeChanged);
+        storage.stream().map(ChildData::getPath).filter(p -> !p.equals(path)).forEach(this::nodeChanged);
     }
 
-    private void processEvent(WatchedEvent event)
-    {
-        if ( state.get() != State.STARTED )
-        {
+    private void processEvent(WatchedEvent event) {
+        if (state.get() != State.STARTED) {
             return;
         }
 
         // NOTE: Persistent/Recursive watchers never trigger NodeChildrenChanged
 
-        switch ( event.getType() )
-        {
-        case NodeDataChanged:
-        case NodeCreated:
-        {
-            nodeChanged(event.getPath());
-            break;
-        }
+        switch (event.getType()) {
+            case NodeDataChanged:
+            case NodeCreated: {
+                nodeChanged(event.getPath());
+                break;
+            }
 
-        case NodeDeleted:
-        {
-            removeStorage(event.getPath());
-            break;
-        }
+            case NodeDeleted: {
+                removeStorage(event.getPath());
+                break;
+            }
         }
     }
 
-    private void checkChildrenChanged(String fromPath, Stat oldStat, Stat newStat)
-    {
-        if ( (state.get() != State.STARTED) || !recursive )
-        {
+    private void checkChildrenChanged(String fromPath, Stat oldStat, Stat newStat) {
+        if ((state.get() != State.STARTED) || !recursive) {
             return;
         }
 
-        if ( (oldStat != null) && (oldStat.getCversion() == newStat.getCversion()) )
-        {
+        if ((oldStat != null) && (oldStat.getCversion() == newStat.getCversion())) {
             return; // children haven't changed
         }
 
         final Phaser outstandingOps = getPhaserAndRegister();
 
-        try
-        {
+        try {
             BackgroundCallback callback = (__, event) -> {
-                if ( event.getResultCode() == OK.intValue() )
-                {
+                if (event.getResultCode() == OK.intValue()) {
                     event.getChildren().forEach(child -> nodeChanged(ZKPaths.makePath(fromPath, child)));
-                }
-                else if ( event.getResultCode() == NONODE.intValue() )
-                {
+                } else if (event.getResultCode() == NONODE.intValue()) {
                     removeStorage(event.getPath());
-                }
-                else
-                {
+                } else {
                     handleException(event);
                 }
                 outstandingOps.arriveAndDeregister();
             };
 
             client.getChildren().inBackground(callback).forPath(fromPath);
-        }
-        catch ( Exception e )
-        {
+        } catch (Exception e) {
             handleException(e);
         }
     }
 
-    private void nodeChanged(String fromPath)
-    {
-        if ( state.get() != State.STARTED )
-        {
+    private void nodeChanged(String fromPath) {
+        if (state.get() != State.STARTED) {
             return;
         }
 
         final Phaser outstandingOps = getPhaserAndRegister();
 
-        try
-        {
+        try {
             BackgroundCallback callback = (__, event) -> {
-                if ( event.getResultCode() == OK.intValue() )
-                {
-                    Optional<ChildData> childData = putStorage(new ChildData(event.getPath(), event.getStat(), event.getData()));
-                    checkChildrenChanged(event.getPath(), childData.map(ChildData::getStat).orElse(null), event.getStat());
-                }
-                else if ( event.getResultCode() == NONODE.intValue() )
-                {
+                if (event.getResultCode() == OK.intValue()) {
+                    Optional<ChildData> childData =
+                            putStorage(new ChildData(event.getPath(), event.getStat(), event.getData()));
+                    checkChildrenChanged(
+                            event.getPath(), childData.map(ChildData::getStat).orElse(null), event.getStat());
+                } else if (event.getResultCode() == NONODE.intValue()) {
                     removeStorage(event.getPath());
-                }
-                else
-                {
+                } else {
                     handleException(event);
                 }
                 outstandingOps.arriveAndDeregister();
             };
 
-            if ( compressedData )
-            {
+            if (compressedData) {
                 client.getData().decompressed().inBackground(callback).forPath(fromPath);
-            }
-            else
-            {
+            } else {
                 client.getData().inBackground(callback).forPath(fromPath);
             }
-        }
-        catch ( Exception e )
-        {
+        } catch (Exception e) {
             handleException(e);
         }
     }
 
-    private Optional<ChildData> putStorage(ChildData data)
-    {
+    private Optional<ChildData> putStorage(ChildData data) {
         Optional<ChildData> previousData = storage.put(data);
-        if ( previousData.isPresent() )
-        {
-            if ( previousData.get().getStat().getVersion() != data.getStat().getVersion() )
-            {
+        if (previousData.isPresent()) {
+            if (previousData.get().getStat().getVersion() != data.getStat().getVersion()) {
                 callListeners(l -> l.event(NODE_CHANGED, previousData.get(), data));
             }
-        }
-        else
-        {
+        } else {
             callListeners(l -> l.event(NODE_CREATED, null, data));
         }
         return previousData;
     }
 
-    private void removeStorage(String path)
-    {
+    private void removeStorage(String path) {
         storage.remove(path).ifPresent(previousData -> callListeners(l -> l.event(NODE_DELETED, previousData, null)));
     }
 
-    private void callListeners(Consumer<CuratorCacheListener> proc)
-    {
-        if ( state.get() == State.STARTED )
-        {
+    private void callListeners(Consumer<CuratorCacheListener> proc) {
+        if (state.get() == State.STARTED) {
             client.runSafe(() -> listenerManager.forEach(proc));
         }
     }
 
-    private void handleException(CuratorEvent event)
-    {
+    private void handleException(CuratorEvent event) {
         handleException(KeeperException.create(KeeperException.Code.get(event.getResultCode())));
     }
 
-    private void handleException(Exception e)
-    {
+    private void handleException(Exception e) {
         ThreadUtils.checkInterrupted(e);
         exceptionHandler.accept(e);
     }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/CuratorCacheImpl.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/CuratorCacheImpl.java
@@ -19,19 +19,9 @@
 
 package org.apache.curator.framework.recipes.cache;
 
-import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type.*;
-import static org.apache.zookeeper.KeeperException.Code.NONODE;
-import static org.apache.zookeeper.KeeperException.Code.OK;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.Phaser;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
@@ -45,8 +35,20 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
-class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge {
+import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type.*;
+import static org.apache.zookeeper.KeeperException.Code.NONODE;
+import static org.apache.zookeeper.KeeperException.Code.OK;
+
+class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge
+{
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final AtomicReference<State> state = new AtomicReference<>(State.LATENT);
     private final PersistentWatcher persistentWatcher;
@@ -59,26 +61,43 @@ class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge {
     private final StandardListenerManager<CuratorCacheListener> listenerManager = StandardListenerManager.standard();
     private final Consumer<Exception> exceptionHandler;
 
-    private final Phaser outstandingOps = new Phaser() {
+    private final Phaser rootPhaser = new Phaser()
+    {
         @Override
-        protected boolean onAdvance(int phase, int registeredParties) {
-            callListeners(CuratorCacheListener::initialized);
-            return true;
+        protected boolean onAdvance(int phase, int registeredParties)
+        {
+            callListeners(CuratorCacheListener::initialized); 
+            synchronized (CuratorCacheImpl.this)
+            {
+                currentChildPhaser = rootPhaser; 
+            } 
+            return true; 
         }
     };
 
-    private enum State {
+    private Phaser currentChildPhaser = new Phaser(rootPhaser);
+
+    private synchronized Phaser getPhaserAndRegister()
+    {
+        if (currentChildPhaser.getRegisteredParties() >= 0xffff)
+        {
+            currentChildPhaser = new Phaser(rootPhaser);
+        }
+
+        currentChildPhaser.register();
+
+        return currentChildPhaser;
+    }
+
+    private enum State
+    {
         LATENT,
         STARTED,
         CLOSED
     }
 
-    CuratorCacheImpl(
-            CuratorFramework client,
-            CuratorCacheStorage storage,
-            String path,
-            Options[] optionsArg,
-            Consumer<Exception> exceptionHandler) {
+    CuratorCacheImpl(CuratorFramework client, CuratorCacheStorage storage, String path, Options[] optionsArg, Consumer<Exception> exceptionHandler)
+    {
         Set<Options> options = (optionsArg != null) ? Sets.newHashSet(optionsArg) : Collections.emptySet();
         this.client = client;
         this.storage = (storage != null) ? storage : CuratorCacheStorage.standard();
@@ -93,53 +112,65 @@ class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge {
     }
 
     @Override
-    public void start() {
+    public void start()
+    {
         Preconditions.checkState(state.compareAndSet(State.LATENT, State.STARTED), "Already started");
         persistentWatcher.start();
     }
 
     @Override
-    public void close() {
-        if (state.compareAndSet(State.STARTED, State.CLOSED)) {
+    public void close()
+    {
+        if ( state.compareAndSet(State.STARTED, State.CLOSED) )
+        {
             persistentWatcher.close();
-            if (clearOnClose) {
+            if ( clearOnClose )
+            {
                 storage.clear();
             }
         }
     }
 
     @Override
-    public boolean isCuratorCache() {
+    public boolean isCuratorCache()
+    {
         return true;
     }
 
     @Override
-    public Listenable<CuratorCacheListener> listenable() {
+    public Listenable<CuratorCacheListener> listenable()
+    {
         return listenerManager;
     }
 
     @Override
-    public Optional<ChildData> get(String path) {
+    public Optional<ChildData> get(String path)
+    {
         return storage.get(path);
     }
 
     @Override
-    public int size() {
+    public int size()
+    {
         return storage.size();
     }
 
     @Override
-    public Stream<ChildData> stream() {
+    public Stream<ChildData> stream()
+    {
         return storage.stream();
     }
 
     @VisibleForTesting
-    CuratorCacheStorage storage() {
+    CuratorCacheStorage storage()
+    {
         return storage;
     }
 
-    private void rebuild() {
-        if (state.get() != State.STARTED) {
+    private void rebuild()
+    {
+        if ( state.get() != State.STARTED )
+        {
             return;
         }
 
@@ -149,116 +180,158 @@ class CuratorCacheImpl implements CuratorCache, CuratorCacheBridge {
         // rebuild remaining nodes - note: this may cause some nodes to be queried twice
         // (though versions checks will minimize that). If someone can think of a better
         // way let us know
-        storage.stream().map(ChildData::getPath).filter(p -> !p.equals(path)).forEach(this::nodeChanged);
+        storage.stream()
+            .map(ChildData::getPath)
+            .filter(p -> !p.equals(path))
+            .forEach(this::nodeChanged);
     }
 
-    private void processEvent(WatchedEvent event) {
-        if (state.get() != State.STARTED) {
+    private void processEvent(WatchedEvent event)
+    {
+        if ( state.get() != State.STARTED )
+        {
             return;
         }
 
         // NOTE: Persistent/Recursive watchers never trigger NodeChildrenChanged
 
-        switch (event.getType()) {
-            case NodeDataChanged:
-            case NodeCreated: {
-                nodeChanged(event.getPath());
-                break;
-            }
+        switch ( event.getType() )
+        {
+        case NodeDataChanged:
+        case NodeCreated:
+        {
+            nodeChanged(event.getPath());
+            break;
+        }
 
-            case NodeDeleted: {
-                removeStorage(event.getPath());
-                break;
-            }
+        case NodeDeleted:
+        {
+            removeStorage(event.getPath());
+            break;
+        }
         }
     }
 
-    private void checkChildrenChanged(String fromPath, Stat oldStat, Stat newStat) {
-        if ((state.get() != State.STARTED) || !recursive) {
+    private void checkChildrenChanged(String fromPath, Stat oldStat, Stat newStat)
+    {
+        if ( (state.get() != State.STARTED) || !recursive )
+        {
             return;
         }
 
-        if ((oldStat != null) && (oldStat.getCversion() == newStat.getCversion())) {
+        if ( (oldStat != null) && (oldStat.getCversion() == newStat.getCversion()) )
+        {
             return; // children haven't changed
         }
 
-        try {
+        final Phaser outstandingOps = getPhaserAndRegister();
+
+        try
+        {
             BackgroundCallback callback = (__, event) -> {
-                if (event.getResultCode() == OK.intValue()) {
+                if ( event.getResultCode() == OK.intValue() )
+                {
                     event.getChildren().forEach(child -> nodeChanged(ZKPaths.makePath(fromPath, child)));
-                } else if (event.getResultCode() == NONODE.intValue()) {
+                }
+                else if ( event.getResultCode() == NONODE.intValue() )
+                {
                     removeStorage(event.getPath());
-                } else {
+                }
+                else
+                {
                     handleException(event);
                 }
                 outstandingOps.arriveAndDeregister();
             };
 
-            outstandingOps.register();
             client.getChildren().inBackground(callback).forPath(fromPath);
-        } catch (Exception e) {
+        }
+        catch ( Exception e )
+        {
             handleException(e);
         }
     }
 
-    private void nodeChanged(String fromPath) {
-        if (state.get() != State.STARTED) {
+    private void nodeChanged(String fromPath)
+    {
+        if ( state.get() != State.STARTED )
+        {
             return;
         }
 
-        try {
+        final Phaser outstandingOps = getPhaserAndRegister();
+
+        try
+        {
             BackgroundCallback callback = (__, event) -> {
-                if (event.getResultCode() == OK.intValue()) {
-                    Optional<ChildData> childData =
-                            putStorage(new ChildData(event.getPath(), event.getStat(), event.getData()));
-                    checkChildrenChanged(
-                            event.getPath(), childData.map(ChildData::getStat).orElse(null), event.getStat());
-                } else if (event.getResultCode() == NONODE.intValue()) {
+                if ( event.getResultCode() == OK.intValue() )
+                {
+                    Optional<ChildData> childData = putStorage(new ChildData(event.getPath(), event.getStat(), event.getData()));
+                    checkChildrenChanged(event.getPath(), childData.map(ChildData::getStat).orElse(null), event.getStat());
+                }
+                else if ( event.getResultCode() == NONODE.intValue() )
+                {
                     removeStorage(event.getPath());
-                } else {
+                }
+                else
+                {
                     handleException(event);
                 }
                 outstandingOps.arriveAndDeregister();
             };
 
-            outstandingOps.register();
-            if (compressedData) {
+            if ( compressedData )
+            {
                 client.getData().decompressed().inBackground(callback).forPath(fromPath);
-            } else {
+            }
+            else
+            {
                 client.getData().inBackground(callback).forPath(fromPath);
             }
-        } catch (Exception e) {
+        }
+        catch ( Exception e )
+        {
             handleException(e);
         }
     }
 
-    private Optional<ChildData> putStorage(ChildData data) {
+    private Optional<ChildData> putStorage(ChildData data)
+    {
         Optional<ChildData> previousData = storage.put(data);
-        if (previousData.isPresent()) {
-            if (previousData.get().getStat().getVersion() != data.getStat().getVersion()) {
+        if ( previousData.isPresent() )
+        {
+            if ( previousData.get().getStat().getVersion() != data.getStat().getVersion() )
+            {
                 callListeners(l -> l.event(NODE_CHANGED, previousData.get(), data));
             }
-        } else {
+        }
+        else
+        {
             callListeners(l -> l.event(NODE_CREATED, null, data));
         }
         return previousData;
     }
 
-    private void removeStorage(String path) {
+    private void removeStorage(String path)
+    {
         storage.remove(path).ifPresent(previousData -> callListeners(l -> l.event(NODE_DELETED, previousData, null)));
     }
 
-    private void callListeners(Consumer<CuratorCacheListener> proc) {
-        if (state.get() == State.STARTED) {
+    private void callListeners(Consumer<CuratorCacheListener> proc)
+    {
+        if ( state.get() == State.STARTED )
+        {
             client.runSafe(() -> listenerManager.forEach(proc));
         }
     }
 
-    private void handleException(CuratorEvent event) {
+    private void handleException(CuratorEvent event)
+    {
         handleException(KeeperException.create(KeeperException.Code.get(event.getResultCode())));
     }
 
-    private void handleException(Exception e) {
+    private void handleException(Exception e)
+    {
         ThreadUtils.checkInterrupted(e);
         exceptionHandler.accept(e);
     }

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCache.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/cache/TestCuratorCache.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 public class TestCuratorCache extends CuratorTestBase {
     @Test
     public void testUpdateWhenNotCachingData() throws Exception // mostly copied from TestPathChildrenCache
-    {
+            {
         CuratorCacheStorage storage = new StandardCuratorCacheStorage(false);
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(
                 server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1))) {
@@ -46,7 +46,7 @@ public class TestCuratorCache extends CuratorTestBase {
             final CountDownLatch addedLatch = new CountDownLatch(1);
             client.create().creatingParentsIfNeeded().forPath("/test");
             try (CuratorCache cache =
-                         CuratorCache.builder(client, "/test").withStorage(storage).build()) {
+                    CuratorCache.builder(client, "/test").withStorage(storage).build()) {
                 cache.listenable()
                         .addListener(builder()
                                 .forChanges((__, ___) -> updatedLatch.countDown())
@@ -182,28 +182,24 @@ public class TestCuratorCache extends CuratorTestBase {
 
     // CURATOR-690 - CuratorCache fails to load the cache if there are more than 64K child ZNodes
     @Test
-    public void testGreaterThan64kZNodes() throws Exception
-    {
+    public void testGreaterThan64kZNodes() throws Exception {
         final CuratorCacheStorage storage = new StandardCuratorCacheStorage(false);
 
         // Phaser has a hard-limit of 64k registrants; we need to create more than that to trigger the initial problem.
         final int zNodeCount = 0xffff + 5;
 
         try (CuratorFramework client = CuratorFrameworkFactory.newClient(
-                server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1)))
-        {
+                server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1))) {
             client.start();
             final CountDownLatch initializedLatch = new CountDownLatch(1);
             client.create().creatingParentsIfNeeded().forPath("/test");
 
 
-            for (int i = 0; i < zNodeCount; i++)
-            {
+            for (int i = 0; i < zNodeCount; i++) {
                 client.create().forPath("/test/node_" + i);
             }
 
-            try (CuratorCache cache = CuratorCache.builder(client, "/test").withStorage(storage).build())
-            {
+            try (CuratorCache cache = CuratorCache.builder(client, "/test").withStorage(storage).build()) {
                 cache.listenable()
                         .addListener(builder()
                                 .forInitialized(() -> initializedLatch.countDown())


### PR DESCRIPTION
This PR addresses the 64K child ZNode scaling limitation of CuratorCache.

This is done by utilizing tiered Phasers to handle monitoring of additional outstanding operations during the initialization phase of the cache.

As each child Phaser reaches the 0xffff capacity of a single Phaser, an additional child Phaser is created and registered with the root Phaser.

After initialization completes, the "currentChildPhaser" member variable is set to rootPhaser such that all child Phasers (which will never be used again) can be GC'd.

A unit test has been provided which fails without this fix, but succeeds with. 