### PR TITLE
CURATOR-693. Bump zookeeper to 3.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
         <!-- versions -->
-        <zookeeper-version>3.7.1</zookeeper-version>
+        <zookeeper-version>3.7.2</zookeeper-version>
         <maven-bundle-plugin-version>5.1.4</maven-bundle-plugin-version>
         <maven-compiler-plugin-version>3.10.0</maven-compiler-plugin-version>
         <maven-dependency-plugin-version>3.2.0</maven-dependency-plugin-version>


### PR DESCRIPTION
Ref - CURATOR-693

The PR is aiming to bump zk to 3.7.2 to address CVE-2023-44981