### PR TITLE
CURATOR-704. Add server compatibility check support

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/utils/Compatibility.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/Compatibility.java
@@ -22,6 +22,7 @@ package org.apache.curator.utils;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/curator-client/src/main/java/org/apache/curator/utils/Compatibility.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/Compatibility.java
@@ -22,7 +22,6 @@ package org.apache.curator.utils;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
-
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/curator-client/src/main/java/org/apache/curator/utils/ZookeeperCompatibility.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/ZookeeperCompatibility.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.curator.utils;
 
 /**

--- a/curator-client/src/main/java/org/apache/curator/utils/ZookeeperCompatibility.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/ZookeeperCompatibility.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.curator.utils;
+
+/**
+ * Describe feature supports based on server compatibility (as opposed to {@code Compatibility}
+ * which represents client compatibility.
+ */
+public interface ZookeeperCompatibility {
+  public enum Version implements ZookeeperCompatibility {
+    VERSION_3_5(false),
+    LATEST(true);
+
+    private final boolean hasPersistentWatchers;
+
+    private Version(boolean hasPersistentWatchers) {
+      this.hasPersistentWatchers = hasPersistentWatchers;
+    }
+
+    @Override
+    public boolean hasPersistentWatchers() {
+      return this.hasPersistentWatchers && Compatibility.hasPersistentWatchers();
+    }
+  }
+
+  /**
+   * Check if both client and server support persistent watchers
+   * @return {@code true} if both the client library and the server version support persistent watchers
+   */
+  boolean hasPersistentWatchers();
+}

--- a/curator-client/src/main/java/org/apache/curator/utils/ZookeeperCompatibility.java
+++ b/curator-client/src/main/java/org/apache/curator/utils/ZookeeperCompatibility.java
@@ -20,29 +20,52 @@
 package org.apache.curator.utils;
 
 /**
- * Describe feature supports based on server compatibility (as opposed to {@code Compatibility}
- * which represents client compatibility.
+ * Describe feature supports based on server compatibility (as opposed to
+ * {@code Compatibility} which represents client compatibility.
  */
-public interface ZookeeperCompatibility {
-  public enum Version implements ZookeeperCompatibility {
-    VERSION_3_5(false),
-    LATEST(true);
+public class ZookeeperCompatibility {
+    /**
+     * Represent latest version with all features enabled
+     */
+    public static final ZookeeperCompatibility LATEST =
+            builder().hasPersistentWatchers(true).build();
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        // List of features introduced by Zookeeper over time.
+        // All values are set to false by default for backward compatibility
+        private boolean hasPersistentWatchers = false;
+
+        public Builder hasPersistentWatchers(boolean value) {
+            this.hasPersistentWatchers = value;
+            return this;
+        }
+
+        public boolean hasPersistentWatchers() {
+            return this.hasPersistentWatchers;
+        }
+
+        public ZookeeperCompatibility build() {
+            return new ZookeeperCompatibility(this);
+        }
+    }
 
     private final boolean hasPersistentWatchers;
 
-    private Version(boolean hasPersistentWatchers) {
-      this.hasPersistentWatchers = hasPersistentWatchers;
+    private ZookeeperCompatibility(Builder builder) {
+        this.hasPersistentWatchers = builder.hasPersistentWatchers;
     }
 
-    @Override
+    /**
+     * Check if both client and server support persistent watchers
+     *
+     * @return {@code true} if both the client library and the server version
+     *         support persistent watchers
+     */
     public boolean hasPersistentWatchers() {
-      return this.hasPersistentWatchers && Compatibility.hasPersistentWatchers();
+        return this.hasPersistentWatchers && Compatibility.hasPersistentWatchers();
     }
-  }
-
-  /**
-   * Check if both client and server support persistent watchers
-   * @return {@code true} if both the client library and the server version support persistent watchers
-   */
-  boolean hasPersistentWatchers();
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
@@ -34,6 +34,7 @@ import org.apache.curator.framework.schema.SchemaSet;
 import org.apache.curator.framework.state.ConnectionStateErrorPolicy;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.EnsurePath;
+import org.apache.curator.utils.ZookeeperCompatibility;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 
@@ -261,6 +262,13 @@ public interface CuratorFramework extends Closeable {
      * @return client
      */
     public CuratorZookeeperClient getZookeeperClient();
+
+    /**
+     * Return zookeeper server compatibility
+     *
+     * @return compatibility
+     */
+    public ZookeeperCompatibility getZookeeperCompatibility();
 
     /**
      * Allocates an ensure path instance that is namespace aware

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
@@ -175,7 +175,7 @@ public class CuratorFrameworkFactory {
                 ConnectionStateListenerManagerFactory.standard;
         private int simulatedSessionExpirationPercent = 100;
         private ZKClientConfig zkClientConfig;
-        private ZookeeperCompatibility zookeeperCompatibility = ZookeeperCompatibility.Version.LATEST;
+        private ZookeeperCompatibility zookeeperCompatibility = ZookeeperCompatibility.LATEST;
 
         /**
          * Apply the current values and build a new CuratorFramework
@@ -522,8 +522,8 @@ public class CuratorFrameworkFactory {
         }
 
         public Builder zookeeperCompatibility(ZookeeperCompatibility zookeeperCompatibility) {
-          this.zookeeperCompatibility = zookeeperCompatibility;
-          return this;
+            this.zookeeperCompatibility = zookeeperCompatibility;
+            return this;
         }
 
         public Executor getRunSafeService() {
@@ -648,7 +648,7 @@ public class CuratorFrameworkFactory {
         }
 
         public ZookeeperCompatibility getZookeeperCompatibility() {
-          return zookeeperCompatibility;
+            return zookeeperCompatibility;
         }
 
         private Builder() {}

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.curator.framework;
 
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.net.InetAddress;
@@ -46,6 +47,7 @@ import org.apache.curator.framework.state.ConnectionStateErrorPolicy;
 import org.apache.curator.framework.state.ConnectionStateListenerManagerFactory;
 import org.apache.curator.framework.state.StandardConnectionStateErrorPolicy;
 import org.apache.curator.utils.DefaultZookeeperFactory;
+import org.apache.curator.utils.ZookeeperCompatibility;
 import org.apache.curator.utils.ZookeeperFactory;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
@@ -174,6 +176,7 @@ public class CuratorFrameworkFactory {
                 ConnectionStateListenerManagerFactory.standard;
         private int simulatedSessionExpirationPercent = 100;
         private ZKClientConfig zkClientConfig;
+        private ZookeeperCompatibility zookeeperCompatibility = ZookeeperCompatibility.Version.LATEST;
 
         /**
          * Apply the current values and build a new CuratorFramework
@@ -519,6 +522,11 @@ public class CuratorFrameworkFactory {
             return this;
         }
 
+        public Builder zookeeperCompatibility(ZookeeperCompatibility zookeeperCompatibility) {
+          this.zookeeperCompatibility = zookeeperCompatibility;
+          return this;
+        }
+
         public Executor getRunSafeService() {
             return runSafeService;
         }
@@ -638,6 +646,10 @@ public class CuratorFrameworkFactory {
 
         public ConnectionStateListenerManagerFactory getConnectionStateListenerManagerFactory() {
             return connectionStateListenerManagerFactory;
+        }
+
+        public ZookeeperCompatibility getZookeeperCompatibility() {
+          return zookeeperCompatibility;
         }
 
         private Builder() {}

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
@@ -19,7 +19,6 @@
 
 package org.apache.curator.framework;
 
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.net.InetAddress;

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/CuratorCacheBridgeBuilderImpl.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/cache/CuratorCacheBridgeBuilderImpl.java
@@ -21,7 +21,6 @@ package org.apache.curator.framework.recipes.cache;
 
 import java.util.concurrent.ExecutorService;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.utils.Compatibility;
 import org.slf4j.LoggerFactory;
 
 class CuratorCacheBridgeBuilderImpl implements CuratorCacheBridgeBuilder {
@@ -57,7 +56,7 @@ class CuratorCacheBridgeBuilderImpl implements CuratorCacheBridgeBuilder {
 
     @Override
     public CuratorCacheBridge build() {
-        if (!forceTreeCache && Compatibility.hasPersistentWatchers()) {
+        if (!forceTreeCache && client.getZookeeperCompatibility().hasPersistentWatchers()) {
             if (executorService != null) {
                 LoggerFactory.getLogger(getClass()).warn("CuratorCache does not support custom ExecutorService");
             }

--- a/curator-test-zk35/src/test/java/org/apache/curator/zk35/TestIs35.java
+++ b/curator-test-zk35/src/test/java/org/apache/curator/zk35/TestIs35.java
@@ -35,9 +35,7 @@ public class TestIs35 extends CuratorTestBase {
         assertTrue(Compatibility.hasAddrField());
         assertFalse(Compatibility.hasPersistentWatchers());
         assertFalse(ZookeeperCompatibility.LATEST.hasPersistentWatchers());
-        assertFalse(ZookeeperCompatibility.builder()
-            .build()
-            .hasPersistentWatchers());
+        assertFalse(ZookeeperCompatibility.builder().build().hasPersistentWatchers());
         assertFalse(ZookeeperCompatibility.builder()
                 .hasPersistentWatchers(false)
                 .build()

--- a/curator-test-zk35/src/test/java/org/apache/curator/zk35/TestIs35.java
+++ b/curator-test-zk35/src/test/java/org/apache/curator/zk35/TestIs35.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.Compatibility;
+import org.apache.curator.utils.ZookeeperCompatibility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +34,14 @@ public class TestIs35 extends CuratorTestBase {
         assertFalse(Compatibility.hasGetReachableOrOneMethod());
         assertTrue(Compatibility.hasAddrField());
         assertFalse(Compatibility.hasPersistentWatchers());
+        assertFalse(ZookeeperCompatibility.LATEST.hasPersistentWatchers());
+        assertFalse(ZookeeperCompatibility.builder()
+            .build()
+            .hasPersistentWatchers());
+        assertFalse(ZookeeperCompatibility.builder()
+                .hasPersistentWatchers(false)
+                .build()
+                .hasPersistentWatchers());
     }
 
     @Override

--- a/curator-test-zk36/src/test/java/org/apache/curator/zk36/TestIs36.java
+++ b/curator-test-zk36/src/test/java/org/apache/curator/zk36/TestIs36.java
@@ -36,9 +36,7 @@ public class TestIs36 extends CuratorTestBase {
         assertTrue(Compatibility.hasAddrField());
         assertTrue(Compatibility.hasPersistentWatchers());
         assertTrue(ZookeeperCompatibility.LATEST.hasPersistentWatchers());
-        assertFalse(ZookeeperCompatibility.builder()
-            .build()
-            .hasPersistentWatchers());
+        assertFalse(ZookeeperCompatibility.builder().build().hasPersistentWatchers());
         assertFalse(ZookeeperCompatibility.builder()
                 .hasPersistentWatchers(false)
                 .build()

--- a/curator-test-zk36/src/test/java/org/apache/curator/zk36/TestIs36.java
+++ b/curator-test-zk36/src/test/java/org/apache/curator/zk36/TestIs36.java
@@ -19,10 +19,12 @@
 
 package org.apache.curator.zk36;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.apache.curator.test.compatibility.CuratorTestBase;
 import org.apache.curator.utils.Compatibility;
+import org.apache.curator.utils.ZookeeperCompatibility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +35,14 @@ public class TestIs36 extends CuratorTestBase {
         assertTrue(Compatibility.hasGetReachableOrOneMethod());
         assertTrue(Compatibility.hasAddrField());
         assertTrue(Compatibility.hasPersistentWatchers());
+        assertTrue(ZookeeperCompatibility.LATEST.hasPersistentWatchers());
+        assertFalse(ZookeeperCompatibility.builder()
+            .build()
+            .hasPersistentWatchers());
+        assertFalse(ZookeeperCompatibility.builder()
+                .hasPersistentWatchers(false)
+                .build()
+                .hasPersistentWatchers());
         try {
             Class.forName("org.apache.zookeeper.proto.WhoAmIResponse");
             fail("WhoAmIResponse is introduced after ZooKeeper 3.7");

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCuratorFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCuratorFrameworkImpl.java
@@ -40,7 +40,6 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
-
 public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
     private final CuratorFrameworkImpl client;
     private final Filters filters;

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCuratorFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCuratorFrameworkImpl.java
@@ -32,7 +32,6 @@ import org.apache.curator.framework.imps.CuratorFrameworkImpl;
 import org.apache.curator.framework.imps.CuratorMultiTransactionImpl;
 import org.apache.curator.framework.imps.GetACLBuilderImpl;
 import org.apache.curator.framework.imps.SyncBuilderImpl;
-import org.apache.curator.utils.Compatibility;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.WatchMode;
@@ -40,6 +39,7 @@ import org.apache.curator.x.async.api.*;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
+
 
 public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
     private final CuratorFrameworkImpl client;
@@ -140,8 +140,8 @@ public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
     @Override
     public AsyncWatchBuilder addWatch() {
         Preconditions.checkState(
-                Compatibility.hasPersistentWatchers(),
-                "addWatch() is not supported in the ZooKeeper library being used.");
+                client.getZookeeperCompatibility().hasPersistentWatchers(),
+                "addWatch() is not supported in the ZooKeeper library and/or server being used.");
         return new AsyncWatchBuilderImpl(client, filters);
     }
 


### PR DESCRIPTION
Add new interface ZookeeperCompatibility to represent server compatibility in addition to the existing Compatibility class (which represents client compatibility).

Enhance CuratorFramework to accept ZookeeperCompatibility instance, allowing user to specify which server version to target (default is LATEST).