### PR TITLE
CURATOR-715/mkdirs/bottom up existence check

### DIFF
--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreate.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreate.java
@@ -20,9 +20,8 @@
 package org.apache.curator.framework.imps;
 
 import static org.apache.zookeeper.ZooDefs.Ids.ANYONE_ID_UNSAFE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -465,5 +464,34 @@ public class TestCreate extends BaseClassForTests {
         assertEquals(ProtectedUtils.toProtectedZNodePath(path, null), path);
         path = ZKPaths.makePath("hola", name);
         assertEquals(ProtectedUtils.normalizePath(path), "/hola/yo");
+    }
+
+    /**
+     * Tests that parents existence checks don't need READ access to the whole path (from / to the new node)
+     * but just to the first ancestor parent. (See https://issues.apache.org/jira/browse/ZOOKEEPER-2590)
+     */
+    @Test
+    public void testForbiddenAncestors() throws Exception {
+        CuratorFramework client = createClient(testACLProvider);
+        try {
+            client.start();
+
+            client.create().creatingParentsIfNeeded().forPath("/bat/bi/hiru");
+            client.setACL().withACL(Collections.singletonList(new ACL(0, ANYONE_ID_UNSAFE))).forPath("/bat");
+
+            // In creation attempts where the parent ("/bat") has ACL that restricts read, creation request fails.
+            try {
+                client.create().creatingParentsIfNeeded().forPath("/bat/bost");
+                fail("Expected NoAuthException when not authorized to read new node grandparent");
+            } catch(KeeperException.NoAuthException noAuthException) {
+            }
+
+            // But creating a node in the same subtree where its grandparent has read access is allowed and
+            // Curator will not check for higher nodes' existence.
+            client.create().creatingParentsIfNeeded().forPath("/bat/bi/hiru/bost");
+            assertNotNull(client.checkExists().forPath("/bat/bi/hiru/bost"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
     }
 }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreate.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreate.java
@@ -21,7 +21,6 @@ package org.apache.curator.framework.imps;
 
 import static org.apache.zookeeper.ZooDefs.Ids.ANYONE_ID_UNSAFE;
 import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -477,13 +476,15 @@ public class TestCreate extends BaseClassForTests {
             client.start();
 
             client.create().creatingParentsIfNeeded().forPath("/bat/bi/hiru");
-            client.setACL().withACL(Collections.singletonList(new ACL(0, ANYONE_ID_UNSAFE))).forPath("/bat");
+            client.setACL()
+                    .withACL(Collections.singletonList(new ACL(0, ANYONE_ID_UNSAFE)))
+                    .forPath("/bat");
 
             // In creation attempts where the parent ("/bat") has ACL that restricts read, creation request fails.
             try {
                 client.create().creatingParentsIfNeeded().forPath("/bat/bost");
                 fail("Expected NoAuthException when not authorized to read new node grandparent");
-            } catch(KeeperException.NoAuthException noAuthException) {
+            } catch (KeeperException.NoAuthException noAuthException) {
             }
 
             // But creating a node in the same subtree where its grandparent has read access is allowed and

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
         <!-- versions -->
-        <zookeeper-version>3.9.1</zookeeper-version>
+        <zookeeper-version>3.9.2</zookeeper-version>
         <maven-bundle-plugin-version>5.1.4</maven-bundle-plugin-version>
         <maven-compiler-plugin-version>3.10.0</maven-compiler-plugin-version>
         <maven-dependency-plugin-version>3.2.0</maven-dependency-plugin-version>


### PR DESCRIPTION
This PR tackles the problem reported in https://issues.apache.org/jira/browse/CURATOR-715.

Namely, that ZooKeeper trees where upper nodes have restricted READ ACLs, it is not possible to use `creatingParentsIfNeeded` without changing the ACLs. 

This is because the implementation prior to this patch iterated from root node to the newly created one, checking existence of all intermediate nodes.

This patch changes that approach from top-down to bottom-up and the first ancestor that exists is where the validation stops thus avoiding `exists` checks on the higher nodes with more restricted access.

This is only relevant since https://issues.apache.org/jira/browse/ZOOKEEPER-2590