### PR TITLE
[CURATOR-721] Upgrade Guava Listenablefuture

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <!-- resteasy-jaxrs dependency cannot be higher than 2.x for compatibility with Jersey 1.x -->
         <resteasy-jaxrs-version>2.3.5.Final</resteasy-jaxrs-version>
         <guava-version>32.0.0-jre</guava-version>
-        <guava-listenablefuture-version>1.0</guava-listenablefuture-version>
+        <guava-listenablefuture-version>9999.0-empty-to-avoid-conflict-with-guava</guava-listenablefuture-version>
         <guava-failureaccess-version>1.0.1</guava-failureaccess-version>
         <junit-version>5.6.2</junit-version>
         <swift-version>0.23.1</swift-version>


### PR DESCRIPTION
This removes duplicate class ListenableFuture.
See more at https://github.com/google/guava/issues/7385