### PR TITLE
CURATOR-719: Fix orSetData for parallel create calls

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -1147,23 +1147,26 @@ public class CreateBuilderImpl
 
                 if (createdPath == null) {
                     try {
-                        if (failBeforeNextCreateForTesting) {
-                            failBeforeNextCreateForTesting = false;
-                            throw new KeeperException.ConnectionLossException();
-                        }
-                        createdPath = client.getZooKeeper().create(path, data, aclList, createMode, storingStat, ttl);
-                    } catch (KeeperException.NoNodeException e) {
-                        if (createParentsIfNeeded) {
-                            ZKPaths.mkdirs(
-                                    client.getZooKeeper(),
-                                    path,
-                                    false,
-                                    acling.getACLProviderForParents(),
-                                    createParentsAsContainers);
-                            createdPath = client.getZooKeeper()
-                                    .create(path, data, acling.getAclList(path), createMode, storingStat, ttl);
-                        } else {
-                            throw e;
+                        try {
+                            if (failBeforeNextCreateForTesting) {
+                                failBeforeNextCreateForTesting = false;
+                                throw new KeeperException.ConnectionLossException();
+                            }
+                            createdPath =
+                                    client.getZooKeeper().create(path, data, aclList, createMode, storingStat, ttl);
+                        } catch (KeeperException.NoNodeException e) {
+                            if (createParentsIfNeeded) {
+                                ZKPaths.mkdirs(
+                                        client.getZooKeeper(),
+                                        path,
+                                        false,
+                                        acling.getACLProviderForParents(),
+                                        createParentsAsContainers);
+                                createdPath = client.getZooKeeper()
+                                        .create(path, data, acling.getAclList(path), createMode, storingStat, ttl);
+                            } else {
+                                throw e;
+                            }
                         }
                     } catch (KeeperException.NodeExistsException e) {
                         if (setDataIfExists) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CURATOR-719

This fix really just lets the `catch (KeeperException.NodeExistsException e)` clause catch exceptions thrown in the `if (createParentsIfNeeded)` clause. Previously, since the two `catch` statements were for the same try, the `KeeperException.NodeExistsException` logic would not be called if that error was thrown when creating the node after creating the parents. This case can easily be seen when trying to call create.orSetData() in parallel on the same node, while creating parents if needed. This is because the `NoNodeException` would be thrown for both parallel calls, but only one would be able to create the new node in the catch statement, and the other would get an un-catchable `NodeExistsException`.