### PR TITLE
CURATOR-720: Stop retry if client is closed

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
+++ b/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
@@ -399,6 +399,9 @@ public class CuratorZookeeperClient implements Closeable {
     public void internalBlockUntilConnectedOrTimedOut() throws InterruptedException {
         long waitTimeMs = connectionTimeoutMs;
         while (!state.isConnected() && (waitTimeMs > 0)) {
+            if (!started.get()) {
+                throw new IllegalStateException("Client is not started");
+            }
             final CountDownLatch latch = new CountDownLatch(1);
             Watcher tempWatcher = new Watcher() {
                 @Override

--- a/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
+++ b/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java
@@ -400,7 +400,7 @@ public class CuratorZookeeperClient implements Closeable {
         long waitTimeMs = connectionTimeoutMs;
         while (!state.isConnected() && (waitTimeMs > 0)) {
             if (!started.get()) {
-                throw new IllegalStateException("Client is not started");
+                throw new IllegalStateException("Client is not started or has been closed");
             }
             final CountDownLatch latch = new CountDownLatch(1);
             Watcher tempWatcher = new Watcher() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CURATOR-720

Stop a retry loop if the client is stopped.