### PR TITLE
CURATOR-725: Allow for global compression

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFramework.java
@@ -346,6 +346,13 @@ public interface CuratorFramework extends Closeable {
     SchemaSet getSchemaSet();
 
     /**
+     * Return whether compression is enabled by default for all create, setData and getData operations.
+     *
+     * @return if compression is enabled
+     */
+    boolean compressionEnabled();
+
+    /**
      * Calls {@link #notifyAll()} on the given object after first synchronizing on it. This is
      * done from the {@link #runSafe(Runnable)} thread.
      *

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
@@ -163,7 +163,7 @@ public class CuratorFrameworkFactory {
         private List<AuthInfo> authInfos = null;
         private byte[] defaultData = LOCAL_ADDRESS;
         private CompressionProvider compressionProvider = DEFAULT_COMPRESSION_PROVIDER;
-        private boolean globalCompressionEnabled = false;
+        private boolean compressionEnabled = false;
         private ZookeeperFactory zookeeperFactory = DEFAULT_ZOOKEEPER_FACTORY;
         private ACLProvider aclProvider = DEFAULT_ACL_PROVIDER;
         private boolean canBeReadOnly = false;
@@ -370,13 +370,13 @@ public class CuratorFrameworkFactory {
 
         /**
          * By default, each write or read call must explicitly use compression.
-         * Call this method to enable compression on all read and write calls.
+         * Call this method to enable compression by default on all read and write calls.
          * <p>
          * In order to implement filtered compression, use this option and a custom {@link CompressionProvider} that only compresses and decompresses the zNodes that match the desired filter.
          * @return this
          */
-        public Builder enableGlobalCompression() {
-            this.globalCompressionEnabled = true;
+        public Builder enableCompression() {
+            this.compressionEnabled = true;
             return this;
         }
 
@@ -555,8 +555,8 @@ public class CuratorFrameworkFactory {
             return compressionProvider;
         }
 
-        public boolean globalCompressionEnabled() {
-            return globalCompressionEnabled;
+        public boolean compressionEnabled() {
+            return compressionEnabled;
         }
 
         public ThreadFactory getThreadFactory() {

--- a/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java
@@ -163,6 +163,7 @@ public class CuratorFrameworkFactory {
         private List<AuthInfo> authInfos = null;
         private byte[] defaultData = LOCAL_ADDRESS;
         private CompressionProvider compressionProvider = DEFAULT_COMPRESSION_PROVIDER;
+        private boolean globalCompressionEnabled = false;
         private ZookeeperFactory zookeeperFactory = DEFAULT_ZOOKEEPER_FACTORY;
         private ACLProvider aclProvider = DEFAULT_ACL_PROVIDER;
         private boolean canBeReadOnly = false;
@@ -368,6 +369,18 @@ public class CuratorFrameworkFactory {
         }
 
         /**
+         * By default, each write or read call must explicitly use compression.
+         * Call this method to enable compression on all read and write calls.
+         * <p>
+         * In order to implement filtered compression, use this option and a custom {@link CompressionProvider} that only compresses and decompresses the zNodes that match the desired filter.
+         * @return this
+         */
+        public Builder enableGlobalCompression() {
+            this.globalCompressionEnabled = true;
+            return this;
+        }
+
+        /**
          * @param zookeeperFactory the zookeeper factory to use
          * @return this
          */
@@ -540,6 +553,10 @@ public class CuratorFrameworkFactory {
 
         public CompressionProvider getCompressionProvider() {
             return compressionProvider;
+        }
+
+        public boolean globalCompressionEnabled() {
+            return globalCompressionEnabled;
         }
 
         public ThreadFactory getThreadFactory() {

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/Compressible.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/Compressible.java
@@ -26,4 +26,12 @@ public interface Compressible<T> {
      * @return this
      */
     public T compressed();
+
+    /**
+     * Cause the data to be uncompressed, even if the {@link org.apache.curator.framework.CuratorFramework}
+     * has compressionEnabled
+     *
+     * @return this
+     */
+    public T uncompressed();
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/api/Decompressible.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/Decompressible.java
@@ -26,4 +26,12 @@ public interface Decompressible<T> {
      * @return this
      */
     public T decompressed();
+
+    /**
+     * Cause the data to not be de-compressed, even if the {@link org.apache.curator.framework.CuratorFramework}
+     * has compressionEnabled
+     *
+     * @return this
+     */
+    public T undecompressed();
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -100,7 +100,7 @@ public class CreateBuilderImpl
         acling = new ACLing(client.getAclProvider());
         createParentsIfNeeded = false;
         createParentsAsContainers = false;
-        compress = false;
+        compress = client.globalCompressionEnabled();
         setDataIfExists = false;
         storingStat = null;
         ttl = -1;
@@ -123,7 +123,7 @@ public class CreateBuilderImpl
         this.backgrounding = backgrounding;
         this.createParentsIfNeeded = createParentsIfNeeded;
         this.createParentsAsContainers = createParentsAsContainers;
-        this.compress = compress;
+        this.compress = client.globalCompressionEnabled() || compress;
         this.setDataIfExists = setDataIfExists;
         this.acling = new ACLing(client.getAclProvider(), aclList);
         this.storingStat = storingStat;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -100,7 +100,7 @@ public class CreateBuilderImpl
         acling = new ACLing(client.getAclProvider());
         createParentsIfNeeded = false;
         createParentsAsContainers = false;
-        compress = client.globalCompressionEnabled();
+        compress = client.compressionEnabled();
         setDataIfExists = false;
         storingStat = null;
         ttl = -1;
@@ -123,7 +123,7 @@ public class CreateBuilderImpl
         this.backgrounding = backgrounding;
         this.createParentsIfNeeded = createParentsIfNeeded;
         this.createParentsAsContainers = createParentsAsContainers;
-        this.compress = client.globalCompressionEnabled() || compress;
+        this.compress = compress;
         this.setDataIfExists = setDataIfExists;
         this.acling = new ACLing(client.getAclProvider(), aclList);
         this.storingStat = storingStat;
@@ -194,6 +194,12 @@ public class CreateBuilderImpl
             }
 
             @Override
+            public ACLCreateModePathAndBytesable<T> uncompressed() {
+                CreateBuilderImpl.this.uncompressed();
+                return this;
+            }
+
+            @Override
             public T forPath(String path) throws Exception {
                 return forPath(path, client.getDefaultData());
             }
@@ -216,7 +222,16 @@ public class CreateBuilderImpl
 
     @Override
     public CreateBackgroundModeStatACLable compressed() {
-        compress = true;
+        return withCompression(true);
+    }
+
+    @Override
+    public CreateBackgroundModeStatACLable uncompressed() {
+        return withCompression(false);
+    }
+
+    private CreateBackgroundModeStatACLable withCompression(boolean compress) {
+        this.compress = compress;
         return new CreateBackgroundModeStatACLable() {
             @Override
             public CreateBackgroundModeACLable storingStatIn(Stat stat) {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -108,6 +108,7 @@ public class CuratorFrameworkImpl implements CuratorFramework {
     private final FailedDeleteManager failedDeleteManager;
     private final FailedRemoveWatchManager failedRemoveWatcherManager;
     private final CompressionProvider compressionProvider;
+    private final boolean globalCompressionEnabled;
     private final ACLProvider aclProvider;
     private final NamespaceFacadeCache namespaceFacadeCache;
     private final boolean useContainerParentsIfAvailable;
@@ -184,6 +185,7 @@ public class CuratorFrameworkImpl implements CuratorFramework {
                 builder.getSimulatedSessionExpirationPercent(),
                 builder.getConnectionStateListenerManagerFactory());
         compressionProvider = builder.getCompressionProvider();
+        globalCompressionEnabled = builder.globalCompressionEnabled();
         aclProvider = builder.getAclProvider();
         state = new AtomicReference<CuratorFrameworkState>(CuratorFrameworkState.LATENT);
         useContainerParentsIfAvailable = builder.useContainerParentsIfAvailable();
@@ -283,6 +285,7 @@ public class CuratorFrameworkImpl implements CuratorFramework {
         failedDeleteManager = parent.failedDeleteManager;
         failedRemoveWatcherManager = parent.failedRemoveWatcherManager;
         compressionProvider = parent.compressionProvider;
+        globalCompressionEnabled = parent.globalCompressionEnabled;
         aclProvider = parent.aclProvider;
         namespaceFacadeCache = parent.namespaceFacadeCache;
         namespace = parent.namespace;
@@ -640,6 +643,10 @@ public class CuratorFrameworkImpl implements CuratorFramework {
 
     CompressionProvider getCompressionProvider() {
         return compressionProvider;
+    }
+
+    boolean globalCompressionEnabled() {
+        return globalCompressionEnabled;
     }
 
     boolean useContainerParentsIfAvailable() {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -108,7 +108,7 @@ public class CuratorFrameworkImpl implements CuratorFramework {
     private final FailedDeleteManager failedDeleteManager;
     private final FailedRemoveWatchManager failedRemoveWatcherManager;
     private final CompressionProvider compressionProvider;
-    private final boolean globalCompressionEnabled;
+    private final boolean compressionEnabled;
     private final ACLProvider aclProvider;
     private final NamespaceFacadeCache namespaceFacadeCache;
     private final boolean useContainerParentsIfAvailable;
@@ -185,7 +185,7 @@ public class CuratorFrameworkImpl implements CuratorFramework {
                 builder.getSimulatedSessionExpirationPercent(),
                 builder.getConnectionStateListenerManagerFactory());
         compressionProvider = builder.getCompressionProvider();
-        globalCompressionEnabled = builder.globalCompressionEnabled();
+        compressionEnabled = builder.compressionEnabled();
         aclProvider = builder.getAclProvider();
         state = new AtomicReference<CuratorFrameworkState>(CuratorFrameworkState.LATENT);
         useContainerParentsIfAvailable = builder.useContainerParentsIfAvailable();
@@ -285,7 +285,7 @@ public class CuratorFrameworkImpl implements CuratorFramework {
         failedDeleteManager = parent.failedDeleteManager;
         failedRemoveWatcherManager = parent.failedRemoveWatcherManager;
         compressionProvider = parent.compressionProvider;
-        globalCompressionEnabled = parent.globalCompressionEnabled;
+        compressionEnabled = parent.compressionEnabled;
         aclProvider = parent.aclProvider;
         namespaceFacadeCache = parent.namespaceFacadeCache;
         namespace = parent.namespace;
@@ -621,6 +621,11 @@ public class CuratorFrameworkImpl implements CuratorFramework {
         return schemaSet;
     }
 
+    @Override
+    public boolean compressionEnabled() {
+        return compressionEnabled;
+    }
+
     ACLProvider getAclProvider() {
         return aclProvider;
     }
@@ -643,10 +648,6 @@ public class CuratorFrameworkImpl implements CuratorFramework {
 
     CompressionProvider getCompressionProvider() {
         return compressionProvider;
-    }
-
-    boolean globalCompressionEnabled() {
-        return globalCompressionEnabled;
     }
 
     boolean useContainerParentsIfAvailable() {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
@@ -46,7 +46,7 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
         responseStat = null;
         watching = new Watching(client);
         backgrounding = new Backgrounding();
-        decompress = false;
+        decompress = client.globalCompressionEnabled();
     }
 
     public GetDataBuilderImpl(
@@ -59,7 +59,7 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
         this.responseStat = responseStat;
         this.watching = new Watching(client, watcher);
         this.backgrounding = backgrounding;
-        this.decompress = decompress;
+        this.decompress = client.globalCompressionEnabled() || decompress;
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
@@ -87,7 +87,7 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
 
             @Override
             public ErrorListenerPathable<byte[]> inBackground(
-                BackgroundCallback callback, Object context, Executor executor) {
+                    BackgroundCallback callback, Object context, Executor executor) {
                 return GetDataBuilderImpl.this.inBackground(callback, context, executor);
             }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
@@ -39,7 +39,7 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
     private Stat responseStat;
     private Watching watching;
     private Backgrounding backgrounding;
-    private Boolean decompress;
+    private boolean decompress;
 
     GetDataBuilderImpl(CuratorFrameworkImpl client) {
         this.client = client;
@@ -54,12 +54,12 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
             Stat responseStat,
             Watcher watcher,
             Backgrounding backgrounding,
-            Boolean decompress) {
+            boolean decompress) {
         this.client = client;
         this.responseStat = responseStat;
         this.watching = new Watching(client, watcher);
         this.backgrounding = backgrounding;
-        this.decompress = decompress != null ? decompress : client.compressionEnabled();
+        this.decompress = decompress;
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
@@ -54,14 +54,14 @@ public class SetDataBuilderImpl
         this.client = client;
         backgrounding = new Backgrounding();
         version = -1;
-        compress = false;
+        compress = client.globalCompressionEnabled();
     }
 
     public SetDataBuilderImpl(CuratorFrameworkImpl client, Backgrounding backgrounding, int version, boolean compress) {
         this.client = client;
         this.backgrounding = backgrounding;
         this.version = version;
-        this.compress = compress;
+        this.compress = client.globalCompressionEnabled() || compress;
     }
 
     <T> TransactionSetDataBuilder<T> asTransactionSetDataBuilder(

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
@@ -128,7 +128,7 @@ public class SetDataBuilderImpl
 
             @Override
             public ErrorListenerPathAndBytesable<Stat> inBackground(
-                BackgroundCallback callback, Object context, Executor executor) {
+                    BackgroundCallback callback, Object context, Executor executor) {
                 return SetDataBuilderImpl.this.inBackground(callback, context, executor);
             }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
@@ -35,12 +35,19 @@ class TempGetDataBuilderImpl implements TempGetDataBuilder {
     TempGetDataBuilderImpl(CuratorFrameworkImpl client) {
         this.client = client;
         responseStat = null;
-        decompress = client.globalCompressionEnabled();
+        decompress = client.compressionEnabled();
     }
 
     @Override
     public StatPathable<byte[]> decompressed() {
         decompress = true;
+        return this;
+    }
+
+
+    @Override
+    public StatPathable<byte[]> undecompressed() {
+        decompress = false;
         return this;
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
@@ -35,7 +35,7 @@ class TempGetDataBuilderImpl implements TempGetDataBuilder {
     TempGetDataBuilderImpl(CuratorFrameworkImpl client) {
         this.client = client;
         responseStat = null;
-        decompress = false;
+        decompress = client.globalCompressionEnabled();
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
@@ -44,7 +44,6 @@ class TempGetDataBuilderImpl implements TempGetDataBuilder {
         return this;
     }
 
-
     @Override
     public StatPathable<byte[]> undecompressed() {
         decompress = false;

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompression.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompression.java
@@ -104,7 +104,7 @@ public class TestCompression extends BaseClassForTests {
         CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
                 .retryPolicy(new RetryOneTime(1))
-                .enableGlobalCompression()
+                .enableCompression()
                 .build();
         try {
             client.start();

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionNew.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionNew.java
@@ -154,7 +154,7 @@ public class TestCompressionInTransactionNew extends BaseClassForTests {
         CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
                 .retryPolicy(new RetryOneTime(1))
-                .enableGlobalCompression()
+                .enableCompression()
                 .build();
         try {
             client.start();

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionOld.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionOld.java
@@ -20,8 +20,11 @@
 package org.apache.curator.framework.imps;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.zip.ZipException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
@@ -180,6 +183,8 @@ public class TestCompressionInTransactionOld extends BaseClassForTests {
 
         final byte[] data1 = "here's a string".getBytes();
         final byte[] data2 = "here's another string".getBytes();
+        final byte[] gzipedData1 = GzipCompressionProvider.doCompress(data1);
+        final byte[] gzipedData2 = GzipCompressionProvider.doCompress(data2);
 
         CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
@@ -189,40 +194,56 @@ public class TestCompressionInTransactionOld extends BaseClassForTests {
         try {
             client.start();
 
-            // Create the nodes
+            // Create the nodes in a transaction
+            // path1 is compressed (globally)
+            // path2 is uncompressed (override)
             client.inTransaction()
                     .create()
                     .forPath(path1, data1)
                     .and()
                     .create()
+                    .uncompressed()
                     .forPath(path2, data2)
                     .and()
                     .commit();
 
             // Check they exist
             assertNotNull(client.checkExists().forPath(path1));
-            assertNotEquals(data1.length, client.checkExists().forPath(path1).getDataLength());
+            assertEquals(gzipedData1.length, client.checkExists().forPath(path1).getDataLength());
             assertNotNull(client.checkExists().forPath(path2));
-            assertNotEquals(data2.length, client.checkExists().forPath(path2).getDataLength());
+            assertEquals(data2.length, client.checkExists().forPath(path2).getDataLength());
+            assertArrayEquals(data1, client.getData().forPath(path1));
             assertArrayEquals(data1, client.getData().decompressed().forPath(path1));
-            assertArrayEquals(data2, client.getData().decompressed().forPath(path2));
+            assertArrayEquals(gzipedData1, client.getData().undecompressed().forPath(path1));
+            assertArrayEquals(data2, client.getData().undecompressed().forPath(path2));
+            assertThrows(
+                    ZipException.class, () -> client.getData().decompressed().forPath(path2));
+            assertThrows(ZipException.class, () -> client.getData().forPath(path2));
 
-            // Set the nodes, path1 compressed, path2 uncompressed.
+            // Set data in transaction
+            // path1 is uncompressed (override)
+            // path2 is compressed (globally)
             client.inTransaction()
                     .setData()
-                    .forPath(path1, data2)
+                    .uncompressed()
+                    .forPath(path1, data1)
                     .and()
                     .setData()
-                    .forPath(path2, data1)
+                    .forPath(path2, data2)
                     .and()
                     .commit();
 
             assertNotNull(client.checkExists().forPath(path1));
-            assertNotEquals(data2.length, client.checkExists().forPath(path1).getDataLength());
+            assertEquals(data1.length, client.checkExists().forPath(path1).getDataLength());
             assertNotNull(client.checkExists().forPath(path2));
-            assertNotEquals(data1.length, client.checkExists().forPath(path2).getDataLength());
-            assertArrayEquals(data2, client.getData().decompressed().forPath(path1));
-            assertArrayEquals(data1, client.getData().decompressed().forPath(path2));
+            assertEquals(gzipedData2.length, client.checkExists().forPath(path2).getDataLength());
+            assertArrayEquals(data1, client.getData().undecompressed().forPath(path1));
+            assertThrows(
+                    ZipException.class, () -> client.getData().decompressed().forPath(path1));
+            assertThrows(ZipException.class, () -> client.getData().forPath(path1));
+            assertArrayEquals(data2, client.getData().decompressed().forPath(path2));
+            assertArrayEquals(data2, client.getData().forPath(path2));
+            assertArrayEquals(gzipedData2, client.getData().undecompressed().forPath(path2));
         } finally {
             CloseableUtils.closeQuietly(client);
         }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionOld.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCompressionInTransactionOld.java
@@ -184,7 +184,7 @@ public class TestCompressionInTransactionOld extends BaseClassForTests {
         CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
                 .retryPolicy(new RetryOneTime(1))
-                .enableGlobalCompression()
+                .enableCompression()
                 .build();
         try {
             client.start();

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncGetDataBuilder.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncGetDataBuilder.java
@@ -34,6 +34,14 @@ public interface AsyncGetDataBuilder extends AsyncPathable<AsyncStage<byte[]>> {
     AsyncPathable<AsyncStage<byte[]>> decompressed();
 
     /**
+     * Cause the data to not be de-compressed, even if the {@link org.apache.curator.framework.CuratorFramework}
+     * has compressionEnabled
+     *
+     * @return this
+     */
+    AsyncPathable<AsyncStage<byte[]>> undecompressed();
+
+    /**
      * Have the operation fill the provided stat object
      *
      * @param stat the stat to have filled in
@@ -50,4 +58,14 @@ public interface AsyncGetDataBuilder extends AsyncPathable<AsyncStage<byte[]>> {
      * @return this
      */
     AsyncPathable<AsyncStage<byte[]>> decompressedStoringStatIn(Stat stat);
+
+    /**
+     * Have the operation fill the provided stat object without the data being de-compressed
+     *
+     * @param stat the stat to have filled in
+     * @see #undecompressed()
+     * @see #storingStatIn(org.apache.zookeeper.data.Stat)
+     * @return this
+     */
+    AsyncPathable<AsyncStage<byte[]>> undecompressedStoringStatIn(Stat stat);
 }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncSetDataBuilder.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncSetDataBuilder.java
@@ -34,6 +34,14 @@ public interface AsyncSetDataBuilder extends AsyncPathAndBytesable<AsyncStage<St
     AsyncPathAndBytesable<AsyncStage<Stat>> compressed();
 
     /**
+     * Cause the data to be uncompressed, even if the {@link org.apache.curator.framework.CuratorFramework}
+     * has compressionEnabled
+     *
+     * @return this
+     */
+    AsyncPathAndBytesable<AsyncStage<Stat>> uncompressed();
+
+    /**
      * Cause the data to be compressed using the configured compression provider.
      * Only sets if the version matches. By default -1 is used
      * which matches all versions.
@@ -42,6 +50,16 @@ public interface AsyncSetDataBuilder extends AsyncPathAndBytesable<AsyncStage<St
      * @return this
      */
     AsyncPathAndBytesable<AsyncStage<Stat>> compressedWithVersion(int version);
+
+    /**
+     * Cause the data to be uncompressed, even if the {@link org.apache.curator.framework.CuratorFramework}
+     * has compressionEnabled. Only sets if the version matches. By default -1 is used
+     * which matches all versions.
+     *
+     * @param version version
+     * @return this
+     */
+    AsyncPathAndBytesable<AsyncStage<Stat>> uncompressedWithVersion(int version);
 
     /**
      * Only sets if the version matches. By default -1 is used

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncTransactionCreateBuilder.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncTransactionCreateBuilder.java
@@ -82,7 +82,7 @@ public interface AsyncTransactionCreateBuilder extends AsyncPathAndBytesable<Cur
      * @see #compressed()
      * @return this
      */
-    AsyncPathAndBytesable<CuratorOp> withOptions(CreateMode createMode, List<ACL> aclList, Boolean compressed);
+    AsyncPathAndBytesable<CuratorOp> withOptions(CreateMode createMode, List<ACL> aclList, boolean compressed);
 
     /**
      * Specify mode, acl list, compression and ttl
@@ -97,5 +97,5 @@ public interface AsyncTransactionCreateBuilder extends AsyncPathAndBytesable<Cur
      * @return this
      */
     AsyncPathAndBytesable<CuratorOp> withOptions(
-            CreateMode createMode, List<ACL> aclList, Boolean compressed, long ttl);
+            CreateMode createMode, List<ACL> aclList, boolean compressed, long ttl);
 }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncTransactionCreateBuilder.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncTransactionCreateBuilder.java
@@ -52,6 +52,14 @@ public interface AsyncTransactionCreateBuilder extends AsyncPathAndBytesable<Cur
     AsyncPathAndBytesable<CuratorOp> compressed();
 
     /**
+     * Cause the data to be uncompressed, even if the {@link org.apache.curator.framework.CuratorFramework}
+     * has compressionEnabled
+     *
+     * @return this
+     */
+    AsyncPathAndBytesable<CuratorOp> uncompressed();
+
+    /**
      * Specify a TTL when mode is {@link org.apache.zookeeper.CreateMode#PERSISTENT_WITH_TTL} or
      * {@link org.apache.zookeeper.CreateMode#PERSISTENT_SEQUENTIAL_WITH_TTL}. If
      * the znode has not been modified within the given TTL, it will be deleted once it has no
@@ -74,7 +82,7 @@ public interface AsyncTransactionCreateBuilder extends AsyncPathAndBytesable<Cur
      * @see #compressed()
      * @return this
      */
-    AsyncPathAndBytesable<CuratorOp> withOptions(CreateMode createMode, List<ACL> aclList, boolean compressed);
+    AsyncPathAndBytesable<CuratorOp> withOptions(CreateMode createMode, List<ACL> aclList, Boolean compressed);
 
     /**
      * Specify mode, acl list, compression and ttl
@@ -89,5 +97,5 @@ public interface AsyncTransactionCreateBuilder extends AsyncPathAndBytesable<Cur
      * @return this
      */
     AsyncPathAndBytesable<CuratorOp> withOptions(
-            CreateMode createMode, List<ACL> aclList, boolean compressed, long ttl);
+            CreateMode createMode, List<ACL> aclList, Boolean compressed, long ttl);
 }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncTransactionSetDataBuilder.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/api/AsyncTransactionSetDataBuilder.java
@@ -41,6 +41,14 @@ public interface AsyncTransactionSetDataBuilder extends AsyncPathAndBytesable<Cu
     AsyncPathAndBytesable<CuratorOp> compressed();
 
     /**
+     * Cause the data to be uncompressed, even if the {@link org.apache.curator.framework.CuratorFramework}
+     * has compressionEnabled
+     *
+     * @return this
+     */
+    AsyncPathAndBytesable<CuratorOp> uncompressed();
+
+    /**
      * Cause the data to be compressed using the configured compression provider.
      * Also changes the version number used. By default, -1 is used
      *
@@ -48,4 +56,13 @@ public interface AsyncTransactionSetDataBuilder extends AsyncPathAndBytesable<Cu
      * @return this
      */
     AsyncPathAndBytesable<CuratorOp> withVersionCompressed(int version);
+
+    /**
+     * Cause the data to be uncompressed, even if the {@link org.apache.curator.framework.CuratorFramework}
+     * has compressionEnabled. Also changes the version number used. By default, -1 is used
+     *
+     * @param version version to use
+     * @return this
+     */
+    AsyncPathAndBytesable<CuratorOp> withVersionUncompressed(int version);
 }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/api/CreateOption.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/api/CreateOption.java
@@ -70,6 +70,11 @@ public enum CreateOption {
     compress,
 
     /**
+     * Cause the data to be uncompressed
+     */
+    uncompress,
+
+    /**
      * If the ZNode already exists, Curator will instead call setData()
      */
     setDataIfExists

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCreateBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCreateBuilderImpl.java
@@ -167,7 +167,9 @@ class AsyncCreateBuilderImpl implements AsyncCreateBuilder {
                         || options.contains(CreateOption.createParentsAsContainers),
                 options.contains(CreateOption.createParentsAsContainers),
                 options.contains(CreateOption.doProtected),
-                options.contains(CreateOption.compress) ? true : options.contains(CreateOption.uncompress) ? false : client.compressionEnabled(),
+                options.contains(CreateOption.compress)
+                        ? true
+                        : options.contains(CreateOption.uncompress) ? false : client.compressionEnabled(),
                 options.contains(CreateOption.setDataIfExists),
                 aclList,
                 stat,

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCreateBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCreateBuilderImpl.java
@@ -167,7 +167,7 @@ class AsyncCreateBuilderImpl implements AsyncCreateBuilder {
                         || options.contains(CreateOption.createParentsAsContainers),
                 options.contains(CreateOption.createParentsAsContainers),
                 options.contains(CreateOption.doProtected),
-                options.contains(CreateOption.compress),
+                options.contains(CreateOption.compress) ? true : options.contains(CreateOption.uncompress) ? false : client.compressionEnabled(),
                 options.contains(CreateOption.setDataIfExists),
                 aclList,
                 stat,

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetDataBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetDataBuilderImpl.java
@@ -33,18 +33,25 @@ class AsyncGetDataBuilderImpl implements AsyncGetDataBuilder {
     private final CuratorFrameworkImpl client;
     private final Filters filters;
     private final WatchMode watchMode;
-    private boolean decompressed = false;
+    private boolean decompressed;
     private Stat stat = null;
 
     AsyncGetDataBuilderImpl(CuratorFrameworkImpl client, Filters filters, WatchMode watchMode) {
         this.client = client;
         this.filters = filters;
         this.watchMode = watchMode;
+        this.decompressed = client.compressionEnabled();
     }
 
     @Override
     public AsyncPathable<AsyncStage<byte[]>> decompressed() {
         decompressed = true;
+        return this;
+    }
+
+    @Override
+    public AsyncPathable<AsyncStage<byte[]>> undecompressed() {
+        decompressed = false;
         return this;
     }
 
@@ -57,6 +64,13 @@ class AsyncGetDataBuilderImpl implements AsyncGetDataBuilder {
     @Override
     public AsyncPathable<AsyncStage<byte[]>> decompressedStoringStatIn(Stat stat) {
         decompressed = true;
+        this.stat = stat;
+        return this;
+    }
+
+    @Override
+    public AsyncPathable<AsyncStage<byte[]>> undecompressedStoringStatIn(Stat stat) {
+        decompressed = false;
         this.stat = stat;
         return this;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncSetDataBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncSetDataBuilderImpl.java
@@ -31,12 +31,13 @@ import org.apache.zookeeper.data.Stat;
 class AsyncSetDataBuilderImpl implements AsyncSetDataBuilder {
     private final CuratorFrameworkImpl client;
     private final Filters filters;
-    private boolean compressed = false;
+    private boolean compressed;
     private int version = -1;
 
     AsyncSetDataBuilderImpl(CuratorFrameworkImpl client, Filters filters) {
         this.client = client;
         this.filters = filters;
+        this.compressed = client.compressionEnabled();
     }
 
     @Override
@@ -56,8 +57,21 @@ class AsyncSetDataBuilderImpl implements AsyncSetDataBuilder {
     }
 
     @Override
+    public AsyncPathAndBytesable<AsyncStage<Stat>> uncompressed() {
+        compressed = false;
+        return this;
+    }
+
+    @Override
     public AsyncPathAndBytesable<AsyncStage<Stat>> compressedWithVersion(int version) {
         compressed = true;
+        this.version = version;
+        return this;
+    }
+
+    @Override
+    public AsyncPathAndBytesable<AsyncStage<Stat>> uncompressedWithVersion(int version) {
+        compressed = false;
         this.version = version;
         return this;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
@@ -199,7 +199,8 @@ class AsyncTransactionOpImpl implements AsyncTransactionOp {
             private CuratorOp internalForPath(String path, byte[] data, boolean useData) {
                 TransactionSetDataBuilder<CuratorOp> builder1 =
                         client.transactionOp().setData();
-                VersionPathAndBytesable<CuratorOp> builder2 = compressed ? builder1.compressed() : builder1;
+                VersionPathAndBytesable<CuratorOp> builder2 =
+                        compressed ? builder1.compressed() : builder1.uncompressed();
                 PathAndBytesable<CuratorOp> builder3 = builder2.withVersion(version);
                 try {
                     return useData ? builder3.forPath(path, data) : builder3.forPath(path);

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
@@ -117,8 +117,9 @@ class AsyncTransactionOpImpl implements AsyncTransactionOp {
                 TransactionCreateBuilder2<CuratorOp> builder1 = (ttl > 0)
                         ? client.transactionOp().create().withTtl(ttl)
                         : client.transactionOp().create();
-                ACLPathAndBytesable<CuratorOp> builder2 =
-                        compressed ? builder1.compressed().withMode(createMode) : builder1.uncompressed().withMode(createMode);
+                ACLPathAndBytesable<CuratorOp> builder2 = compressed
+                        ? builder1.compressed().withMode(createMode)
+                        : builder1.uncompressed().withMode(createMode);
                 PathAndBytesable<CuratorOp> builder3 = builder2.withACL(aclList);
                 try {
                     return useData ? builder3.forPath(path, data) : builder3.forPath(path);

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
@@ -85,20 +85,16 @@ class AsyncTransactionOpImpl implements AsyncTransactionOp {
 
             @Override
             public AsyncPathAndBytesable<CuratorOp> withOptions(
-                    CreateMode createMode, List<ACL> aclList, Boolean compressed) {
+                    CreateMode createMode, List<ACL> aclList, boolean compressed) {
                 return withOptions(createMode, aclList, compressed, ttl);
             }
 
             @Override
             public AsyncPathAndBytesable<CuratorOp> withOptions(
-                    CreateMode createMode, List<ACL> aclList, Boolean compressed, long ttl) {
+                    CreateMode createMode, List<ACL> aclList, boolean compressed, long ttl) {
                 this.createMode = Objects.requireNonNull(createMode, "createMode cannot be null");
                 this.aclList = aclList;
-                if (compressed == Boolean.TRUE) {
-                    this.compressed = true;
-                } else if (compressed == Boolean.FALSE) {
-                    this.compressed = false;
-                }
+                this.compressed = compressed;
                 this.ttl = ttl;
                 return this;
             }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
@@ -213,8 +213,15 @@ public class ModeledFrameworkImpl<T> implements ModeledFramework<T> {
         try {
             byte[] bytes = modelSpec.serializer().serialize(item);
             AsyncSetDataBuilder dataBuilder = dslClient.setData();
-            AsyncPathAndBytesable<AsyncStage<Stat>> next =
-                    isCompressed() ? dataBuilder.compressedWithVersion(version) : dataBuilder.withVersion(version);
+            AsyncPathAndBytesable<AsyncStage<Stat>> next;
+            Boolean isCompressed = isCompressed();
+            if (isCompressed == Boolean.TRUE) {
+                next = dataBuilder.compressedWithVersion(version);
+            } else if (isCompressed == Boolean.FALSE) {
+                next = dataBuilder.uncompressedWithVersion(version);
+            } else {
+                next = dataBuilder.withVersion(version);
+            }
             return next.forPath(resolveForSet(item), bytes);
         } catch (Exception e) {
             return ModelStage.exceptionally(e);
@@ -355,7 +362,7 @@ public class ModeledFrameworkImpl<T> implements ModeledFramework<T> {
                 .withOptions(
                         modelSpec.createMode(),
                         fixAclList(modelSpec.aclList()),
-                        modelSpec.createOptions().contains(CreateOption.compress),
+                        isCompressed(),
                         modelSpec.ttl())
                 .forPath(resolveForSet(model), modelSpec.serializer().serialize(model));
     }
@@ -368,12 +375,16 @@ public class ModeledFrameworkImpl<T> implements ModeledFramework<T> {
     @Override
     public CuratorOp updateOp(T model, int version) {
         AsyncTransactionSetDataBuilder builder = client.transactionOp().setData();
-        if (isCompressed()) {
-            return builder.withVersionCompressed(version)
-                    .forPath(resolveForSet(model), modelSpec.serializer().serialize(model));
+        Boolean isCompressed = isCompressed();
+        AsyncPathAndBytesable<CuratorOp> builder2;
+        if (isCompressed == Boolean.TRUE) {
+            builder2 = builder.withVersionCompressed(version);
+        } else if (isCompressed == Boolean.FALSE) {
+            builder2 = builder.withVersionUncompressed(version);
+        } else {
+            builder2 = builder.withVersion(version);
         }
-        return builder.withVersion(version)
-                .forPath(resolveForSet(model), modelSpec.serializer().serialize(model));
+        return builder2.forPath(resolveForSet(model), modelSpec.serializer().serialize(model));
     }
 
     @Override
@@ -407,15 +418,27 @@ public class ModeledFrameworkImpl<T> implements ModeledFramework<T> {
         return client.transaction().forOperations(operations);
     }
 
-    private boolean isCompressed() {
-        return modelSpec.createOptions().contains(CreateOption.compress);
+    private Boolean isCompressed() {
+        if (modelSpec.createOptions().contains(CreateOption.compress)) {
+            return Boolean.TRUE;
+        } else if (modelSpec.createOptions().contains(CreateOption.uncompress)) {
+            return Boolean.FALSE;
+        } else {
+            return null;
+        }
     }
 
     private <U> ModelStage<U> internalRead(Function<ZNode<T>, U> resolver, Stat storingStatIn) {
         Stat stat = (storingStatIn != null) ? storingStatIn : new Stat();
-        AsyncPathable<AsyncStage<byte[]>> next = isCompressed()
-                ? watchableClient.getData().decompressedStoringStatIn(stat)
-                : watchableClient.getData().storingStatIn(stat);
+        AsyncPathable<AsyncStage<byte[]>> next;
+        Boolean isCompressed = isCompressed();
+        if (isCompressed == Boolean.TRUE) {
+            next = watchableClient.getData().decompressedStoringStatIn(stat);
+        } else if (isCompressed == Boolean.FALSE) {
+            next = watchableClient.getData().undecompressedStoringStatIn(stat);
+        } else {
+            next = watchableClient.getData().storingStatIn(stat);
+        }
         AsyncStage<byte[]> asyncStage = next.forPath(modelSpec.path().fullPath());
         ModelStage<U> modelStage = ModelStage.make(asyncStage.event());
         asyncStage.whenComplete((value, e) -> {

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
@@ -359,11 +359,7 @@ public class ModeledFrameworkImpl<T> implements ModeledFramework<T> {
     public CuratorOp createOp(T model) {
         return client.transactionOp()
                 .create()
-                .withOptions(
-                        modelSpec.createMode(),
-                        fixAclList(modelSpec.aclList()),
-                        isCompressed(),
-                        modelSpec.ttl())
+                .withOptions(modelSpec.createMode(), fixAclList(modelSpec.aclList()), isCompressed(), modelSpec.ttl())
                 .forPath(resolveForSet(model), modelSpec.serializer().serialize(model));
     }
 

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestModeledFramework.java
@@ -300,4 +300,442 @@ public class TestModeledFramework extends TestModeledFrameworkBase {
             assertTrue(e.getCause() instanceof KeeperException.NoAuthException);
         }
     }
+
+    @Test
+    public void testCompressedCreateAndRead() throws Exception {
+        try (CuratorFramework compressedRawClient =
+                createRawClientBuilder().enableCompression().build()) {
+            compressedRawClient.start();
+            AsyncCuratorFramework compressedAsync = AsyncCuratorFramework.wrap(compressedRawClient);
+            TestModel rawModel = new TestModel("John", "Galt", "1 Galt's Gulch", 42, BigInteger.valueOf(1));
+
+            // These should be compressed
+            ModeledFramework<TestModel> clientWithCompressedFramework =
+                    ModeledFramework.wrap(compressedAsync, modelSpec);
+            ModeledFramework<TestModel> clientWithCompressedModel = ModeledFramework.wrap(async, compressedModelSpec);
+
+            // These should be uncompressed
+            ModeledFramework<TestModel> client = ModeledFramework.wrap(async, modelSpec);
+            ModeledFramework<TestModel> clientWithUncompressedModel =
+                    ModeledFramework.wrap(async, uncompressedModelSpec);
+            ModeledFramework<TestModel> clientWithCompressedFrameworkAndUncompressedModel =
+                    ModeledFramework.wrap(compressedAsync, uncompressedModelSpec);
+
+            // Create with compressedFramework, read with all other clients
+            complete(clientWithCompressedFramework.set(rawModel), (path, e) -> assertNull(e));
+            complete(clientWithCompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(client.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithCompressedFrameworkAndUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            clientWithCompressedFramework.delete();
+
+            // Create with compressedModel, read with all other clients
+            complete(clientWithCompressedModel.set(rawModel), (path, e) -> assertNull(e));
+            complete(clientWithCompressedFramework.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(client.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithCompressedFrameworkAndUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            clientWithCompressedModel.delete();
+
+            // Create with regular (implicitly uncompressed) client, read with all other clients
+            complete(client.set(rawModel), (path, e) -> assertNull(e));
+            complete(clientWithUncompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(
+                    clientWithCompressedFrameworkAndUncompressedModel.read(),
+                    (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            client.delete();
+
+            // Create with uncompressedModel, read with all other clients
+            complete(clientWithUncompressedModel.set(rawModel), (path, e) -> assertNull(e));
+            complete(client.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(
+                    clientWithCompressedFrameworkAndUncompressedModel.read(),
+                    (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            clientWithUncompressedModel.delete();
+
+            // Create with compressedFramework overriden by an uncompressedModel, read with all other clients
+            complete(clientWithCompressedFrameworkAndUncompressedModel.set(rawModel), (path, e) -> assertNull(e));
+            complete(client.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithUncompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            clientWithCompressedFrameworkAndUncompressedModel.delete();
+        }
+    }
+
+    @Test
+    public void testCompressedUpdateAndRead() throws Exception {
+        try (CuratorFramework compressedRawClient =
+                createRawClientBuilder().enableCompression().build()) {
+            compressedRawClient.start();
+            AsyncCuratorFramework compressedAsync = AsyncCuratorFramework.wrap(compressedRawClient);
+            TestModel rawModel = new TestModel("John", "Galt", "1 Galt's Gulch", 42, BigInteger.valueOf(1));
+
+            // These should be compressed
+            ModeledFramework<TestModel> clientWithCompressedFramework =
+                    ModeledFramework.wrap(compressedAsync, modelSpec);
+            ModeledFramework<TestModel> clientWithCompressedModel = ModeledFramework.wrap(async, compressedModelSpec);
+
+            // These should be uncompressed
+            ModeledFramework<TestModel> client = ModeledFramework.wrap(async, modelSpec);
+            ModeledFramework<TestModel> clientWithUncompressedModel =
+                    ModeledFramework.wrap(async, uncompressedModelSpec);
+            ModeledFramework<TestModel> clientWithCompressedFrameworkAndUncompressedModel =
+                    ModeledFramework.wrap(compressedAsync, uncompressedModelSpec);
+
+            // Create the node - so we can update in each command
+            complete(client.set(rawModel), (model, e) -> assertNull(e));
+
+            // Update with compressedFramework, read with all other clients
+            complete(clientWithCompressedFramework.update(rawModel), (stat, e) -> assertNull(e));
+            complete(clientWithCompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(client.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithCompressedFrameworkAndUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+
+            // Update with compressedModel, read with all other clients
+            complete(clientWithCompressedModel.update(rawModel), (stat, e) -> assertNull(e));
+            complete(clientWithCompressedFramework.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(client.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithCompressedFrameworkAndUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+
+            // Update with regular (implicitly uncompressed) client, read with all other clients
+            complete(client.update(rawModel), (stat, e) -> assertNull(e));
+            complete(clientWithUncompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(
+                    clientWithCompressedFrameworkAndUncompressedModel.read(),
+                    (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+
+            // Update with uncompressedModel, read with all other clients
+            complete(clientWithUncompressedModel.update(rawModel), (stat, e) -> assertNull(e));
+            complete(client.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(
+                    clientWithCompressedFrameworkAndUncompressedModel.read(),
+                    (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+
+            // Update with compressedFramework overriden by an uncompressedModel, read with all other clients
+            complete(clientWithCompressedFrameworkAndUncompressedModel.update(rawModel), (stat, e) -> assertNull(e));
+            complete(client.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithUncompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+        }
+    }
+
+    @Test
+    public void testCompressedCreateOp() throws Exception {
+        try (CuratorFramework compressedRawClient =
+                createRawClientBuilder().enableCompression().build()) {
+            compressedRawClient.start();
+            AsyncCuratorFramework compressedAsync = AsyncCuratorFramework.wrap(compressedRawClient);
+            TestModel rawModel = new TestModel("John", "Galt", "1 Galt's Gulch", 42, BigInteger.valueOf(1));
+
+            // These should be compressed
+            ModeledFramework<TestModel> clientWithCompressedFramework =
+                    ModeledFramework.wrap(compressedAsync, modelSpec);
+            ModeledFramework<TestModel> clientWithCompressedModel = ModeledFramework.wrap(async, compressedModelSpec);
+
+            // These should be uncompressed
+            ModeledFramework<TestModel> client = ModeledFramework.wrap(async, modelSpec);
+            ModeledFramework<TestModel> clientWithUncompressedModel =
+                    ModeledFramework.wrap(async, uncompressedModelSpec);
+            ModeledFramework<TestModel> clientWithCompressedFrameworkAndUncompressedModel =
+                    ModeledFramework.wrap(compressedAsync, uncompressedModelSpec);
+
+            // Make sure the parent node(s) exist
+            rawClient
+                    .create()
+                    .creatingParentsIfNeeded()
+                    .forPath(modelSpec.path().parent().fullPath());
+
+            // Create with compressedFramework, read with all other clients
+            complete(
+                    clientWithCompressedFramework.inTransaction(
+                            Collections.singletonList(clientWithCompressedFramework.createOp(rawModel))),
+                    (results, e) -> assertNull(e));
+            complete(clientWithCompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(client.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithCompressedFrameworkAndUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            clientWithCompressedFramework.delete();
+
+            // Create with compressedModel, read with all other clients
+            complete(
+                    clientWithCompressedModel.inTransaction(
+                            Collections.singletonList(clientWithCompressedModel.createOp(rawModel))),
+                    (results, e) -> assertNull(e));
+            complete(clientWithCompressedFramework.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(client.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithCompressedFrameworkAndUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            clientWithCompressedModel.delete();
+
+            // Create with regular (implicitly uncompressed) client, read with all other clients
+            complete(
+                    client.inTransaction(Collections.singletonList(client.createOp(rawModel))),
+                    (results, e) -> assertNull(e));
+            complete(clientWithUncompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(
+                    clientWithCompressedFrameworkAndUncompressedModel.read(),
+                    (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            client.delete();
+
+            // Create with uncompressedModel, read with all other clients
+            complete(
+                    clientWithUncompressedModel.inTransaction(
+                            Collections.singletonList(clientWithUncompressedModel.createOp(rawModel))),
+                    (results, e) -> assertNull(e));
+            complete(client.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(
+                    clientWithCompressedFrameworkAndUncompressedModel.read(),
+                    (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            clientWithUncompressedModel.delete();
+
+            // Create with compressedFramework overriden by an uncompressedModel, read with all other clients
+            complete(
+                    clientWithCompressedFrameworkAndUncompressedModel.inTransaction(Collections.singletonList(
+                            clientWithCompressedFrameworkAndUncompressedModel.createOp(rawModel))),
+                    (results, e) -> assertNull(e));
+            complete(client.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithUncompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            clientWithCompressedFrameworkAndUncompressedModel.delete();
+        }
+    }
+
+    @Test
+    public void testCompressedUpdateOp() throws Exception {
+        try (CuratorFramework compressedRawClient =
+                createRawClientBuilder().enableCompression().build()) {
+            compressedRawClient.start();
+            AsyncCuratorFramework compressedAsync = AsyncCuratorFramework.wrap(compressedRawClient);
+            TestModel rawModel = new TestModel("John", "Galt", "1 Galt's Gulch", 42, BigInteger.valueOf(1));
+
+            // These should be compressed
+            ModeledFramework<TestModel> clientWithCompressedFramework =
+                    ModeledFramework.wrap(compressedAsync, modelSpec);
+            ModeledFramework<TestModel> clientWithCompressedModel = ModeledFramework.wrap(async, compressedModelSpec);
+
+            // These should be uncompressed
+            ModeledFramework<TestModel> client = ModeledFramework.wrap(async, modelSpec);
+            ModeledFramework<TestModel> clientWithUncompressedModel =
+                    ModeledFramework.wrap(async, uncompressedModelSpec);
+            ModeledFramework<TestModel> clientWithCompressedFrameworkAndUncompressedModel =
+                    ModeledFramework.wrap(compressedAsync, uncompressedModelSpec);
+
+            // Create the node - so we can update in each command
+            complete(client.set(rawModel), (model, e) -> assertNull(e));
+
+            // Update with compressedFramework, read with all other clients
+            complete(
+                    clientWithCompressedFramework.inTransaction(
+                            Collections.singletonList(clientWithCompressedFramework.updateOp(rawModel))),
+                    (results, e) -> assertNull(e));
+            complete(clientWithCompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(client.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithCompressedFrameworkAndUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+
+            // Update with compressedModel, read with all other clients
+            complete(
+                    clientWithCompressedModel.inTransaction(
+                            Collections.singletonList(clientWithCompressedModel.updateOp(rawModel))),
+                    (results, e) -> assertNull(e));
+            complete(clientWithCompressedFramework.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(client.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+            complete(clientWithCompressedFrameworkAndUncompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(RuntimeException.class, e.getClass());
+            });
+
+            // Update with regular (implicitly uncompressed) client, read with all other clients
+            complete(
+                    client.inTransaction(Collections.singletonList(client.updateOp(rawModel))),
+                    (results, e) -> assertNull(e));
+            complete(clientWithUncompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(
+                    clientWithCompressedFrameworkAndUncompressedModel.read(),
+                    (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+
+            // Update with uncompressedModel, read with all other clients
+            complete(
+                    clientWithUncompressedModel.inTransaction(
+                            Collections.singletonList(clientWithUncompressedModel.updateOp(rawModel))),
+                    (results, e) -> assertNull(e));
+            complete(client.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(
+                    clientWithCompressedFrameworkAndUncompressedModel.read(),
+                    (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+
+            // Update with compressedFramework overriden by an uncompressedModel, read with all other clients
+            complete(
+                    clientWithCompressedFrameworkAndUncompressedModel.inTransaction(Collections.singletonList(
+                            clientWithCompressedFrameworkAndUncompressedModel.updateOp(rawModel))),
+                    (results, e) -> assertNull(e));
+            complete(client.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithUncompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
+            complete(clientWithCompressedModel.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+            complete(clientWithCompressedFramework.read(), (model, e) -> {
+                assertNotNull(e);
+                assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
+            });
+        }
+    }
 }

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestModeledFramework.java
@@ -336,9 +336,9 @@ public class TestModeledFramework extends TestModeledFrameworkBase {
                 assertNotNull(e);
                 assertEquals(RuntimeException.class, e.getClass());
             });
-            clientWithCompressedFramework.delete();
 
             // Create with compressedModel, read with all other clients
+            clientWithCompressedModel.delete();
             complete(clientWithCompressedModel.set(rawModel), (path, e) -> assertNull(e));
             complete(clientWithCompressedFramework.read(), (model, e) -> assertEquals(model, rawModel));
             complete(client.read(), (model, e) -> {
@@ -353,9 +353,9 @@ public class TestModeledFramework extends TestModeledFrameworkBase {
                 assertNotNull(e);
                 assertEquals(RuntimeException.class, e.getClass());
             });
-            clientWithCompressedModel.delete();
 
             // Create with regular (implicitly uncompressed) client, read with all other clients
+            client.delete();
             complete(client.set(rawModel), (path, e) -> assertNull(e));
             complete(clientWithUncompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
             complete(
@@ -369,9 +369,9 @@ public class TestModeledFramework extends TestModeledFrameworkBase {
                 assertNotNull(e);
                 assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
             });
-            client.delete();
 
             // Create with uncompressedModel, read with all other clients
+            clientWithUncompressedModel.delete();
             complete(clientWithUncompressedModel.set(rawModel), (path, e) -> assertNull(e));
             complete(client.read(), (model, e) -> assertEquals(model, rawModel));
             complete(
@@ -385,9 +385,9 @@ public class TestModeledFramework extends TestModeledFrameworkBase {
                 assertNotNull(e);
                 assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
             });
-            clientWithUncompressedModel.delete();
 
             // Create with compressedFramework overriden by an uncompressedModel, read with all other clients
+            clientWithCompressedFrameworkAndUncompressedModel.delete();
             complete(clientWithCompressedFrameworkAndUncompressedModel.set(rawModel), (path, e) -> assertNull(e));
             complete(client.read(), (model, e) -> assertEquals(model, rawModel));
             complete(clientWithUncompressedModel.read(), (model, e) -> assertEquals(model, rawModel));
@@ -547,9 +547,9 @@ public class TestModeledFramework extends TestModeledFrameworkBase {
                 assertNotNull(e);
                 assertEquals(RuntimeException.class, e.getClass());
             });
-            clientWithCompressedFramework.delete();
 
             // Create with compressedModel, read with all other clients
+            clientWithCompressedModel.delete();
             complete(
                     clientWithCompressedModel.inTransaction(
                             Collections.singletonList(clientWithCompressedModel.createOp(rawModel))),
@@ -567,9 +567,9 @@ public class TestModeledFramework extends TestModeledFrameworkBase {
                 assertNotNull(e);
                 assertEquals(RuntimeException.class, e.getClass());
             });
-            clientWithCompressedModel.delete();
 
             // Create with regular (implicitly uncompressed) client, read with all other clients
+            client.delete();
             complete(
                     client.inTransaction(Collections.singletonList(client.createOp(rawModel))),
                     (results, e) -> assertNull(e));
@@ -585,9 +585,9 @@ public class TestModeledFramework extends TestModeledFrameworkBase {
                 assertNotNull(e);
                 assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
             });
-            client.delete();
 
             // Create with uncompressedModel, read with all other clients
+            clientWithUncompressedModel.delete();
             complete(
                     clientWithUncompressedModel.inTransaction(
                             Collections.singletonList(clientWithUncompressedModel.createOp(rawModel))),
@@ -604,9 +604,9 @@ public class TestModeledFramework extends TestModeledFrameworkBase {
                 assertNotNull(e);
                 assertEquals(KeeperException.DataInconsistencyException.class, e.getClass());
             });
-            clientWithUncompressedModel.delete();
 
             // Create with compressedFramework overriden by an uncompressedModel, read with all other clients
+            clientWithCompressedFrameworkAndUncompressedModel.delete();
             complete(
                     clientWithCompressedFrameworkAndUncompressedModel.inTransaction(Collections.singletonList(
                             clientWithCompressedFrameworkAndUncompressedModel.createOp(rawModel))),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CURATOR-725

Allow users to use a CuratorFramework setting to enable compression on all create/setData/getData requests. When using this flag with a custom `CompressionProvider`, this can easily allow for a filtered compression implementation.