### PR TITLE
CURATOR-726: Improve tracing for certain operations

### DIFF
--- a/curator-client/src/main/java/org/apache/curator/drivers/OperationTrace.java
+++ b/curator-client/src/main/java/org/apache/curator/drivers/OperationTrace.java
@@ -36,7 +36,7 @@ public class OperationTrace {
     private int requestTransactionCount;
     private long requestBytesLength;
     private long responseBytesLength;
-    private int responseChildrenCount;
+    private int responseChildrenCount = -1;
     private String path;
     private boolean withWatcher;
     private long sessionId;

--- a/curator-client/src/main/java/org/apache/curator/drivers/OperationTrace.java
+++ b/curator-client/src/main/java/org/apache/curator/drivers/OperationTrace.java
@@ -33,8 +33,10 @@ public class OperationTrace {
 
     private int returnCode = KeeperException.Code.OK.intValue();
     private long latencyMs;
+    private int requestTransactionCount;
     private long requestBytesLength;
     private long responseBytesLength;
+    private int responseChildrenCount;
     private String path;
     private boolean withWatcher;
     private long sessionId;
@@ -54,6 +56,11 @@ public class OperationTrace {
 
     public OperationTrace setReturnCode(int returnCode) {
         this.returnCode = returnCode;
+        return this;
+    }
+
+    public OperationTrace setRequestTransactionCount(int transactionCount) {
+        this.requestTransactionCount = transactionCount;
         return this;
     }
 
@@ -97,6 +104,11 @@ public class OperationTrace {
         return this.setResponseBytesLength(data.length);
     }
 
+    public OperationTrace setResponseChildrenCount(int responseChildrenCount) {
+        this.responseChildrenCount = responseChildrenCount;
+        return this;
+    }
+
     public OperationTrace setPath(String path) {
         this.path = path;
         return this;
@@ -124,12 +136,20 @@ public class OperationTrace {
         return this.latencyMs;
     }
 
+    public int getRequestTransactionCount() {
+        return this.requestTransactionCount;
+    }
+
     public long getRequestBytesLength() {
         return this.requestBytesLength;
     }
 
     public long getResponseBytesLength() {
         return this.responseBytesLength;
+    }
+
+    public int getResponseChildrenCount() {
+        return this.responseChildrenCount;
     }
 
     public long getSessionId() {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
@@ -113,7 +113,7 @@ class CuratorEventImpl implements CuratorEvent {
                 + opResults + '}';
     }
 
-    oCuratorEventImpl(
+    CuratorEventImpl(
             CuratorFrameworkImpl client,
             CuratorEventType type,
             int resultCode,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
@@ -113,7 +113,7 @@ class CuratorEventImpl implements CuratorEvent {
                 + opResults + '}';
     }
 
-    CuratorEventImpl(
+    oCuratorEventImpl(
             CuratorFrameworkImpl client,
             CuratorEventType type,
             int resultCode,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
@@ -165,14 +165,11 @@ public class GetChildrenBuilderImpl
                 @Override
                 public void processResult(int rc, String path, Object o, List<String> strings, Stat stat) {
                     watching.commitWatcher(rc, false);
-                    if (strings == null) {
-                        strings = Lists.newArrayList();
-                    }
                     trace.setReturnCode(rc)
                             .setPath(path)
                             .setWithWatcher(watching.hasWatcher())
                             .setStat(stat)
-                            .setResponseChildrenCount(strings.size())
+                            .setResponseChildrenCount(strings != null ? strings.size() : 0)
                             .commit();
                     CuratorEventImpl event = new CuratorEventImpl(
                             client,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
@@ -165,14 +165,15 @@ public class GetChildrenBuilderImpl
                 @Override
                 public void processResult(int rc, String path, Object o, List<String> strings, Stat stat) {
                     watching.commitWatcher(rc, false);
+                    if (strings == null) {
+                        strings = Lists.newArrayList();
+                    }
                     trace.setReturnCode(rc)
                             .setPath(path)
                             .setWithWatcher(watching.hasWatcher())
                             .setStat(stat)
+                            .setResponseChildrenCount(strings.size())
                             .commit();
-                    if (strings == null) {
-                        strings = Lists.newArrayList();
-                    }
                     CuratorEventImpl event = new CuratorEventImpl(
                             client,
                             CuratorEventType.CHILDREN,
@@ -241,6 +242,7 @@ public class GetChildrenBuilderImpl
         trace.setPath(path)
                 .setWithWatcher(watching.hasWatcher())
                 .setStat(responseStat)
+                .setResponseChildrenCount(children != null ? children.size() : 0)
                 .commit();
         return children;
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
@@ -165,11 +165,14 @@ public class GetChildrenBuilderImpl
                 @Override
                 public void processResult(int rc, String path, Object o, List<String> strings, Stat stat) {
                     watching.commitWatcher(rc, false);
+                    if (strings == null) {
+                        strings = Lists.newArrayList();
+                    }
                     trace.setReturnCode(rc)
                             .setPath(path)
                             .setWithWatcher(watching.hasWatcher())
                             .setStat(stat)
-                            .setResponseChildrenCount(strings != null ? strings.size() : 0)
+                            .setResponseChildrenCount(strings.size())
                             .commit();
                     CuratorEventImpl event = new CuratorEventImpl(
                             client,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CURATOR-726

In Apache Solr, we are trying to refactor all of our custom ZK interaction logic to use Curator. One of the things we do is implement metrics on our interactions with ZK. Curator allows us to do this with Tracing and CuratorListeners. However there are two things that don't give us the information we need.

1. The "Get Children" command trace does not give the information needed for the number of Children fetched.
2. The "Multi Transaction" command trace:
    - The trace does not give the number of commands that are in the transaction, which is something we track currently.
    - The MultiTransaction trace is not an AdvancedTrace, it's a normal Trace for some reason. AdvancedTracerDrivers cannot read regular traces, so we can't even see these. We need to update Curator to use an AdvancedTrace for this command.

Therefore in this PR, I have added the two pieces of information (# of Children fetched and # of transactions) and also converted the MultiTransaciton to use an AdvancedTrace.