### PR TITLE
hotfix: build scan rejected by ge.apache.org

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -24,7 +24,14 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
-        <version>1.23</version>
+        <!--
+          Make sure the extension version is compatible with server version of https://ge.apache.org/, otherwise CI
+          could pass while build scan rejected. It might be good to fail CI in this case, so we can drop this comment,
+          but I did find an option.
+
+          Refs: https://docs.gradle.com/develocity/compatibility/
+        -->
+        <version>1.22.2</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>


### PR DESCRIPTION
I saw following logs in test phase of https://github.com/apache/curator/actions/runs/12448243386/job/34752620203.

```
[INFO] Publishing build scan...
[INFO] 
[INFO] The request was rejected.
Develocity Maven extension version 1.23 is newer than the newest version supported by Develocity 2024.2.2 which is 1.22. Please update to a newer version of Develocity.
```
