### PR TITLE
CURATOR-718: Refactor CuratorFramework inheritance hierarchy by composing functionalities

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/AddWatchBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/AddWatchBuilderImpl.java
@@ -34,18 +34,18 @@ import org.apache.zookeeper.AddWatchMode;
 import org.apache.zookeeper.Watcher;
 
 public class AddWatchBuilderImpl implements AddWatchBuilder, Pathable<Void>, BackgroundOperation<String> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private Watching watching;
     private Backgrounding backgrounding = new Backgrounding();
     private AddWatchMode mode = AddWatchMode.PERSISTENT_RECURSIVE;
 
-    AddWatchBuilderImpl(CuratorFrameworkImpl client) {
+    AddWatchBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
         watching = new Watching(client, true);
     }
 
     public AddWatchBuilderImpl(
-            CuratorFrameworkImpl client, Watching watching, Backgrounding backgrounding, AddWatchMode mode) {
+            InternalCuratorFramework client, Watching watching, Backgrounding backgrounding, AddWatchMode mode) {
         this.client = client;
         this.watching = watching;
         this.backgrounding = backgrounding;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/AddWatchBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/AddWatchBuilderImpl.java
@@ -34,18 +34,18 @@ import org.apache.zookeeper.AddWatchMode;
 import org.apache.zookeeper.Watcher;
 
 public class AddWatchBuilderImpl implements AddWatchBuilder, Pathable<Void>, BackgroundOperation<String> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private Watching watching;
     private Backgrounding backgrounding = new Backgrounding();
     private AddWatchMode mode = AddWatchMode.PERSISTENT_RECURSIVE;
 
-    AddWatchBuilderImpl(InternalCuratorFramework client) {
+    AddWatchBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
         watching = new Watching(client, true);
     }
 
     public AddWatchBuilderImpl(
-            InternalCuratorFramework client, Watching watching, Backgrounding backgrounding, AddWatchMode mode) {
+            CuratorFrameworkBase client, Watching watching, Backgrounding backgrounding, AddWatchMode mode) {
         this.client = client;
         this.watching = watching;
         this.backgrounding = backgrounding;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/BackgroundSyncImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/BackgroundSyncImpl.java
@@ -24,10 +24,10 @@ import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.zookeeper.AsyncCallback;
 
 class BackgroundSyncImpl implements BackgroundOperation<String> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Object context;
 
-    BackgroundSyncImpl(CuratorFrameworkImpl client, Object context) {
+    BackgroundSyncImpl(InternalCuratorFramework client, Object context) {
         this.client = client;
         this.context = context;
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/BackgroundSyncImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/BackgroundSyncImpl.java
@@ -24,10 +24,10 @@ import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.zookeeper.AsyncCallback;
 
 class BackgroundSyncImpl implements BackgroundOperation<String> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Object context;
 
-    BackgroundSyncImpl(InternalCuratorFramework client, Object context) {
+    BackgroundSyncImpl(CuratorFrameworkBase client, Object context) {
         this.client = client;
         this.context = context;
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/Backgrounding.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/Backgrounding.java
@@ -62,11 +62,11 @@ public class Backgrounding {
         errorListener = null;
     }
 
-    Backgrounding(InternalCuratorFramework client, BackgroundCallback callback, Object context, Executor executor) {
+    Backgrounding(CuratorFrameworkBase client, BackgroundCallback callback, Object context, Executor executor) {
         this(wrapCallback(client, callback, executor), context);
     }
 
-    Backgrounding(InternalCuratorFramework client, BackgroundCallback callback, Executor executor) {
+    Backgrounding(CuratorFrameworkBase client, BackgroundCallback callback, Executor executor) {
         this(wrapCallback(client, callback, executor));
     }
 
@@ -119,7 +119,7 @@ public class Backgrounding {
     }
 
     private static BackgroundCallback wrapCallback(
-            final InternalCuratorFramework client, final BackgroundCallback callback, final Executor executor) {
+            final CuratorFrameworkBase client, final BackgroundCallback callback, final Executor executor) {
         return new BackgroundCallback() {
             @Override
             public void processResult(CuratorFramework dummy, final CuratorEvent event) throws Exception {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/Backgrounding.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/Backgrounding.java
@@ -62,11 +62,11 @@ public class Backgrounding {
         errorListener = null;
     }
 
-    Backgrounding(CuratorFrameworkImpl client, BackgroundCallback callback, Object context, Executor executor) {
+    Backgrounding(InternalCuratorFramework client, BackgroundCallback callback, Object context, Executor executor) {
         this(wrapCallback(client, callback, executor), context);
     }
 
-    Backgrounding(CuratorFrameworkImpl client, BackgroundCallback callback, Executor executor) {
+    Backgrounding(InternalCuratorFramework client, BackgroundCallback callback, Executor executor) {
         this(wrapCallback(client, callback, executor));
     }
 
@@ -119,7 +119,7 @@ public class Backgrounding {
     }
 
     private static BackgroundCallback wrapCallback(
-            final CuratorFrameworkImpl client, final BackgroundCallback callback, final Executor executor) {
+            final InternalCuratorFramework client, final BackgroundCallback callback, final Executor executor) {
         return new BackgroundCallback() {
             @Override
             public void processResult(CuratorFramework dummy, final CuratorEvent event) throws Exception {
@@ -131,7 +131,7 @@ public class Backgrounding {
                         } catch (Exception e) {
                             ThreadUtils.checkInterrupted(e);
                             if (e instanceof KeeperException) {
-                                client.validateConnection(client.codeToState(((KeeperException) e).code()));
+                                client.validateConnection(FrameworkUtils.codeToState(((KeeperException) e).code()));
                             }
                             client.logError("Background operation result handling threw exception", e);
                         }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -70,7 +70,7 @@ public class CreateBuilderImpl
                 BackgroundOperation<PathAndBytes>,
                 ErrorListenerPathAndBytesable<String> {
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final ProtectedMode protectedMode = new ProtectedMode();
     private CreateMode createMode;
     private Backgrounding backgrounding;
@@ -93,7 +93,7 @@ public class CreateBuilderImpl
     @VisibleForTesting
     boolean failNextIdempotentCheckForTesting = false;
 
-    CreateBuilderImpl(CuratorFrameworkImpl client) {
+    CreateBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
         createMode = CreateMode.PERSISTENT;
         backgrounding = new Backgrounding();
@@ -107,7 +107,7 @@ public class CreateBuilderImpl
     }
 
     public CreateBuilderImpl(
-            CuratorFrameworkImpl client,
+            InternalCuratorFramework client,
             CreateMode createMode,
             Backgrounding backgrounding,
             boolean createParentsIfNeeded,
@@ -737,7 +737,7 @@ public class CreateBuilderImpl
     }
 
     static <T> void backgroundCreateParentsThenNode(
-            final CuratorFrameworkImpl client,
+            final InternalCuratorFramework client,
             final OperationAndData<T> mainOperationAndData,
             final String path,
             final InternalACLProvider aclProvider,
@@ -766,7 +766,7 @@ public class CreateBuilderImpl
     }
 
     private void backgroundSetData(
-            final CuratorFrameworkImpl client,
+            final InternalCuratorFramework client,
             final OperationAndData<PathAndBytes> mainOperationAndData,
             final String path,
             final Backgrounding backgrounding) {
@@ -801,7 +801,7 @@ public class CreateBuilderImpl
     }
 
     private void backgroundCheckIdempotent(
-            final CuratorFrameworkImpl client,
+            final InternalCuratorFramework client,
             final OperationAndData<PathAndBytes> mainOperationAndData,
             final String path,
             final Backgrounding backgrounding) {
@@ -844,7 +844,7 @@ public class CreateBuilderImpl
     }
 
     private static <T> void sendBackgroundResponse(
-            CuratorFrameworkImpl client,
+            InternalCuratorFramework client,
             int rc,
             String path,
             Object ctx,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CreateBuilderImpl.java
@@ -70,7 +70,7 @@ public class CreateBuilderImpl
                 BackgroundOperation<PathAndBytes>,
                 ErrorListenerPathAndBytesable<String> {
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final ProtectedMode protectedMode = new ProtectedMode();
     private CreateMode createMode;
     private Backgrounding backgrounding;
@@ -93,7 +93,7 @@ public class CreateBuilderImpl
     @VisibleForTesting
     boolean failNextIdempotentCheckForTesting = false;
 
-    CreateBuilderImpl(InternalCuratorFramework client) {
+    CreateBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
         createMode = CreateMode.PERSISTENT;
         backgrounding = new Backgrounding();
@@ -107,7 +107,7 @@ public class CreateBuilderImpl
     }
 
     public CreateBuilderImpl(
-            InternalCuratorFramework client,
+            CuratorFrameworkBase client,
             CreateMode createMode,
             Backgrounding backgrounding,
             boolean createParentsIfNeeded,
@@ -737,7 +737,7 @@ public class CreateBuilderImpl
     }
 
     static <T> void backgroundCreateParentsThenNode(
-            final InternalCuratorFramework client,
+            final CuratorFrameworkBase client,
             final OperationAndData<T> mainOperationAndData,
             final String path,
             final InternalACLProvider aclProvider,
@@ -766,7 +766,7 @@ public class CreateBuilderImpl
     }
 
     private void backgroundSetData(
-            final InternalCuratorFramework client,
+            final CuratorFrameworkBase client,
             final OperationAndData<PathAndBytes> mainOperationAndData,
             final String path,
             final Backgrounding backgrounding) {
@@ -801,7 +801,7 @@ public class CreateBuilderImpl
     }
 
     private void backgroundCheckIdempotent(
-            final InternalCuratorFramework client,
+            final CuratorFrameworkBase client,
             final OperationAndData<PathAndBytes> mainOperationAndData,
             final String path,
             final Backgrounding backgrounding) {
@@ -844,7 +844,7 @@ public class CreateBuilderImpl
     }
 
     private static <T> void sendBackgroundResponse(
-            InternalCuratorFramework client,
+            CuratorFrameworkBase client,
             int rc,
             String path,
             Object ctx,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
@@ -114,7 +114,7 @@ class CuratorEventImpl implements CuratorEvent {
     }
 
     CuratorEventImpl(
-            CuratorFrameworkImpl client,
+            InternalCuratorFramework client,
             CuratorEventType type,
             int resultCode,
             String path,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorEventImpl.java
@@ -114,7 +114,7 @@ class CuratorEventImpl implements CuratorEvent {
     }
 
     CuratorEventImpl(
-            InternalCuratorFramework client,
+            CuratorFrameworkBase client,
             CuratorEventType type,
             int resultCode,
             String path,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkBase.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkBase.java
@@ -48,14 +48,14 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
 
 /**
- * This is the internal version of {@link CuratorFramework}.
+ * This is the base class of all {@link CuratorFramework}s, it is public for private usages (a.k.a. impls/details package).
  *
- * <p>Most internal codes should use {@link InternalCuratorFramework} instead of {@link CuratorFrameworkImpl}, so
+ * <p>Most internal codes should use {@link CuratorFrameworkBase} instead of {@link CuratorFrameworkImpl}, so
  * functionalities could be added additively by overriding methods in {@link DelegatingCuratorFramework}.
  *
- * <p>An instance of {@link CuratorFramework} MUST BE an instance of {@link InternalCuratorFramework}.
+ * <p>An instance of {@link CuratorFramework} MUST BE an instance of {@link CuratorFrameworkBase}.
  */
-public abstract class InternalCuratorFramework implements CuratorFramework {
+public abstract class CuratorFrameworkBase implements CuratorFramework {
     abstract NamespaceImpl getNamespaceImpl();
 
     @Override
@@ -111,7 +111,7 @@ public abstract class InternalCuratorFramework implements CuratorFramework {
         return getZookeeperClient().getZooKeeper();
     }
 
-    protected final void internalSync(InternalCuratorFramework impl, String path, Object context) {
+    protected final void internalSync(CuratorFrameworkBase impl, String path, Object context) {
         BackgroundOperation<String> operation = new BackgroundSyncImpl(impl, context);
         processBackgroundOperation(new OperationAndData(operation, path, null, null, context, null), null);
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -74,7 +74,7 @@ import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class CuratorFrameworkImpl extends InternalCuratorFramework {
+public final class CuratorFrameworkImpl extends CuratorFrameworkBase {
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final CuratorZookeeperClient client;
     private final StandardListenerManager<CuratorListener> listeners;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorMultiTransactionImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorMultiTransactionImpl.java
@@ -50,14 +50,14 @@ public class CuratorMultiTransactionImpl
                 CuratorMultiTransactionMain,
                 BackgroundOperation<CuratorMultiTransactionRecord>,
                 ErrorListenerMultiTransactionMain {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private Backgrounding backgrounding = new Backgrounding();
 
-    public CuratorMultiTransactionImpl(InternalCuratorFramework client) {
+    public CuratorMultiTransactionImpl(CuratorFrameworkBase client) {
         this.client = client;
     }
 
-    public CuratorMultiTransactionImpl(InternalCuratorFramework client, Backgrounding backgrounding) {
+    public CuratorMultiTransactionImpl(CuratorFrameworkBase client, Backgrounding backgrounding) {
         this.client = client;
         this.backgrounding = backgrounding;
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorMultiTransactionImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorMultiTransactionImpl.java
@@ -50,14 +50,14 @@ public class CuratorMultiTransactionImpl
                 CuratorMultiTransactionMain,
                 BackgroundOperation<CuratorMultiTransactionRecord>,
                 ErrorListenerMultiTransactionMain {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private Backgrounding backgrounding = new Backgrounding();
 
-    public CuratorMultiTransactionImpl(CuratorFrameworkImpl client) {
+    public CuratorMultiTransactionImpl(InternalCuratorFramework client) {
         this.client = client;
     }
 
-    public CuratorMultiTransactionImpl(CuratorFrameworkImpl client, Backgrounding backgrounding) {
+    public CuratorMultiTransactionImpl(InternalCuratorFramework client, Backgrounding backgrounding) {
         this.client = client;
         this.backgrounding = backgrounding;
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorTempFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorTempFrameworkImpl.java
@@ -36,7 +36,7 @@ public class CuratorTempFrameworkImpl implements CuratorTempFramework {
     private final long inactiveThresholdMs;
 
     // guarded by sync
-    private CuratorFrameworkImpl client;
+    private InternalCuratorFramework client;
 
     // guarded by sync
     private ScheduledExecutorService cleanup;
@@ -67,7 +67,7 @@ public class CuratorTempFrameworkImpl implements CuratorTempFramework {
     }
 
     @VisibleForTesting
-    synchronized CuratorFrameworkImpl getClient() {
+    synchronized InternalCuratorFramework getClient() {
         return client;
     }
 
@@ -83,7 +83,7 @@ public class CuratorTempFrameworkImpl implements CuratorTempFramework {
 
     private synchronized void openConnectionIfNeeded() throws Exception {
         if (client == null) {
-            client = (CuratorFrameworkImpl) factory.build(); // cast is safe - we control both sides of this
+            client = (InternalCuratorFramework) factory.build(); // cast is safe - we control both sides of this
             client.start();
         }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorTempFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorTempFrameworkImpl.java
@@ -36,7 +36,7 @@ public class CuratorTempFrameworkImpl implements CuratorTempFramework {
     private final long inactiveThresholdMs;
 
     // guarded by sync
-    private InternalCuratorFramework client;
+    private CuratorFrameworkBase client;
 
     // guarded by sync
     private ScheduledExecutorService cleanup;
@@ -67,7 +67,7 @@ public class CuratorTempFrameworkImpl implements CuratorTempFramework {
     }
 
     @VisibleForTesting
-    synchronized InternalCuratorFramework getClient() {
+    synchronized CuratorFrameworkBase getClient() {
         return client;
     }
 
@@ -83,7 +83,7 @@ public class CuratorTempFrameworkImpl implements CuratorTempFramework {
 
     private synchronized void openConnectionIfNeeded() throws Exception {
         if (client == null) {
-            client = (InternalCuratorFramework) factory.build(); // cast is safe - we control both sides of this
+            client = (CuratorFrameworkBase) factory.build(); // cast is safe - we control both sides of this
             client.start();
         }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorTransactionImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorTransactionImpl.java
@@ -35,12 +35,12 @@ import org.apache.zookeeper.data.Stat;
 
 @SuppressWarnings("deprecation")
 class CuratorTransactionImpl implements CuratorTransaction, CuratorTransactionBridge, CuratorTransactionFinal {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final CuratorMultiTransactionRecord transaction;
 
     private boolean isCommitted = false;
 
-    CuratorTransactionImpl(InternalCuratorFramework client) {
+    CuratorTransactionImpl(CuratorFrameworkBase client) {
         this.client = client;
         transaction = new CuratorMultiTransactionRecord();
     }
@@ -83,7 +83,7 @@ class CuratorTransactionImpl implements CuratorTransaction, CuratorTransactionBr
     }
 
     static <T> TransactionCheckBuilder<T> makeTransactionCheckBuilder(
-            final InternalCuratorFramework client, final T context, final CuratorMultiTransactionRecord transaction) {
+            final CuratorFrameworkBase client, final T context, final CuratorMultiTransactionRecord transaction) {
         return new TransactionCheckBuilder<T>() {
             private int version = -1;
 
@@ -125,7 +125,7 @@ class CuratorTransactionImpl implements CuratorTransaction, CuratorTransactionBr
     }
 
     static List<CuratorTransactionResult> wrapResults(
-            InternalCuratorFramework client, List<OpResult> resultList, CuratorMultiTransactionRecord transaction) {
+            CuratorFrameworkBase client, List<OpResult> resultList, CuratorMultiTransactionRecord transaction) {
         ImmutableList.Builder<CuratorTransactionResult> builder = ImmutableList.builder();
         for (int i = 0; i < resultList.size(); ++i) {
             OpResult opResult = resultList.get(i);
@@ -138,7 +138,7 @@ class CuratorTransactionImpl implements CuratorTransaction, CuratorTransactionBr
     }
 
     static CuratorTransactionResult makeCuratorResult(
-            InternalCuratorFramework client, OpResult opResult, TypeAndPath metadata) {
+            CuratorFrameworkBase client, OpResult opResult, TypeAndPath metadata) {
         String resultPath = null;
         Stat resultStat = null;
         int error = 0;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorTransactionImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorTransactionImpl.java
@@ -35,12 +35,12 @@ import org.apache.zookeeper.data.Stat;
 
 @SuppressWarnings("deprecation")
 class CuratorTransactionImpl implements CuratorTransaction, CuratorTransactionBridge, CuratorTransactionFinal {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final CuratorMultiTransactionRecord transaction;
 
     private boolean isCommitted = false;
 
-    CuratorTransactionImpl(CuratorFrameworkImpl client) {
+    CuratorTransactionImpl(InternalCuratorFramework client) {
         this.client = client;
         transaction = new CuratorMultiTransactionRecord();
     }
@@ -83,7 +83,7 @@ class CuratorTransactionImpl implements CuratorTransaction, CuratorTransactionBr
     }
 
     static <T> TransactionCheckBuilder<T> makeTransactionCheckBuilder(
-            final CuratorFrameworkImpl client, final T context, final CuratorMultiTransactionRecord transaction) {
+            final InternalCuratorFramework client, final T context, final CuratorMultiTransactionRecord transaction) {
         return new TransactionCheckBuilder<T>() {
             private int version = -1;
 
@@ -125,7 +125,7 @@ class CuratorTransactionImpl implements CuratorTransaction, CuratorTransactionBr
     }
 
     static List<CuratorTransactionResult> wrapResults(
-            CuratorFrameworkImpl client, List<OpResult> resultList, CuratorMultiTransactionRecord transaction) {
+            InternalCuratorFramework client, List<OpResult> resultList, CuratorMultiTransactionRecord transaction) {
         ImmutableList.Builder<CuratorTransactionResult> builder = ImmutableList.builder();
         for (int i = 0; i < resultList.size(); ++i) {
             OpResult opResult = resultList.get(i);
@@ -138,7 +138,7 @@ class CuratorTransactionImpl implements CuratorTransaction, CuratorTransactionBr
     }
 
     static CuratorTransactionResult makeCuratorResult(
-            CuratorFrameworkImpl client, OpResult opResult, TypeAndPath metadata) {
+            InternalCuratorFramework client, OpResult opResult, TypeAndPath metadata) {
         String resultPath = null;
         Stat resultStat = null;
         int error = 0;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DelegatingCuratorFramework.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DelegatingCuratorFramework.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.curator.framework.imps;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.CuratorZookeeperClient;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.ACLProvider;
+import org.apache.curator.framework.api.CompressionProvider;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.CuratorListener;
+import org.apache.curator.framework.api.UnhandledErrorListener;
+import org.apache.curator.framework.listen.Listenable;
+import org.apache.curator.framework.schema.SchemaSet;
+import org.apache.curator.framework.state.ConnectionStateErrorPolicy;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.utils.ZookeeperCompatibility;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
+
+public class DelegatingCuratorFramework extends InternalCuratorFramework {
+    protected final InternalCuratorFramework client;
+
+    public DelegatingCuratorFramework(InternalCuratorFramework client) {
+        this.client = client;
+    }
+
+    @Override
+    public void start() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CuratorFrameworkState getState() {
+        return client.getState();
+    }
+
+    @Override
+    @Deprecated
+    public boolean isStarted() {
+        return client.isStarted();
+    }
+
+    @Override
+    public Listenable<ConnectionStateListener> getConnectionStateListenable() {
+        return client.getConnectionStateListenable();
+    }
+
+    @Override
+    public Listenable<CuratorListener> getCuratorListenable() {
+        return client.getCuratorListenable();
+    }
+
+    @Override
+    public Listenable<UnhandledErrorListener> getUnhandledErrorListenable() {
+        return client.getUnhandledErrorListenable();
+    }
+
+    @Override
+    public CuratorFramework usingNamespace(String newNamespace) {
+        return client.usingNamespace(newNamespace);
+    }
+
+    @Override
+    public CuratorZookeeperClient getZookeeperClient() {
+        return client.getZookeeperClient();
+    }
+
+    @Override
+    public ZookeeperCompatibility getZookeeperCompatibility() {
+        return client.getZookeeperCompatibility();
+    }
+
+    @Override
+    @Deprecated
+    public void clearWatcherReferences(Watcher watcher) {
+        client.clearWatcherReferences(watcher);
+    }
+
+    @Override
+    public boolean blockUntilConnected(int maxWaitTime, TimeUnit units) throws InterruptedException {
+        return client.blockUntilConnected(maxWaitTime, units);
+    }
+
+    @Override
+    public void blockUntilConnected() throws InterruptedException {
+        client.blockUntilConnected();
+    }
+
+    @Override
+    public ConnectionStateErrorPolicy getConnectionStateErrorPolicy() {
+        return client.getConnectionStateErrorPolicy();
+    }
+
+    @Override
+    public QuorumVerifier getCurrentConfig() {
+        return client.getCurrentConfig();
+    }
+
+    @Override
+    public SchemaSet getSchemaSet() {
+        return client.getSchemaSet();
+    }
+
+    @Override
+    public CompletableFuture<Void> postSafeNotify(Object monitorHolder) {
+        return client.postSafeNotify(monitorHolder);
+    }
+
+    @Override
+    public CompletableFuture<Void> runSafe(Runnable runnable) {
+        return client.runSafe(runnable);
+    }
+
+    @Override
+    NamespaceImpl getNamespaceImpl() {
+        return client.getNamespaceImpl();
+    }
+
+    @Override
+    void validateConnection(Watcher.Event.KeeperState state) {
+        client.validateConnection(state);
+    }
+
+    @Override
+    WatcherRemovalManager getWatcherRemovalManager() {
+        return client.getWatcherRemovalManager();
+    }
+
+    @Override
+    FailedDeleteManager getFailedDeleteManager() {
+        return client.getFailedDeleteManager();
+    }
+
+    @Override
+    FailedRemoveWatchManager getFailedRemoveWatcherManager() {
+        return client.getFailedRemoveWatcherManager();
+    }
+
+    @Override
+    public void logError(String reason, Throwable e) {
+        client.logError(reason, e);
+    }
+
+    @Override
+    byte[] getDefaultData() {
+        return client.getDefaultData();
+    }
+
+    @Override
+    CompressionProvider getCompressionProvider() {
+        return client.getCompressionProvider();
+    }
+
+    @Override
+    public boolean compressionEnabled() {
+        return client.compressionEnabled();
+    }
+
+    @Override
+    ACLProvider getAclProvider() {
+        return client.getAclProvider();
+    }
+
+    @Override
+    boolean useContainerParentsIfAvailable() {
+        return client.useContainerParentsIfAvailable();
+    }
+
+    @Override
+    EnsembleTracker getEnsembleTracker() {
+        return client.getEnsembleTracker();
+    }
+
+    @Override
+    NamespaceFacadeCache getNamespaceFacadeCache() {
+        return client.getNamespaceFacadeCache();
+    }
+
+    @Override
+    public <DATA_TYPE> void processBackgroundOperation(
+            OperationAndData<DATA_TYPE> operationAndData, CuratorEvent event) {
+        client.processBackgroundOperation(operationAndData, event);
+    }
+
+    @Override
+    <DATA_TYPE> boolean queueOperation(OperationAndData<DATA_TYPE> operationAndData) {
+        return client.queueOperation(operationAndData);
+    }
+}

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DelegatingCuratorFramework.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DelegatingCuratorFramework.java
@@ -36,21 +36,15 @@ import org.apache.curator.utils.ZookeeperCompatibility;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 
-public class DelegatingCuratorFramework extends InternalCuratorFramework {
-    protected final InternalCuratorFramework client;
+/**
+ * Delegates methods to shadowed {@link CuratorFrameworkBase} so subclasses can override only methods that need
+ * additional cares.
+ */
+abstract class DelegatingCuratorFramework extends CuratorFrameworkBase {
+    protected final CuratorFrameworkBase client;
 
-    public DelegatingCuratorFramework(InternalCuratorFramework client) {
+    public DelegatingCuratorFramework(CuratorFrameworkBase client) {
         this.client = client;
-    }
-
-    @Override
-    public void start() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void close() {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -201,8 +195,7 @@ public class DelegatingCuratorFramework extends InternalCuratorFramework {
     }
 
     @Override
-    public <DATA_TYPE> void processBackgroundOperation(
-            OperationAndData<DATA_TYPE> operationAndData, CuratorEvent event) {
+    <DATA_TYPE> void processBackgroundOperation(OperationAndData<DATA_TYPE> operationAndData, CuratorEvent event) {
         client.processBackgroundOperation(operationAndData, event);
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
@@ -34,7 +34,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
 
 public class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<String>, ErrorListenerPathable<Void> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private int version;
     private Backgrounding backgrounding;
     private boolean deletingChildrenIfNeeded;
@@ -47,7 +47,7 @@ public class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<Str
     @VisibleForTesting
     boolean failBeforeNextDeleteForTesting = false;
 
-    DeleteBuilderImpl(InternalCuratorFramework client) {
+    DeleteBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
         version = -1;
         backgrounding = new Backgrounding();
@@ -57,7 +57,7 @@ public class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<Str
     }
 
     public DeleteBuilderImpl(
-            InternalCuratorFramework client,
+            CuratorFrameworkBase client,
             int version,
             Backgrounding backgrounding,
             boolean deletingChildrenIfNeeded,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DeleteBuilderImpl.java
@@ -34,7 +34,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
 
 public class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<String>, ErrorListenerPathable<Void> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private int version;
     private Backgrounding backgrounding;
     private boolean deletingChildrenIfNeeded;
@@ -47,7 +47,7 @@ public class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<Str
     @VisibleForTesting
     boolean failBeforeNextDeleteForTesting = false;
 
-    DeleteBuilderImpl(CuratorFrameworkImpl client) {
+    DeleteBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
         version = -1;
         backgrounding = new Backgrounding();
@@ -57,7 +57,7 @@ public class DeleteBuilderImpl implements DeleteBuilder, BackgroundOperation<Str
     }
 
     public DeleteBuilderImpl(
-            CuratorFrameworkImpl client,
+            InternalCuratorFramework client,
             int version,
             Backgrounding backgrounding,
             boolean deletingChildrenIfNeeded,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
@@ -34,19 +34,19 @@ import org.apache.zookeeper.data.Stat;
 
 public class ExistsBuilderImpl
         implements ExistsBuilder, BackgroundOperation<String>, ErrorListenerPathable<Stat>, ACLableExistBuilderMain {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private Backgrounding backgrounding;
     private Watching watching;
     private boolean createParentsIfNeeded;
     private boolean createParentContainersIfNeeded;
     private ACLing acling;
 
-    ExistsBuilderImpl(CuratorFrameworkImpl client) {
+    ExistsBuilderImpl(InternalCuratorFramework client) {
         this(client, new Backgrounding(), null, false, false);
     }
 
     public ExistsBuilderImpl(
-            CuratorFrameworkImpl client,
+            InternalCuratorFramework client,
             Backgrounding backgrounding,
             Watcher watcher,
             boolean createParentsIfNeeded,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ExistsBuilderImpl.java
@@ -34,19 +34,19 @@ import org.apache.zookeeper.data.Stat;
 
 public class ExistsBuilderImpl
         implements ExistsBuilder, BackgroundOperation<String>, ErrorListenerPathable<Stat>, ACLableExistBuilderMain {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private Backgrounding backgrounding;
     private Watching watching;
     private boolean createParentsIfNeeded;
     private boolean createParentContainersIfNeeded;
     private ACLing acling;
 
-    ExistsBuilderImpl(InternalCuratorFramework client) {
+    ExistsBuilderImpl(CuratorFrameworkBase client) {
         this(client, new Backgrounding(), null, false, false);
     }
 
     public ExistsBuilderImpl(
-            InternalCuratorFramework client,
+            CuratorFrameworkBase client,
             Backgrounding backgrounding,
             Watcher watcher,
             boolean createParentsIfNeeded,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
@@ -34,12 +34,12 @@ import org.slf4j.LoggerFactory;
 
 class FindAndDeleteProtectedNodeInBackground implements BackgroundOperation<Void> {
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final String namespaceAdjustedParentPath;
     private final String protectedId;
 
     FindAndDeleteProtectedNodeInBackground(
-            InternalCuratorFramework client, String namespaceAdjustedParentPath, String protectedId) {
+            CuratorFrameworkBase client, String namespaceAdjustedParentPath, String protectedId) {
         this.client = client;
         this.namespaceAdjustedParentPath = namespaceAdjustedParentPath;
         this.protectedId = protectedId;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FindAndDeleteProtectedNodeInBackground.java
@@ -34,12 +34,12 @@ import org.slf4j.LoggerFactory;
 
 class FindAndDeleteProtectedNodeInBackground implements BackgroundOperation<Void> {
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final String namespaceAdjustedParentPath;
     private final String protectedId;
 
     FindAndDeleteProtectedNodeInBackground(
-            CuratorFrameworkImpl client, String namespaceAdjustedParentPath, String protectedId) {
+            InternalCuratorFramework client, String namespaceAdjustedParentPath, String protectedId) {
         this.client = client;
         this.namespaceAdjustedParentPath = namespaceAdjustedParentPath;
         this.protectedId = protectedId;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/FrameworkUtils.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/FrameworkUtils.java
@@ -19,10 +19,31 @@
 
 package org.apache.curator.framework.imps;
 
-import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
 
-class NamespaceWatchedEvent extends WatchedEvent {
-    NamespaceWatchedEvent(InternalCuratorFramework client, WatchedEvent event) {
-        super(event.getType(), event.getState(), client.unfixForNamespace(event.getPath()));
+class FrameworkUtils {
+    static Watcher.Event.KeeperState codeToState(KeeperException.Code code) {
+        switch (code) {
+            case AUTHFAILED:
+            case NOAUTH: {
+                return Watcher.Event.KeeperState.AuthFailed;
+            }
+
+            case CONNECTIONLOSS:
+            case OPERATIONTIMEOUT: {
+                return Watcher.Event.KeeperState.Disconnected;
+            }
+
+            case SESSIONEXPIRED: {
+                return Watcher.Event.KeeperState.Expired;
+            }
+
+            case OK:
+            case SESSIONMOVED: {
+                return Watcher.Event.KeeperState.SyncConnected;
+            }
+        }
+        return Watcher.Event.KeeperState.fromInt(-1);
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetACLBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetACLBuilderImpl.java
@@ -35,18 +35,18 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
 public class GetACLBuilderImpl implements GetACLBuilder, BackgroundOperation<String>, ErrorListenerPathable<List<ACL>> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
 
     private Backgrounding backgrounding;
     private Stat responseStat;
 
-    GetACLBuilderImpl(InternalCuratorFramework client) {
+    GetACLBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
         backgrounding = new Backgrounding();
         responseStat = new Stat();
     }
 
-    public GetACLBuilderImpl(InternalCuratorFramework client, Backgrounding backgrounding, Stat responseStat) {
+    public GetACLBuilderImpl(CuratorFrameworkBase client, Backgrounding backgrounding, Stat responseStat) {
         this.client = client;
         this.backgrounding = backgrounding;
         this.responseStat = responseStat;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetACLBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetACLBuilderImpl.java
@@ -35,18 +35,18 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
 public class GetACLBuilderImpl implements GetACLBuilder, BackgroundOperation<String>, ErrorListenerPathable<List<ACL>> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
 
     private Backgrounding backgrounding;
     private Stat responseStat;
 
-    GetACLBuilderImpl(CuratorFrameworkImpl client) {
+    GetACLBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
         backgrounding = new Backgrounding();
         responseStat = new Stat();
     }
 
-    public GetACLBuilderImpl(CuratorFrameworkImpl client, Backgrounding backgrounding, Stat responseStat) {
+    public GetACLBuilderImpl(InternalCuratorFramework client, Backgrounding backgrounding, Stat responseStat) {
         this.client = client;
         this.backgrounding = backgrounding;
         this.responseStat = responseStat;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
@@ -41,12 +41,12 @@ import org.apache.zookeeper.data.Stat;
 
 public class GetChildrenBuilderImpl
         implements GetChildrenBuilder, BackgroundOperation<String>, ErrorListenerPathable<List<String>> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private Watching watching;
     private Backgrounding backgrounding;
     private Stat responseStat;
 
-    GetChildrenBuilderImpl(InternalCuratorFramework client) {
+    GetChildrenBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
         watching = new Watching(client);
         backgrounding = new Backgrounding();
@@ -54,7 +54,7 @@ public class GetChildrenBuilderImpl
     }
 
     public GetChildrenBuilderImpl(
-            InternalCuratorFramework client, Watcher watcher, Backgrounding backgrounding, Stat responseStat) {
+            CuratorFrameworkBase client, Watcher watcher, Backgrounding backgrounding, Stat responseStat) {
         this.client = client;
         this.watching = new Watching(client, watcher);
         this.backgrounding = backgrounding;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetChildrenBuilderImpl.java
@@ -41,12 +41,12 @@ import org.apache.zookeeper.data.Stat;
 
 public class GetChildrenBuilderImpl
         implements GetChildrenBuilder, BackgroundOperation<String>, ErrorListenerPathable<List<String>> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private Watching watching;
     private Backgrounding backgrounding;
     private Stat responseStat;
 
-    GetChildrenBuilderImpl(CuratorFrameworkImpl client) {
+    GetChildrenBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
         watching = new Watching(client);
         backgrounding = new Backgrounding();
@@ -54,7 +54,7 @@ public class GetChildrenBuilderImpl
     }
 
     public GetChildrenBuilderImpl(
-            CuratorFrameworkImpl client, Watcher watcher, Backgrounding backgrounding, Stat responseStat) {
+            InternalCuratorFramework client, Watcher watcher, Backgrounding backgrounding, Stat responseStat) {
         this.client = client;
         this.watching = new Watching(client, watcher);
         this.backgrounding = backgrounding;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetConfigBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetConfigBuilderImpl.java
@@ -32,19 +32,18 @@ import org.apache.zookeeper.data.Stat;
 
 public class GetConfigBuilderImpl
         implements GetConfigBuilder, BackgroundOperation<Void>, ErrorListenerEnsembleable<byte[]> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
 
     private Backgrounding backgrounding;
     private Watching watching;
     private Stat stat;
 
-    public GetConfigBuilderImpl(InternalCuratorFramework client) {
+    public GetConfigBuilderImpl(CuratorFrameworkBase client) {
         this(client, new Backgrounding(), null, null);
     }
 
-    public GetConfigBuilderImpl(
-            InternalCuratorFramework client, Backgrounding backgrounding, Watcher watcher, Stat stat) {
-        this.client = (InternalCuratorFramework) client.usingNamespace(null);
+    public GetConfigBuilderImpl(CuratorFrameworkBase client, Backgrounding backgrounding, Watcher watcher, Stat stat) {
+        this.client = (CuratorFrameworkBase) client.usingNamespace(null);
         this.backgrounding = backgrounding;
         this.watching = new Watching(this.client, watcher);
         this.stat = stat;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetConfigBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetConfigBuilderImpl.java
@@ -32,18 +32,19 @@ import org.apache.zookeeper.data.Stat;
 
 public class GetConfigBuilderImpl
         implements GetConfigBuilder, BackgroundOperation<Void>, ErrorListenerEnsembleable<byte[]> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
 
     private Backgrounding backgrounding;
     private Watching watching;
     private Stat stat;
 
-    public GetConfigBuilderImpl(CuratorFrameworkImpl client) {
+    public GetConfigBuilderImpl(InternalCuratorFramework client) {
         this(client, new Backgrounding(), null, null);
     }
 
-    public GetConfigBuilderImpl(CuratorFrameworkImpl client, Backgrounding backgrounding, Watcher watcher, Stat stat) {
-        this.client = (CuratorFrameworkImpl) client.usingNamespace(null);
+    public GetConfigBuilderImpl(
+            InternalCuratorFramework client, Backgrounding backgrounding, Watcher watcher, Stat stat) {
+        this.client = (InternalCuratorFramework) client.usingNamespace(null);
         this.backgrounding = backgrounding;
         this.watching = new Watching(this.client, watcher);
         this.stat = stat;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
@@ -35,13 +35,13 @@ import org.slf4j.LoggerFactory;
 
 public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<String>, ErrorListenerPathable<byte[]> {
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private Stat responseStat;
     private Watching watching;
     private Backgrounding backgrounding;
     private boolean decompress;
 
-    GetDataBuilderImpl(CuratorFrameworkImpl client) {
+    GetDataBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
         responseStat = null;
         watching = new Watching(client);
@@ -50,7 +50,7 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
     }
 
     public GetDataBuilderImpl(
-            CuratorFrameworkImpl client,
+            InternalCuratorFramework client,
             Stat responseStat,
             Watcher watcher,
             Backgrounding backgrounding,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/GetDataBuilderImpl.java
@@ -35,13 +35,13 @@ import org.slf4j.LoggerFactory;
 
 public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<String>, ErrorListenerPathable<byte[]> {
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private Stat responseStat;
     private Watching watching;
     private Backgrounding backgrounding;
     private boolean decompress;
 
-    GetDataBuilderImpl(InternalCuratorFramework client) {
+    GetDataBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
         responseStat = null;
         watching = new Watching(client);
@@ -50,7 +50,7 @@ public class GetDataBuilderImpl implements GetDataBuilder, BackgroundOperation<S
     }
 
     public GetDataBuilderImpl(
-            InternalCuratorFramework client,
+            CuratorFrameworkBase client,
             Stat responseStat,
             Watcher watcher,
             Backgrounding backgrounding,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/InternalCuratorFramework.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/InternalCuratorFramework.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.curator.framework.imps;
+
+import com.google.common.base.Preconditions;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.WatcherRemoveCuratorFramework;
+import org.apache.curator.framework.api.ACLProvider;
+import org.apache.curator.framework.api.CompressionProvider;
+import org.apache.curator.framework.api.CreateBuilder;
+import org.apache.curator.framework.api.CuratorClosedException;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.framework.api.ExistsBuilder;
+import org.apache.curator.framework.api.GetACLBuilder;
+import org.apache.curator.framework.api.GetChildrenBuilder;
+import org.apache.curator.framework.api.GetConfigBuilder;
+import org.apache.curator.framework.api.GetDataBuilder;
+import org.apache.curator.framework.api.ReconfigBuilder;
+import org.apache.curator.framework.api.RemoveWatchesBuilder;
+import org.apache.curator.framework.api.SetACLBuilder;
+import org.apache.curator.framework.api.SetDataBuilder;
+import org.apache.curator.framework.api.SyncBuilder;
+import org.apache.curator.framework.api.WatchesBuilder;
+import org.apache.curator.framework.api.transaction.CuratorMultiTransaction;
+import org.apache.curator.framework.api.transaction.CuratorTransaction;
+import org.apache.curator.framework.api.transaction.TransactionOp;
+import org.apache.curator.utils.EnsurePath;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+
+/**
+ * This is the internal version of {@link CuratorFramework}.
+ *
+ * <p>Most internal codes should use {@link InternalCuratorFramework} instead of {@link CuratorFrameworkImpl}, so
+ * functionalities could be added additively by overriding methods in {@link DelegatingCuratorFramework}.
+ *
+ * <p>An instance of {@link CuratorFramework} MUST BE an instance of {@link InternalCuratorFramework}.
+ */
+public abstract class InternalCuratorFramework implements CuratorFramework {
+    abstract NamespaceImpl getNamespaceImpl();
+
+    @Override
+    public final CuratorFramework nonNamespaceView() {
+        return usingNamespace(null);
+    }
+
+    @Override
+    public final String getNamespace() {
+        NamespaceImpl namespace = getNamespaceImpl();
+        String str = namespace.getNamespace();
+        return (str != null) ? str : "";
+    }
+
+    @Deprecated
+    @Override
+    public EnsurePath newNamespaceAwareEnsurePath(String path) {
+        NamespaceImpl namespace = getNamespaceImpl();
+        return namespace.newNamespaceAwareEnsurePath(path);
+    }
+
+    final String unfixForNamespace(String path) {
+        NamespaceImpl namespace = getNamespaceImpl();
+        return namespace.unfixForNamespace(path);
+    }
+
+    final String fixForNamespace(String path) {
+        NamespaceImpl namespace = getNamespaceImpl();
+        return namespace.fixForNamespace(path, false);
+    }
+
+    abstract void validateConnection(Watcher.Event.KeeperState state);
+
+    final String fixForNamespace(String path, boolean isSequential) {
+        NamespaceImpl namespace = getNamespaceImpl();
+        return namespace.fixForNamespace(path, isSequential);
+    }
+
+    protected final void checkState() {
+        CuratorFrameworkState state = getState();
+        switch (state) {
+            case STARTED:
+                return;
+            case STOPPED:
+                throw new CuratorClosedException();
+            default:
+                String msg = String.format("Expected state [%s] was [%s]", CuratorFrameworkState.STARTED, state);
+                throw new IllegalStateException(msg);
+        }
+    }
+
+    final ZooKeeper getZooKeeper() throws Exception {
+        return getZookeeperClient().getZooKeeper();
+    }
+
+    protected final void internalSync(InternalCuratorFramework impl, String path, Object context) {
+        BackgroundOperation<String> operation = new BackgroundSyncImpl(impl, context);
+        processBackgroundOperation(new OperationAndData(operation, path, null, null, context, null), null);
+    }
+
+    abstract byte[] getDefaultData();
+
+    abstract CompressionProvider getCompressionProvider();
+
+    abstract ACLProvider getAclProvider();
+
+    abstract boolean useContainerParentsIfAvailable();
+
+    abstract EnsembleTracker getEnsembleTracker();
+
+    abstract NamespaceFacadeCache getNamespaceFacadeCache();
+
+    @Override
+    public CreateBuilder create() {
+        checkState();
+        return new CreateBuilderImpl(this);
+    }
+
+    @Override
+    public DeleteBuilder delete() {
+        checkState();
+        return new DeleteBuilderImpl(this);
+    }
+
+    @Override
+    public ExistsBuilder checkExists() {
+        checkState();
+        return new ExistsBuilderImpl(this);
+    }
+
+    @Override
+    public GetDataBuilder getData() {
+        checkState();
+        return new GetDataBuilderImpl(this);
+    }
+
+    @Override
+    public SetDataBuilder setData() {
+        checkState();
+        return new SetDataBuilderImpl(this);
+    }
+
+    @Override
+    public GetChildrenBuilder getChildren() {
+        checkState();
+        return new GetChildrenBuilderImpl(this);
+    }
+
+    @Override
+    public GetACLBuilder getACL() {
+        checkState();
+        return new GetACLBuilderImpl(this);
+    }
+
+    @Override
+    public SetACLBuilder setACL() {
+        checkState();
+        return new SetACLBuilderImpl(this);
+    }
+
+    @Override
+    public ReconfigBuilder reconfig() {
+        checkState();
+        return new ReconfigBuilderImpl(this);
+    }
+
+    @Override
+    public GetConfigBuilder getConfig() {
+        checkState();
+        return new GetConfigBuilderImpl(this);
+    }
+
+    @Override
+    public CuratorTransaction inTransaction() {
+        checkState();
+        return new CuratorTransactionImpl(this);
+    }
+
+    @Override
+    public CuratorMultiTransaction transaction() {
+        checkState();
+        return new CuratorMultiTransactionImpl(this);
+    }
+
+    @Override
+    public TransactionOp transactionOp() {
+        checkState();
+        return new TransactionOpImpl(this);
+    }
+
+    @Override
+    public void sync(String path, Object context) {
+        checkState();
+
+        path = fixForNamespace(path);
+
+        internalSync(this, path, context);
+    }
+
+    @Override
+    public SyncBuilder sync() {
+        checkState();
+        return new SyncBuilderImpl(this);
+    }
+
+    @Override
+    public final RemoveWatchesBuilder watches() {
+        checkState();
+        return new RemoveWatchesBuilderImpl(this);
+    }
+
+    @Override
+    public final WatchesBuilder watchers() {
+        Preconditions.checkState(
+                getZookeeperCompatibility().hasPersistentWatchers(),
+                "watchers() is not supported in the ZooKeeper library and/or server being used. Use watches() instead.");
+        checkState();
+        return new WatchesBuilderImpl(this);
+    }
+
+    @Override
+    public final void createContainers(String path) throws Exception {
+        checkExists().creatingParentContainersIfNeeded().forPath(ZKPaths.makePath(path, "foo"));
+    }
+
+    @Override
+    public final WatcherRemoveCuratorFramework newWatcherRemoveCuratorFramework() {
+        return new WatcherRemovalFacade(this);
+    }
+
+    WatcherRemovalManager getWatcherRemovalManager() {
+        return null;
+    }
+
+    abstract FailedDeleteManager getFailedDeleteManager();
+
+    abstract FailedRemoveWatchManager getFailedRemoveWatcherManager();
+
+    abstract void logError(String reason, Throwable e);
+
+    abstract <DATA_TYPE> void processBackgroundOperation(
+            OperationAndData<DATA_TYPE> operationAndData, CuratorEvent event);
+
+    abstract <DATA_TYPE> boolean queueOperation(OperationAndData<DATA_TYPE> operationAndData);
+}

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceFacade.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceFacade.java
@@ -19,117 +19,27 @@
 
 package org.apache.curator.framework.imps;
 
-import org.apache.curator.CuratorZookeeperClient;
-import org.apache.curator.RetryLoop;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.CuratorListener;
-import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.curator.framework.listen.Listenable;
-import org.apache.curator.framework.state.ConnectionStateListener;
-import org.apache.curator.utils.EnsurePath;
-import org.apache.zookeeper.ZooKeeper;
 
-class NamespaceFacade extends CuratorFrameworkImpl {
-    private final CuratorFrameworkImpl client;
+class NamespaceFacade extends DelegatingCuratorFramework {
     private final NamespaceImpl namespace;
     private final FailedDeleteManager failedDeleteManager = new FailedDeleteManager(this);
 
     NamespaceFacade(CuratorFrameworkImpl client, String namespace) {
         super(client);
-        this.client = client;
         this.namespace = new NamespaceImpl(client, namespace);
     }
 
     @Override
-    public CuratorFramework nonNamespaceView() {
-        return usingNamespace(null);
-    }
-
-    @Override
-    public CuratorFramework usingNamespace(String newNamespace) {
-        return client.getNamespaceFacadeCache().get(newNamespace);
-    }
-
-    @Override
-    public String getNamespace() {
-        return namespace.getNamespace();
-    }
-
-    @Override
-    public void start() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void close() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Listenable<ConnectionStateListener> getConnectionStateListenable() {
-        return client.getConnectionStateListenable();
+    NamespaceImpl getNamespaceImpl() {
+        return namespace;
     }
 
     @Override
     public Listenable<CuratorListener> getCuratorListenable() {
         throw new UnsupportedOperationException(
                 "getCuratorListenable() is only available from a non-namespaced CuratorFramework instance");
-    }
-
-    @Override
-    public Listenable<UnhandledErrorListener> getUnhandledErrorListenable() {
-        return client.getUnhandledErrorListenable();
-    }
-
-    @Override
-    public void sync(String path, Object context) {
-        internalSync(this, path, context);
-    }
-
-    @Override
-    public CuratorZookeeperClient getZookeeperClient() {
-        return client.getZookeeperClient();
-    }
-
-    @Override
-    RetryLoop newRetryLoop() {
-        return client.newRetryLoop();
-    }
-
-    @Override
-    ZooKeeper getZooKeeper() throws Exception {
-        return client.getZooKeeper();
-    }
-
-    @Override
-    <DATA_TYPE> void processBackgroundOperation(OperationAndData<DATA_TYPE> operationAndData, CuratorEvent event) {
-        client.processBackgroundOperation(operationAndData, event);
-    }
-
-    @Override
-    void logError(String reason, Throwable e) {
-        client.logError(reason, e);
-    }
-
-    @Override
-    String unfixForNamespace(String path) {
-        return namespace.unfixForNamespace(path);
-    }
-
-    @Override
-    String fixForNamespace(String path) {
-        return namespace.fixForNamespace(path, false);
-    }
-
-    @Override
-    String fixForNamespace(String path, boolean isSequential) {
-        return namespace.fixForNamespace(path, isSequential);
-    }
-
-    @Override
-    public EnsurePath newNamespaceAwareEnsurePath(String path) {
-        return namespace.newNamespaceAwareEnsurePath(path);
     }
 
     @Override

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceFacade.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceFacade.java
@@ -32,6 +32,16 @@ class NamespaceFacade extends DelegatingCuratorFramework {
     }
 
     @Override
+    public void start() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     NamespaceImpl getNamespaceImpl() {
         return namespace;
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceWatchedEvent.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceWatchedEvent.java
@@ -22,7 +22,7 @@ package org.apache.curator.framework.imps;
 import org.apache.zookeeper.WatchedEvent;
 
 class NamespaceWatchedEvent extends WatchedEvent {
-    NamespaceWatchedEvent(InternalCuratorFramework client, WatchedEvent event) {
+    NamespaceWatchedEvent(CuratorFrameworkBase client, WatchedEvent event) {
         super(event.getType(), event.getState(), client.unfixForNamespace(event.getPath()));
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceWatcher.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceWatcher.java
@@ -28,19 +28,19 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 
 class NamespaceWatcher implements Watcher, Closeable {
-    private volatile InternalCuratorFramework client;
+    private volatile CuratorFrameworkBase client;
     private volatile Watcher actualWatcher;
     private final String unfixedPath;
     private volatile CuratorWatcher curatorWatcher;
 
-    NamespaceWatcher(InternalCuratorFramework client, Watcher actualWatcher, String unfixedPath) {
+    NamespaceWatcher(CuratorFrameworkBase client, Watcher actualWatcher, String unfixedPath) {
         this.client = client;
         this.actualWatcher = actualWatcher;
         this.unfixedPath = Preconditions.checkNotNull(unfixedPath, "unfixedPath cannot be null");
         this.curatorWatcher = null;
     }
 
-    NamespaceWatcher(InternalCuratorFramework client, CuratorWatcher curatorWatcher, String unfixedPath) {
+    NamespaceWatcher(CuratorFrameworkBase client, CuratorWatcher curatorWatcher, String unfixedPath) {
         this.client = client;
         this.actualWatcher = null;
         this.curatorWatcher = curatorWatcher;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceWatcher.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/NamespaceWatcher.java
@@ -28,19 +28,19 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 
 class NamespaceWatcher implements Watcher, Closeable {
-    private volatile CuratorFrameworkImpl client;
+    private volatile InternalCuratorFramework client;
     private volatile Watcher actualWatcher;
     private final String unfixedPath;
     private volatile CuratorWatcher curatorWatcher;
 
-    NamespaceWatcher(CuratorFrameworkImpl client, Watcher actualWatcher, String unfixedPath) {
+    NamespaceWatcher(InternalCuratorFramework client, Watcher actualWatcher, String unfixedPath) {
         this.client = client;
         this.actualWatcher = actualWatcher;
         this.unfixedPath = Preconditions.checkNotNull(unfixedPath, "unfixedPath cannot be null");
         this.curatorWatcher = null;
     }
 
-    NamespaceWatcher(CuratorFrameworkImpl client, CuratorWatcher curatorWatcher, String unfixedPath) {
+    NamespaceWatcher(InternalCuratorFramework client, CuratorWatcher curatorWatcher, String unfixedPath) {
         this.client = client;
         this.actualWatcher = null;
         this.curatorWatcher = curatorWatcher;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ProtectedMode.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ProtectedMode.java
@@ -67,7 +67,7 @@ class ProtectedMode {
      * @param createMode create mode in use
      * @throws Exception errors
      */
-    void checkSetSessionId(CuratorFrameworkImpl client, CreateMode createMode) throws Exception {
+    void checkSetSessionId(InternalCuratorFramework client, CreateMode createMode) throws Exception {
         if (doProtected() && (sessionId == 0) && createMode.isEphemeral()) {
             sessionId = client.getZooKeeper().getSessionId();
         }
@@ -82,7 +82,8 @@ class ProtectedMode {
      * @return either the found node or null - client should always use the returned value
      * @throws Exception errors
      */
-    String validateFoundNode(CuratorFrameworkImpl client, CreateMode createMode, String foundNode) throws Exception {
+    String validateFoundNode(InternalCuratorFramework client, CreateMode createMode, String foundNode)
+            throws Exception {
         if (doProtected() && createMode.isEphemeral()) {
             long clientSessionId = client.getZooKeeper().getSessionId();
             if (this.sessionId != clientSessionId) {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ProtectedMode.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ProtectedMode.java
@@ -67,7 +67,7 @@ class ProtectedMode {
      * @param createMode create mode in use
      * @throws Exception errors
      */
-    void checkSetSessionId(InternalCuratorFramework client, CreateMode createMode) throws Exception {
+    void checkSetSessionId(CuratorFrameworkBase client, CreateMode createMode) throws Exception {
         if (doProtected() && (sessionId == 0) && createMode.isEphemeral()) {
             sessionId = client.getZooKeeper().getSessionId();
         }
@@ -82,8 +82,7 @@ class ProtectedMode {
      * @return either the found node or null - client should always use the returned value
      * @throws Exception errors
      */
-    String validateFoundNode(InternalCuratorFramework client, CreateMode createMode, String foundNode)
-            throws Exception {
+    String validateFoundNode(CuratorFrameworkBase client, CreateMode createMode, String foundNode) throws Exception {
         if (doProtected() && createMode.isEphemeral()) {
             long clientSessionId = client.getZooKeeper().getSessionId();
             if (this.sessionId != clientSessionId) {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ReconfigBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ReconfigBuilderImpl.java
@@ -34,7 +34,7 @@ import org.apache.zookeeper.server.DataTree;
 
 public class ReconfigBuilderImpl
         implements ReconfigBuilder, BackgroundOperation<Void>, ErrorListenerReconfigBuilderMain {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
 
     private Backgrounding backgrounding = new Backgrounding();
     private Stat responseStat;
@@ -43,12 +43,12 @@ public class ReconfigBuilderImpl
     private List<String> joining;
     private List<String> leaving;
 
-    public ReconfigBuilderImpl(InternalCuratorFramework client) {
+    public ReconfigBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
     }
 
     public ReconfigBuilderImpl(
-            InternalCuratorFramework client,
+            CuratorFrameworkBase client,
             Backgrounding backgrounding,
             Stat responseStat,
             long fromConfig,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/ReconfigBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/ReconfigBuilderImpl.java
@@ -34,7 +34,7 @@ import org.apache.zookeeper.server.DataTree;
 
 public class ReconfigBuilderImpl
         implements ReconfigBuilder, BackgroundOperation<Void>, ErrorListenerReconfigBuilderMain {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
 
     private Backgrounding backgrounding = new Backgrounding();
     private Stat responseStat;
@@ -43,12 +43,12 @@ public class ReconfigBuilderImpl
     private List<String> joining;
     private List<String> leaving;
 
-    public ReconfigBuilderImpl(CuratorFrameworkImpl client) {
+    public ReconfigBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
     }
 
     public ReconfigBuilderImpl(
-            CuratorFrameworkImpl client,
+            InternalCuratorFramework client,
             Backgrounding backgrounding,
             Stat responseStat,
             long fromConfig,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/RemoveWatchesBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/RemoveWatchesBuilderImpl.java
@@ -37,7 +37,7 @@ public class RemoveWatchesBuilderImpl
                 RemoveWatchesLocal,
                 BackgroundOperation<String>,
                 ErrorListenerPathable<Void> {
-    private CuratorFrameworkImpl client;
+    private InternalCuratorFramework client;
     private Watcher watcher;
     private CuratorWatcher curatorWatcher;
     private WatcherType watcherType;
@@ -46,7 +46,7 @@ public class RemoveWatchesBuilderImpl
     private boolean quietly;
     private Backgrounding backgrounding;
 
-    public RemoveWatchesBuilderImpl(CuratorFrameworkImpl client) {
+    public RemoveWatchesBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
         this.watcher = null;
         this.curatorWatcher = null;
@@ -58,7 +58,7 @@ public class RemoveWatchesBuilderImpl
     }
 
     public RemoveWatchesBuilderImpl(
-            CuratorFrameworkImpl client,
+            InternalCuratorFramework client,
             Watcher watcher,
             CuratorWatcher curatorWatcher,
             WatcherType watcherType,
@@ -191,7 +191,7 @@ public class RemoveWatchesBuilderImpl
         return null;
     }
 
-    protected CuratorFrameworkImpl getClient() {
+    protected InternalCuratorFramework getClient() {
         return client;
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/RemoveWatchesBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/RemoveWatchesBuilderImpl.java
@@ -37,7 +37,7 @@ public class RemoveWatchesBuilderImpl
                 RemoveWatchesLocal,
                 BackgroundOperation<String>,
                 ErrorListenerPathable<Void> {
-    private InternalCuratorFramework client;
+    private CuratorFrameworkBase client;
     private Watcher watcher;
     private CuratorWatcher curatorWatcher;
     private WatcherType watcherType;
@@ -46,7 +46,7 @@ public class RemoveWatchesBuilderImpl
     private boolean quietly;
     private Backgrounding backgrounding;
 
-    public RemoveWatchesBuilderImpl(InternalCuratorFramework client) {
+    public RemoveWatchesBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
         this.watcher = null;
         this.curatorWatcher = null;
@@ -58,7 +58,7 @@ public class RemoveWatchesBuilderImpl
     }
 
     public RemoveWatchesBuilderImpl(
-            InternalCuratorFramework client,
+            CuratorFrameworkBase client,
             Watcher watcher,
             CuratorWatcher curatorWatcher,
             WatcherType watcherType,
@@ -191,7 +191,7 @@ public class RemoveWatchesBuilderImpl
         return null;
     }
 
-    protected InternalCuratorFramework getClient() {
+    protected CuratorFrameworkBase getClient() {
         return client;
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetACLBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetACLBuilderImpl.java
@@ -35,20 +35,21 @@ import org.apache.zookeeper.data.Stat;
 
 public class SetACLBuilderImpl
         implements SetACLBuilder, BackgroundPathable<Stat>, BackgroundOperation<String>, ErrorListenerPathable<Stat> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
 
     private ACLing acling;
     private Backgrounding backgrounding;
     private int version;
 
-    SetACLBuilderImpl(CuratorFrameworkImpl client) {
+    SetACLBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
         backgrounding = new Backgrounding();
         acling = new ACLing(client.getAclProvider());
         version = -1;
     }
 
-    public SetACLBuilderImpl(CuratorFrameworkImpl client, Backgrounding backgrounding, List<ACL> aclList, int version) {
+    public SetACLBuilderImpl(
+            InternalCuratorFramework client, Backgrounding backgrounding, List<ACL> aclList, int version) {
         this.client = client;
         this.acling = new ACLing(client.getAclProvider(), aclList);
         this.version = version;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetACLBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetACLBuilderImpl.java
@@ -35,21 +35,20 @@ import org.apache.zookeeper.data.Stat;
 
 public class SetACLBuilderImpl
         implements SetACLBuilder, BackgroundPathable<Stat>, BackgroundOperation<String>, ErrorListenerPathable<Stat> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
 
     private ACLing acling;
     private Backgrounding backgrounding;
     private int version;
 
-    SetACLBuilderImpl(InternalCuratorFramework client) {
+    SetACLBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
         backgrounding = new Backgrounding();
         acling = new ACLing(client.getAclProvider());
         version = -1;
     }
 
-    public SetACLBuilderImpl(
-            InternalCuratorFramework client, Backgrounding backgrounding, List<ACL> aclList, int version) {
+    public SetACLBuilderImpl(CuratorFrameworkBase client, Backgrounding backgrounding, List<ACL> aclList, int version) {
         this.client = client;
         this.acling = new ACLing(client.getAclProvider(), aclList);
         this.version = version;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
@@ -35,7 +35,7 @@ import org.apache.zookeeper.data.Stat;
 
 public class SetDataBuilderImpl
         implements SetDataBuilder, BackgroundOperation<PathAndBytes>, ErrorListenerPathAndBytesable<Stat> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private Backgrounding backgrounding;
     private int version;
     private boolean compress;
@@ -50,14 +50,15 @@ public class SetDataBuilderImpl
     @VisibleForTesting
     boolean failNextIdempotentCheckForTesting = false;
 
-    SetDataBuilderImpl(CuratorFrameworkImpl client) {
+    SetDataBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
         backgrounding = new Backgrounding();
         version = -1;
         compress = client.compressionEnabled();
     }
 
-    public SetDataBuilderImpl(CuratorFrameworkImpl client, Backgrounding backgrounding, int version, boolean compress) {
+    public SetDataBuilderImpl(
+            InternalCuratorFramework client, Backgrounding backgrounding, int version, boolean compress) {
         this.client = client;
         this.backgrounding = backgrounding;
         this.version = version;
@@ -220,7 +221,7 @@ public class SetDataBuilderImpl
     }
 
     private void backgroundCheckIdempotent(
-            final CuratorFrameworkImpl client,
+            final InternalCuratorFramework client,
             final OperationAndData<PathAndBytes> mainOperationAndData,
             final String path,
             final Backgrounding backgrounding) {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SetDataBuilderImpl.java
@@ -35,7 +35,7 @@ import org.apache.zookeeper.data.Stat;
 
 public class SetDataBuilderImpl
         implements SetDataBuilder, BackgroundOperation<PathAndBytes>, ErrorListenerPathAndBytesable<Stat> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private Backgrounding backgrounding;
     private int version;
     private boolean compress;
@@ -50,15 +50,14 @@ public class SetDataBuilderImpl
     @VisibleForTesting
     boolean failNextIdempotentCheckForTesting = false;
 
-    SetDataBuilderImpl(InternalCuratorFramework client) {
+    SetDataBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
         backgrounding = new Backgrounding();
         version = -1;
         compress = client.compressionEnabled();
     }
 
-    public SetDataBuilderImpl(
-            InternalCuratorFramework client, Backgrounding backgrounding, int version, boolean compress) {
+    public SetDataBuilderImpl(CuratorFrameworkBase client, Backgrounding backgrounding, int version, boolean compress) {
         this.client = client;
         this.backgrounding = backgrounding;
         this.version = version;
@@ -221,7 +220,7 @@ public class SetDataBuilderImpl
     }
 
     private void backgroundCheckIdempotent(
-            final InternalCuratorFramework client,
+            final CuratorFrameworkBase client,
             final OperationAndData<PathAndBytes> mainOperationAndData,
             final String path,
             final Backgrounding backgrounding) {

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SyncBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SyncBuilderImpl.java
@@ -31,15 +31,15 @@ import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.zookeeper.AsyncCallback;
 
 public class SyncBuilderImpl implements SyncBuilder, BackgroundOperation<String>, ErrorListenerPathable<Void> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private Backgrounding backgrounding = new Backgrounding();
 
-    public SyncBuilderImpl(CuratorFrameworkImpl client) {
+    public SyncBuilderImpl(InternalCuratorFramework client) {
         // To change body of created methods use File | Settings | File Templates.
         this.client = client;
     }
 
-    public SyncBuilderImpl(CuratorFrameworkImpl client, Backgrounding backgrounding) {
+    public SyncBuilderImpl(InternalCuratorFramework client, Backgrounding backgrounding) {
         this.client = client;
         this.backgrounding = backgrounding;
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/SyncBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/SyncBuilderImpl.java
@@ -31,15 +31,15 @@ import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.zookeeper.AsyncCallback;
 
 public class SyncBuilderImpl implements SyncBuilder, BackgroundOperation<String>, ErrorListenerPathable<Void> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private Backgrounding backgrounding = new Backgrounding();
 
-    public SyncBuilderImpl(InternalCuratorFramework client) {
+    public SyncBuilderImpl(CuratorFrameworkBase client) {
         // To change body of created methods use File | Settings | File Templates.
         this.client = client;
     }
 
-    public SyncBuilderImpl(InternalCuratorFramework client, Backgrounding backgrounding) {
+    public SyncBuilderImpl(CuratorFrameworkBase client, Backgrounding backgrounding) {
         this.client = client;
         this.backgrounding = backgrounding;
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
@@ -28,11 +28,11 @@ import org.apache.curator.framework.api.TempGetDataBuilder;
 import org.apache.zookeeper.data.Stat;
 
 class TempGetDataBuilderImpl implements TempGetDataBuilder {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private Stat responseStat;
     private boolean decompress;
 
-    TempGetDataBuilderImpl(InternalCuratorFramework client) {
+    TempGetDataBuilderImpl(CuratorFrameworkBase client) {
         this.client = client;
         responseStat = null;
         decompress = client.compressionEnabled();

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/TempGetDataBuilderImpl.java
@@ -28,11 +28,11 @@ import org.apache.curator.framework.api.TempGetDataBuilder;
 import org.apache.zookeeper.data.Stat;
 
 class TempGetDataBuilderImpl implements TempGetDataBuilder {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private Stat responseStat;
     private boolean decompress;
 
-    TempGetDataBuilderImpl(CuratorFrameworkImpl client) {
+    TempGetDataBuilderImpl(InternalCuratorFramework client) {
         this.client = client;
         responseStat = null;
         decompress = client.compressionEnabled();

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/TransactionOpImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/TransactionOpImpl.java
@@ -27,9 +27,9 @@ import org.apache.curator.framework.api.transaction.TransactionOp;
 import org.apache.curator.framework.api.transaction.TransactionSetDataBuilder;
 
 public class TransactionOpImpl implements TransactionOp {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
 
-    public TransactionOpImpl(CuratorFrameworkImpl client) {
+    public TransactionOpImpl(InternalCuratorFramework client) {
         this.client = client;
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/TransactionOpImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/TransactionOpImpl.java
@@ -27,9 +27,9 @@ import org.apache.curator.framework.api.transaction.TransactionOp;
 import org.apache.curator.framework.api.transaction.TransactionSetDataBuilder;
 
 public class TransactionOpImpl implements TransactionOp {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
 
-    public TransactionOpImpl(InternalCuratorFramework client) {
+    public TransactionOpImpl(CuratorFrameworkBase client) {
         this.client = client;
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/WatcherRemovalFacade.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/WatcherRemovalFacade.java
@@ -25,14 +25,24 @@ import org.apache.curator.framework.WatcherRemoveCuratorFramework;
 class WatcherRemovalFacade extends DelegatingCuratorFramework implements WatcherRemoveCuratorFramework {
     private final WatcherRemovalManager removalManager;
 
-    WatcherRemovalFacade(InternalCuratorFramework client) {
+    WatcherRemovalFacade(CuratorFrameworkBase client) {
         super(client);
         removalManager = new WatcherRemovalManager(client);
     }
 
-    private WatcherRemovalFacade(InternalCuratorFramework client, WatcherRemovalManager removalManager) {
+    private WatcherRemovalFacade(CuratorFrameworkBase client, WatcherRemovalManager removalManager) {
         super(client);
         this.removalManager = removalManager;
+    }
+
+    @Override
+    public void start() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException();
     }
 
     WatcherRemovalManager getRemovalManager() {
@@ -51,7 +61,7 @@ class WatcherRemovalFacade extends DelegatingCuratorFramework implements Watcher
 
     @Override
     public CuratorFramework usingNamespace(String newNamespace) {
-        final InternalCuratorFramework newClient = (InternalCuratorFramework) client.usingNamespace(newNamespace);
+        final CuratorFrameworkBase newClient = (CuratorFrameworkBase) client.usingNamespace(newNamespace);
         return new WatcherRemovalFacade(newClient, removalManager);
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/WatcherRemovalFacade.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/WatcherRemovalFacade.java
@@ -19,45 +19,24 @@
 
 package org.apache.curator.framework.imps;
 
-import org.apache.curator.CuratorZookeeperClient;
-import org.apache.curator.RetryLoop;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.WatcherRemoveCuratorFramework;
-import org.apache.curator.framework.api.CuratorEvent;
-import org.apache.curator.framework.api.CuratorListener;
-import org.apache.curator.framework.api.UnhandledErrorListener;
-import org.apache.curator.framework.listen.Listenable;
-import org.apache.curator.framework.state.ConnectionStateListener;
-import org.apache.curator.utils.EnsurePath;
-import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.server.quorum.flexible.QuorumVerifier;
 
-class WatcherRemovalFacade extends CuratorFrameworkImpl implements WatcherRemoveCuratorFramework {
-    private final CuratorFrameworkImpl client;
+class WatcherRemovalFacade extends DelegatingCuratorFramework implements WatcherRemoveCuratorFramework {
     private final WatcherRemovalManager removalManager;
 
-    WatcherRemovalFacade(CuratorFrameworkImpl client) {
-        this(client, new WatcherRemovalManager(client));
-    }
-
-    private WatcherRemovalFacade(CuratorFrameworkImpl client, WatcherRemovalManager removalManager) {
+    WatcherRemovalFacade(InternalCuratorFramework client) {
         super(client);
-        this.client = client;
-        this.removalManager = removalManager;
+        removalManager = new WatcherRemovalManager(client);
     }
 
-    @Override
-    public WatcherRemoveCuratorFramework newWatcherRemoveCuratorFramework() {
-        return client.newWatcherRemoveCuratorFramework();
+    private WatcherRemovalFacade(InternalCuratorFramework client, WatcherRemovalManager removalManager) {
+        super(client);
+        this.removalManager = removalManager;
     }
 
     WatcherRemovalManager getRemovalManager() {
         return removalManager;
-    }
-
-    @Override
-    public QuorumVerifier getCurrentConfig() {
-        return client.getCurrentConfig();
     }
 
     @Override
@@ -71,98 +50,8 @@ class WatcherRemovalFacade extends CuratorFrameworkImpl implements WatcherRemove
     }
 
     @Override
-    public CuratorFramework nonNamespaceView() {
-        return client.nonNamespaceView();
-    }
-
-    @Override
     public CuratorFramework usingNamespace(String newNamespace) {
-        final CuratorFrameworkImpl newClient = (CuratorFrameworkImpl) client.usingNamespace(newNamespace);
+        final InternalCuratorFramework newClient = (InternalCuratorFramework) client.usingNamespace(newNamespace);
         return new WatcherRemovalFacade(newClient, removalManager);
-    }
-
-    @Override
-    public String getNamespace() {
-        return client.getNamespace();
-    }
-
-    @Override
-    public void start() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void close() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Listenable<ConnectionStateListener> getConnectionStateListenable() {
-        return client.getConnectionStateListenable();
-    }
-
-    @Override
-    public Listenable<CuratorListener> getCuratorListenable() {
-        return client.getCuratorListenable();
-    }
-
-    @Override
-    public Listenable<UnhandledErrorListener> getUnhandledErrorListenable() {
-        return client.getUnhandledErrorListenable();
-    }
-
-    @Override
-    public void sync(String path, Object context) {
-        client.sync(path, context);
-    }
-
-    @Override
-    public CuratorZookeeperClient getZookeeperClient() {
-        return client.getZookeeperClient();
-    }
-
-    @Override
-    RetryLoop newRetryLoop() {
-        return client.newRetryLoop();
-    }
-
-    @Override
-    ZooKeeper getZooKeeper() throws Exception {
-        return client.getZooKeeper();
-    }
-
-    @Override
-    <DATA_TYPE> void processBackgroundOperation(OperationAndData<DATA_TYPE> operationAndData, CuratorEvent event) {
-        client.processBackgroundOperation(operationAndData, event);
-    }
-
-    @Override
-    void logError(String reason, Throwable e) {
-        client.logError(reason, e);
-    }
-
-    @Override
-    String unfixForNamespace(String path) {
-        return client.unfixForNamespace(path);
-    }
-
-    @Override
-    String fixForNamespace(String path) {
-        return client.fixForNamespace(path);
-    }
-
-    @Override
-    String fixForNamespace(String path, boolean isSequential) {
-        return client.fixForNamespace(path, isSequential);
-    }
-
-    @Override
-    public EnsurePath newNamespaceAwareEnsurePath(String path) {
-        return client.newNamespaceAwareEnsurePath(path);
-    }
-
-    @Override
-    FailedDeleteManager getFailedDeleteManager() {
-        return client.getFailedDeleteManager();
     }
 }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/WatcherRemovalManager.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/WatcherRemovalManager.java
@@ -31,10 +31,10 @@ import org.slf4j.LoggerFactory;
 
 public class WatcherRemovalManager {
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Set<NamespaceWatcher> entries = Sets.newConcurrentHashSet();
 
-    WatcherRemovalManager(CuratorFrameworkImpl client) {
+    WatcherRemovalManager(InternalCuratorFramework client) {
         this.client = client;
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/WatcherRemovalManager.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/WatcherRemovalManager.java
@@ -31,10 +31,10 @@ import org.slf4j.LoggerFactory;
 
 public class WatcherRemovalManager {
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Set<NamespaceWatcher> entries = Sets.newConcurrentHashSet();
 
-    WatcherRemovalManager(InternalCuratorFramework client) {
+    WatcherRemovalManager(CuratorFrameworkBase client) {
         this.client = client;
     }
 

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/WatchesBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/WatchesBuilderImpl.java
@@ -26,12 +26,12 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.WatcherType;
 
 public class WatchesBuilderImpl extends RemoveWatchesBuilderImpl implements WatchesBuilder {
-    public WatchesBuilderImpl(CuratorFrameworkImpl client) {
+    public WatchesBuilderImpl(InternalCuratorFramework client) {
         super(client);
     }
 
     public WatchesBuilderImpl(
-            CuratorFrameworkImpl client,
+            InternalCuratorFramework client,
             Watcher watcher,
             CuratorWatcher curatorWatcher,
             WatcherType watcherType,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/WatchesBuilderImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/WatchesBuilderImpl.java
@@ -26,12 +26,12 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.WatcherType;
 
 public class WatchesBuilderImpl extends RemoveWatchesBuilderImpl implements WatchesBuilder {
-    public WatchesBuilderImpl(InternalCuratorFramework client) {
+    public WatchesBuilderImpl(CuratorFrameworkBase client) {
         super(client);
     }
 
     public WatchesBuilderImpl(
-            InternalCuratorFramework client,
+            CuratorFrameworkBase client,
             Watcher watcher,
             CuratorWatcher curatorWatcher,
             WatcherType watcherType,

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/Watching.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/Watching.java
@@ -27,31 +27,31 @@ public class Watching {
     private final Watcher watcher;
     private final CuratorWatcher curatorWatcher;
     private final boolean watched;
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private NamespaceWatcher namespaceWatcher;
 
-    public Watching(InternalCuratorFramework client, boolean watched) {
+    public Watching(CuratorFrameworkBase client, boolean watched) {
         this.client = client;
         this.watcher = null;
         this.curatorWatcher = null;
         this.watched = watched;
     }
 
-    public Watching(InternalCuratorFramework client, Watcher watcher) {
+    public Watching(CuratorFrameworkBase client, Watcher watcher) {
         this.client = client;
         this.watcher = watcher;
         this.curatorWatcher = null;
         this.watched = false;
     }
 
-    public Watching(InternalCuratorFramework client, CuratorWatcher watcher) {
+    public Watching(CuratorFrameworkBase client, CuratorWatcher watcher) {
         this.client = client;
         this.watcher = null;
         this.curatorWatcher = watcher;
         this.watched = false;
     }
 
-    public Watching(InternalCuratorFramework client) {
+    public Watching(CuratorFrameworkBase client) {
         this.client = client;
         watcher = null;
         watched = false;

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/Watching.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/Watching.java
@@ -27,31 +27,31 @@ public class Watching {
     private final Watcher watcher;
     private final CuratorWatcher curatorWatcher;
     private final boolean watched;
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private NamespaceWatcher namespaceWatcher;
 
-    public Watching(CuratorFrameworkImpl client, boolean watched) {
+    public Watching(InternalCuratorFramework client, boolean watched) {
         this.client = client;
         this.watcher = null;
         this.curatorWatcher = null;
         this.watched = watched;
     }
 
-    public Watching(CuratorFrameworkImpl client, Watcher watcher) {
+    public Watching(InternalCuratorFramework client, Watcher watcher) {
         this.client = client;
         this.watcher = watcher;
         this.curatorWatcher = null;
         this.watched = false;
     }
 
-    public Watching(CuratorFrameworkImpl client, CuratorWatcher watcher) {
+    public Watching(InternalCuratorFramework client, CuratorWatcher watcher) {
         this.client = client;
         this.watcher = null;
         this.curatorWatcher = watcher;
         this.watched = false;
     }
 
-    public Watching(CuratorFrameworkImpl client) {
+    public Watching(InternalCuratorFramework client) {
         this.client = client;
         watcher = null;
         watched = false;

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCleanState.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCleanState.java
@@ -37,7 +37,7 @@ public class TestCleanState {
 
         try {
             Timing2 timing = new Timing2();
-            CuratorFrameworkImpl internalClient = (CuratorFrameworkImpl) client;
+            InternalCuratorFramework internalClient = (InternalCuratorFramework) client;
             EnsembleTracker ensembleTracker = internalClient.getEnsembleTracker();
             if (ensembleTracker != null) {
                 Awaitility.await().until(() -> !ensembleTracker.hasOutstanding());

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCleanState.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCleanState.java
@@ -37,7 +37,7 @@ public class TestCleanState {
 
         try {
             Timing2 timing = new Timing2();
-            InternalCuratorFramework internalClient = (InternalCuratorFramework) client;
+            CuratorFrameworkBase internalClient = (CuratorFrameworkBase) client;
             EnsembleTracker ensembleTracker = internalClient.getEnsembleTracker();
             if (ensembleTracker != null) {
                 Awaitility.await().until(() -> !ensembleTracker.hasOutstanding());

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFailedDeleteManager.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFailedDeleteManager.java
@@ -250,7 +250,7 @@ public class TestFailedDeleteManager extends BaseClassForTests {
 
         final AtomicBoolean pathAdded = new AtomicBoolean(false);
 
-        ((InternalCuratorFramework) client).getFailedDeleteManager().debugListener =
+        ((CuratorFrameworkBase) client).getFailedDeleteManager().debugListener =
                 new FailedOperationManager.FailedOperationManagerListener<String>() {
 
                     @Override
@@ -277,7 +277,7 @@ public class TestFailedDeleteManager extends BaseClassForTests {
 
         final AtomicBoolean pathAdded = new AtomicBoolean(false);
 
-        ((InternalCuratorFramework) client).getFailedDeleteManager().debugListener =
+        ((CuratorFrameworkBase) client).getFailedDeleteManager().debugListener =
                 new FailedOperationManager.FailedOperationManagerListener<String>() {
 
                     @Override

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFailedDeleteManager.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFailedDeleteManager.java
@@ -250,7 +250,7 @@ public class TestFailedDeleteManager extends BaseClassForTests {
 
         final AtomicBoolean pathAdded = new AtomicBoolean(false);
 
-        ((CuratorFrameworkImpl) client).getFailedDeleteManager().debugListener =
+        ((InternalCuratorFramework) client).getFailedDeleteManager().debugListener =
                 new FailedOperationManager.FailedOperationManagerListener<String>() {
 
                     @Override
@@ -277,7 +277,7 @@ public class TestFailedDeleteManager extends BaseClassForTests {
 
         final AtomicBoolean pathAdded = new AtomicBoolean(false);
 
-        ((CuratorFrameworkImpl) client).getFailedDeleteManager().debugListener =
+        ((InternalCuratorFramework) client).getFailedDeleteManager().debugListener =
                 new FailedOperationManager.FailedOperationManagerListener<String>() {
 
                     @Override

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFramework.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFramework.java
@@ -745,7 +745,7 @@ public class TestFramework extends BaseClassForTests {
 
         client.start();
 
-        CuratorFrameworkImpl nullNamespace = (CuratorFrameworkImpl) client.usingNamespace(null);
+        InternalCuratorFramework nullNamespace = (InternalCuratorFramework) client.usingNamespace(null);
 
         assertNotNull(nullNamespace.getEnsembleTracker());
         assertNotNull(nullNamespace.getNamespaceFacadeCache());

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFramework.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestFramework.java
@@ -745,7 +745,7 @@ public class TestFramework extends BaseClassForTests {
 
         client.start();
 
-        InternalCuratorFramework nullNamespace = (InternalCuratorFramework) client.usingNamespace(null);
+        CuratorFrameworkBase nullNamespace = (CuratorFrameworkBase) client.usingNamespace(null);
 
         assertNotNull(nullNamespace.getEnsembleTracker());
         assertNotNull(nullNamespace.getNamespaceFacadeCache());

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
@@ -218,7 +218,7 @@ public class TestNamespaceFacade extends BaseClassForTests {
                 .connectString("foo")
                 .build();
 
-        assertEquals(((InternalCuratorFramework) client).unfixForNamespace("/foo/bar"), "/foo/bar");
+        assertEquals(((CuratorFrameworkBase) client).unfixForNamespace("/foo/bar"), "/foo/bar");
 
         CloseableUtils.closeQuietly(client);
     }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestNamespaceFacade.java
@@ -217,9 +217,8 @@ public class TestNamespaceFacade extends BaseClassForTests {
                 .retryPolicy(new RetryOneTime(1))
                 .connectString("foo")
                 .build();
-        CuratorFrameworkImpl clientImpl = (CuratorFrameworkImpl) client;
 
-        assertEquals(clientImpl.unfixForNamespace("/foo/bar"), "/foo/bar");
+        assertEquals(((InternalCuratorFramework) client).unfixForNamespace("/foo/bar"), "/foo/bar");
 
         CloseableUtils.closeQuietly(client);
     }

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
@@ -213,7 +213,7 @@ public class TestReconfiguration extends CuratorTestBase {
     public void testAddWithoutEnsembleTracker() throws Exception {
         final String initialClusterCS = cluster.getConnectString();
         try (CuratorFramework client = newClient(cluster.getConnectString(), false)) {
-            assertEquals(((CuratorFrameworkImpl) client).getEnsembleTracker(), null);
+            assertEquals(((InternalCuratorFramework) client).getEnsembleTracker(), null);
             client.start();
 
             QuorumVerifier oldConfig = toQuorumVerifier(client.getConfig().forEnsemble());

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestReconfiguration.java
@@ -213,7 +213,7 @@ public class TestReconfiguration extends CuratorTestBase {
     public void testAddWithoutEnsembleTracker() throws Exception {
         final String initialClusterCS = cluster.getConnectString();
         try (CuratorFramework client = newClient(cluster.getConnectString(), false)) {
-            assertEquals(((InternalCuratorFramework) client).getEnsembleTracker(), null);
+            assertEquals(((CuratorFrameworkBase) client).getEnsembleTracker(), null);
             client.start();
 
             QuorumVerifier oldConfig = toQuorumVerifier(client.getConfig().forEnsemble());

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatchesBuilder.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatchesBuilder.java
@@ -126,7 +126,7 @@ public class TestWatchesBuilder extends CuratorTestBase {
     @Test
     public void testRemoveCuratorWatch() throws Exception {
         Timing timing = new Timing();
-        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder()
+        CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
                 .retryPolicy(new RetryOneTime(1))
                 .build();
@@ -159,7 +159,7 @@ public class TestWatchesBuilder extends CuratorTestBase {
     @Test
     public void testRemoveWatch() throws Exception {
         Timing timing = new Timing();
-        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder()
+        CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
                 .retryPolicy(new RetryOneTime(1))
                 .build();
@@ -184,7 +184,7 @@ public class TestWatchesBuilder extends CuratorTestBase {
     @Test
     public void testRemoveWatchInBackgroundWithCallback() throws Exception {
         Timing timing = new Timing();
-        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder()
+        CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
                 .retryPolicy(new RetryOneTime(1))
                 .build();
@@ -225,7 +225,7 @@ public class TestWatchesBuilder extends CuratorTestBase {
     @Test
     public void testRemoveWatchInBackgroundWithNoCallback() throws Exception {
         Timing timing = new Timing();
-        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder()
+        CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
                 .retryPolicy(new RetryOneTime(1))
                 .build();
@@ -250,7 +250,7 @@ public class TestWatchesBuilder extends CuratorTestBase {
     @Test
     public void testRemoveAllWatches() throws Exception {
         Timing timing = new Timing();
-        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder()
+        CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
                 .retryPolicy(new RetryOneTime(1))
                 .build();
@@ -335,7 +335,7 @@ public class TestWatchesBuilder extends CuratorTestBase {
     @Test
     public void testRemoveLocalWatch() throws Exception {
         Timing timing = new Timing();
-        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder()
+        CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
                 .retryPolicy(new RetryOneTime(1))
                 .build();
@@ -368,7 +368,7 @@ public class TestWatchesBuilder extends CuratorTestBase {
     @Test
     public void testRemoveLocalWatchInBackground() throws Exception {
         Timing timing = new Timing();
-        CuratorFrameworkImpl client = (CuratorFrameworkImpl) CuratorFrameworkFactory.builder()
+        CuratorFramework client = CuratorFrameworkFactory.builder()
                 .connectString(server.getConnectString())
                 .retryPolicy(new RetryOneTime(1))
                 .build();
@@ -510,7 +510,7 @@ public class TestWatchesBuilder extends CuratorTestBase {
 
             final CountDownLatch guaranteeAddedLatch = new CountDownLatch(1);
 
-            ((CuratorFrameworkImpl) client).getFailedRemoveWatcherManager().debugListener =
+            ((InternalCuratorFramework) client).getFailedRemoveWatcherManager().debugListener =
                     new FailedOperationManager.FailedOperationManagerListener<
                             FailedRemoveWatchManager.FailedRemoveWatchDetails>() {
 

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatchesBuilder.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestWatchesBuilder.java
@@ -510,7 +510,7 @@ public class TestWatchesBuilder extends CuratorTestBase {
 
             final CountDownLatch guaranteeAddedLatch = new CountDownLatch(1);
 
-            ((InternalCuratorFramework) client).getFailedRemoveWatcherManager().debugListener =
+            ((CuratorFrameworkBase) client).getFailedRemoveWatcherManager().debugListener =
                     new FailedOperationManager.FailedOperationManagerListener<
                             FailedRemoveWatchManager.FailedRemoveWatchDetails>() {
 

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorEdges.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/leader/TestLeaderSelectorEdges.java
@@ -21,7 +21,6 @@ package org.apache.curator.framework.recipes.leader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.curator.framework.CuratorFramework;
@@ -98,15 +97,13 @@ public class TestLeaderSelectorEdges extends BaseClassForTests {
         } finally {
             try {
                 leaderSelector1.close();
-            } catch (IllegalStateException e) {
-                fail(e.getMessage());
+            } catch (IllegalStateException ignored) {
             }
             try {
                 if (leaderSelector2 != null) {
                     leaderSelector2.close();
                 }
-            } catch (IllegalStateException e) {
-                fail(e.getMessage());
+            } catch (IllegalStateException ignored) {
             }
             client.close();
         }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCreateBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCreateBuilderImpl.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.curator.framework.imps.CreateBuilderImpl;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncCreateBuilder;
 import org.apache.curator.x.async.api.AsyncPathAndBytesable;
@@ -36,7 +36,7 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncCreateBuilderImpl implements AsyncCreateBuilder {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private CreateMode createMode = CreateMode.PERSISTENT;
     private List<ACL> aclList = null;
@@ -45,7 +45,7 @@ class AsyncCreateBuilderImpl implements AsyncCreateBuilder {
     private long ttl = -1;
     private int setDataVersion = -1;
 
-    AsyncCreateBuilderImpl(CuratorFrameworkImpl client, Filters filters) {
+    AsyncCreateBuilderImpl(InternalCuratorFramework client, Filters filters) {
         this.client = client;
         this.filters = filters;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCreateBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCreateBuilderImpl.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.curator.framework.imps.CreateBuilderImpl;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncCreateBuilder;
 import org.apache.curator.x.async.api.AsyncPathAndBytesable;
@@ -36,7 +36,7 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncCreateBuilderImpl implements AsyncCreateBuilder {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private CreateMode createMode = CreateMode.PERSISTENT;
     private List<ACL> aclList = null;
@@ -45,7 +45,7 @@ class AsyncCreateBuilderImpl implements AsyncCreateBuilder {
     private long ttl = -1;
     private int setDataVersion = -1;
 
-    AsyncCreateBuilderImpl(InternalCuratorFramework client, Filters filters) {
+    AsyncCreateBuilderImpl(CuratorFrameworkBase client, Filters filters) {
         this.client = client;
         this.filters = filters;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCuratorFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCuratorFrameworkImpl.java
@@ -28,9 +28,9 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.CuratorMultiTransactionImpl;
 import org.apache.curator.framework.imps.GetACLBuilderImpl;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.framework.imps.SyncBuilderImpl;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
@@ -41,7 +41,7 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
 public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private final WatchMode watchMode;
     private final boolean watched;
@@ -50,9 +50,9 @@ public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
         this(reveal(client), new Filters(null, null, null), WatchMode.stateChangeAndSuccess, false);
     }
 
-    private static InternalCuratorFramework reveal(CuratorFramework client) {
+    private static CuratorFrameworkBase reveal(CuratorFramework client) {
         try {
-            return (InternalCuratorFramework) Objects.requireNonNull(client, "client cannot be null");
+            return (CuratorFrameworkBase) Objects.requireNonNull(client, "client cannot be null");
         } catch (Exception e) {
             throw new IllegalArgumentException(
                     "Only Curator clients created through CuratorFrameworkFactory are supported: "
@@ -61,7 +61,7 @@ public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
     }
 
     public AsyncCuratorFrameworkImpl(
-            InternalCuratorFramework client, Filters filters, WatchMode watchMode, boolean watched) {
+            CuratorFrameworkBase client, Filters filters, WatchMode watchMode, boolean watched) {
         this.client = Objects.requireNonNull(client, "client cannot be null");
         this.filters = Objects.requireNonNull(filters, "filters cannot be null");
         this.watchMode = Objects.requireNonNull(watchMode, "watchMode cannot be null");
@@ -223,7 +223,7 @@ public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
         return filters;
     }
 
-    InternalCuratorFramework getClient() {
+    CuratorFrameworkBase getClient() {
         return client;
     }
 

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCuratorFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncCuratorFrameworkImpl.java
@@ -28,9 +28,9 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
 import org.apache.curator.framework.imps.CuratorMultiTransactionImpl;
 import org.apache.curator.framework.imps.GetACLBuilderImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.framework.imps.SyncBuilderImpl;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
@@ -41,7 +41,7 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
 public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private final WatchMode watchMode;
     private final boolean watched;
@@ -50,9 +50,9 @@ public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
         this(reveal(client), new Filters(null, null, null), WatchMode.stateChangeAndSuccess, false);
     }
 
-    private static CuratorFrameworkImpl reveal(CuratorFramework client) {
+    private static InternalCuratorFramework reveal(CuratorFramework client) {
         try {
-            return (CuratorFrameworkImpl) Objects.requireNonNull(client, "client cannot be null");
+            return (InternalCuratorFramework) Objects.requireNonNull(client, "client cannot be null");
         } catch (Exception e) {
             throw new IllegalArgumentException(
                     "Only Curator clients created through CuratorFrameworkFactory are supported: "
@@ -61,7 +61,7 @@ public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
     }
 
     public AsyncCuratorFrameworkImpl(
-            CuratorFrameworkImpl client, Filters filters, WatchMode watchMode, boolean watched) {
+            InternalCuratorFramework client, Filters filters, WatchMode watchMode, boolean watched) {
         this.client = Objects.requireNonNull(client, "client cannot be null");
         this.filters = Objects.requireNonNull(filters, "filters cannot be null");
         this.watchMode = Objects.requireNonNull(watchMode, "watchMode cannot be null");
@@ -223,7 +223,7 @@ public class AsyncCuratorFrameworkImpl implements AsyncCuratorFramework {
         return filters;
     }
 
-    CuratorFrameworkImpl getClient() {
+    InternalCuratorFramework getClient() {
         return client;
     }
 

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncDeleteBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncDeleteBuilderImpl.java
@@ -24,20 +24,20 @@ import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
 import org.apache.curator.framework.imps.DeleteBuilderImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncDeleteBuilder;
 import org.apache.curator.x.async.api.AsyncPathable;
 import org.apache.curator.x.async.api.DeleteOption;
 
 class AsyncDeleteBuilderImpl implements AsyncDeleteBuilder {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private Set<DeleteOption> options = Collections.emptySet();
     private int version = -1;
 
-    AsyncDeleteBuilderImpl(CuratorFrameworkImpl client, Filters filters) {
+    AsyncDeleteBuilderImpl(InternalCuratorFramework client, Filters filters) {
         this.client = client;
         this.filters = filters;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncDeleteBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncDeleteBuilderImpl.java
@@ -24,20 +24,20 @@ import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.DeleteBuilderImpl;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncDeleteBuilder;
 import org.apache.curator.x.async.api.AsyncPathable;
 import org.apache.curator.x.async.api.DeleteOption;
 
 class AsyncDeleteBuilderImpl implements AsyncDeleteBuilder {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private Set<DeleteOption> options = Collections.emptySet();
     private int version = -1;
 
-    AsyncDeleteBuilderImpl(InternalCuratorFramework client, Filters filters) {
+    AsyncDeleteBuilderImpl(CuratorFrameworkBase client, Filters filters) {
         this.client = client;
         this.filters = filters;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncExistsBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncExistsBuilderImpl.java
@@ -24,8 +24,8 @@ import static org.apache.curator.x.async.details.BackgroundProcs.safeStatProc;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
 import org.apache.curator.framework.imps.ExistsBuilderImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.WatchMode;
 import org.apache.curator.x.async.api.AsyncExistsBuilder;
@@ -34,12 +34,12 @@ import org.apache.curator.x.async.api.ExistsOption;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncExistsBuilderImpl implements AsyncExistsBuilder {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private final WatchMode watchMode;
     private Set<ExistsOption> options = Collections.emptySet();
 
-    AsyncExistsBuilderImpl(CuratorFrameworkImpl client, Filters filters, WatchMode watchMode) {
+    AsyncExistsBuilderImpl(InternalCuratorFramework client, Filters filters, WatchMode watchMode) {
         this.client = client;
         this.filters = filters;
         this.watchMode = watchMode;

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncExistsBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncExistsBuilderImpl.java
@@ -24,8 +24,8 @@ import static org.apache.curator.x.async.details.BackgroundProcs.safeStatProc;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.ExistsBuilderImpl;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.WatchMode;
 import org.apache.curator.x.async.api.AsyncExistsBuilder;
@@ -34,12 +34,12 @@ import org.apache.curator.x.async.api.ExistsOption;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncExistsBuilderImpl implements AsyncExistsBuilder {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private final WatchMode watchMode;
     private Set<ExistsOption> options = Collections.emptySet();
 
-    AsyncExistsBuilderImpl(InternalCuratorFramework client, Filters filters, WatchMode watchMode) {
+    AsyncExistsBuilderImpl(CuratorFrameworkBase client, Filters filters, WatchMode watchMode) {
         this.client = client;
         this.filters = filters;
         this.watchMode = watchMode;

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetChildrenBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetChildrenBuilderImpl.java
@@ -22,8 +22,8 @@ package org.apache.curator.x.async.details;
 import static org.apache.curator.x.async.details.BackgroundProcs.childrenProc;
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import java.util.List;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
 import org.apache.curator.framework.imps.GetChildrenBuilderImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.WatchMode;
 import org.apache.curator.x.async.api.AsyncGetChildrenBuilder;
@@ -31,12 +31,12 @@ import org.apache.curator.x.async.api.AsyncPathable;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncGetChildrenBuilderImpl implements AsyncGetChildrenBuilder {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private final WatchMode watchMode;
     private Stat stat = null;
 
-    AsyncGetChildrenBuilderImpl(CuratorFrameworkImpl client, Filters filters, WatchMode watchMode) {
+    AsyncGetChildrenBuilderImpl(InternalCuratorFramework client, Filters filters, WatchMode watchMode) {
         this.client = client;
         this.filters = filters;
         this.watchMode = watchMode;

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetChildrenBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetChildrenBuilderImpl.java
@@ -22,8 +22,8 @@ package org.apache.curator.x.async.details;
 import static org.apache.curator.x.async.details.BackgroundProcs.childrenProc;
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import java.util.List;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.GetChildrenBuilderImpl;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.WatchMode;
 import org.apache.curator.x.async.api.AsyncGetChildrenBuilder;
@@ -31,12 +31,12 @@ import org.apache.curator.x.async.api.AsyncPathable;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncGetChildrenBuilderImpl implements AsyncGetChildrenBuilder {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private final WatchMode watchMode;
     private Stat stat = null;
 
-    AsyncGetChildrenBuilderImpl(InternalCuratorFramework client, Filters filters, WatchMode watchMode) {
+    AsyncGetChildrenBuilderImpl(CuratorFrameworkBase client, Filters filters, WatchMode watchMode) {
         this.client = client;
         this.filters = filters;
         this.watchMode = watchMode;

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetConfigBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetConfigBuilderImpl.java
@@ -21,8 +21,8 @@ package org.apache.curator.x.async.details;
 
 import static org.apache.curator.x.async.details.BackgroundProcs.dataProc;
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.GetConfigBuilderImpl;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.WatchMode;
 import org.apache.curator.x.async.api.AsyncEnsemblable;
@@ -30,12 +30,12 @@ import org.apache.curator.x.async.api.AsyncGetConfigBuilder;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncGetConfigBuilderImpl implements AsyncGetConfigBuilder {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private final WatchMode watchMode;
     private Stat stat = null;
 
-    AsyncGetConfigBuilderImpl(InternalCuratorFramework client, Filters filters, WatchMode watchMode) {
+    AsyncGetConfigBuilderImpl(CuratorFrameworkBase client, Filters filters, WatchMode watchMode) {
         this.client = client;
         this.filters = filters;
         this.watchMode = watchMode;

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetConfigBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetConfigBuilderImpl.java
@@ -21,8 +21,8 @@ package org.apache.curator.x.async.details;
 
 import static org.apache.curator.x.async.details.BackgroundProcs.dataProc;
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
 import org.apache.curator.framework.imps.GetConfigBuilderImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.WatchMode;
 import org.apache.curator.x.async.api.AsyncEnsemblable;
@@ -30,12 +30,12 @@ import org.apache.curator.x.async.api.AsyncGetConfigBuilder;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncGetConfigBuilderImpl implements AsyncGetConfigBuilder {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private final WatchMode watchMode;
     private Stat stat = null;
 
-    AsyncGetConfigBuilderImpl(CuratorFrameworkImpl client, Filters filters, WatchMode watchMode) {
+    AsyncGetConfigBuilderImpl(InternalCuratorFramework client, Filters filters, WatchMode watchMode) {
         this.client = client;
         this.filters = filters;
         this.watchMode = watchMode;

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetDataBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetDataBuilderImpl.java
@@ -21,8 +21,8 @@ package org.apache.curator.x.async.details;
 
 import static org.apache.curator.x.async.details.BackgroundProcs.dataProc;
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
 import org.apache.curator.framework.imps.GetDataBuilderImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.WatchMode;
 import org.apache.curator.x.async.api.AsyncGetDataBuilder;
@@ -30,13 +30,13 @@ import org.apache.curator.x.async.api.AsyncPathable;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncGetDataBuilderImpl implements AsyncGetDataBuilder {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private final WatchMode watchMode;
     private boolean decompressed;
     private Stat stat = null;
 
-    AsyncGetDataBuilderImpl(CuratorFrameworkImpl client, Filters filters, WatchMode watchMode) {
+    AsyncGetDataBuilderImpl(InternalCuratorFramework client, Filters filters, WatchMode watchMode) {
         this.client = client;
         this.filters = filters;
         this.watchMode = watchMode;

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetDataBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncGetDataBuilderImpl.java
@@ -21,8 +21,8 @@ package org.apache.curator.x.async.details;
 
 import static org.apache.curator.x.async.details.BackgroundProcs.dataProc;
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.GetDataBuilderImpl;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.WatchMode;
 import org.apache.curator.x.async.api.AsyncGetDataBuilder;
@@ -30,13 +30,13 @@ import org.apache.curator.x.async.api.AsyncPathable;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncGetDataBuilderImpl implements AsyncGetDataBuilder {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private final WatchMode watchMode;
     private boolean decompressed;
     private Stat stat = null;
 
-    AsyncGetDataBuilderImpl(InternalCuratorFramework client, Filters filters, WatchMode watchMode) {
+    AsyncGetDataBuilderImpl(CuratorFrameworkBase client, Filters filters, WatchMode watchMode) {
         this.client = client;
         this.filters = filters;
         this.watchMode = watchMode;

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncReconfigBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncReconfigBuilderImpl.java
@@ -22,7 +22,7 @@ package org.apache.curator.x.async.details;
 import static org.apache.curator.x.async.details.BackgroundProcs.ignoredProc;
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import java.util.List;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.framework.imps.ReconfigBuilderImpl;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncEnsemblable;
@@ -30,7 +30,7 @@ import org.apache.curator.x.async.api.AsyncReconfigBuilder;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncReconfigBuilderImpl implements AsyncReconfigBuilder, AsyncEnsemblable<AsyncStage<Void>> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private Stat stat = null;
     private long fromConfig = -1;
@@ -38,7 +38,7 @@ class AsyncReconfigBuilderImpl implements AsyncReconfigBuilder, AsyncEnsemblable
     private List<String> joining = null;
     private List<String> leaving = null;
 
-    AsyncReconfigBuilderImpl(CuratorFrameworkImpl client, Filters filters) {
+    AsyncReconfigBuilderImpl(InternalCuratorFramework client, Filters filters) {
         this.client = client;
         this.filters = filters;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncReconfigBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncReconfigBuilderImpl.java
@@ -22,7 +22,7 @@ package org.apache.curator.x.async.details;
 import static org.apache.curator.x.async.details.BackgroundProcs.ignoredProc;
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import java.util.List;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.ReconfigBuilderImpl;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncEnsemblable;
@@ -30,7 +30,7 @@ import org.apache.curator.x.async.api.AsyncReconfigBuilder;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncReconfigBuilderImpl implements AsyncReconfigBuilder, AsyncEnsemblable<AsyncStage<Void>> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private Stat stat = null;
     private long fromConfig = -1;
@@ -38,7 +38,7 @@ class AsyncReconfigBuilderImpl implements AsyncReconfigBuilder, AsyncEnsemblable
     private List<String> joining = null;
     private List<String> leaving = null;
 
-    AsyncReconfigBuilderImpl(InternalCuratorFramework client, Filters filters) {
+    AsyncReconfigBuilderImpl(CuratorFrameworkBase client, Filters filters) {
         this.client = client;
         this.filters = filters;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncRemoveWatchesBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncRemoveWatchesBuilderImpl.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.curator.framework.api.CuratorWatcher;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.RemoveWatchesBuilderImpl;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncPathable;
@@ -34,14 +34,14 @@ import org.apache.curator.x.async.api.RemoveWatcherOption;
 import org.apache.zookeeper.Watcher;
 
 class AsyncRemoveWatchesBuilderImpl implements AsyncRemoveWatchesBuilder, AsyncPathable<AsyncStage<Void>> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private Watcher.WatcherType watcherType = Watcher.WatcherType.Any;
     private Set<RemoveWatcherOption> options = Collections.emptySet();
     private Watcher watcher = null;
     private CuratorWatcher curatorWatcher = null;
 
-    AsyncRemoveWatchesBuilderImpl(InternalCuratorFramework client, Filters filters) {
+    AsyncRemoveWatchesBuilderImpl(CuratorFrameworkBase client, Filters filters) {
         this.client = client;
         this.filters = filters;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncRemoveWatchesBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncRemoveWatchesBuilderImpl.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.curator.framework.api.CuratorWatcher;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.framework.imps.RemoveWatchesBuilderImpl;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncPathable;
@@ -34,14 +34,14 @@ import org.apache.curator.x.async.api.RemoveWatcherOption;
 import org.apache.zookeeper.Watcher;
 
 class AsyncRemoveWatchesBuilderImpl implements AsyncRemoveWatchesBuilder, AsyncPathable<AsyncStage<Void>> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private Watcher.WatcherType watcherType = Watcher.WatcherType.Any;
     private Set<RemoveWatcherOption> options = Collections.emptySet();
     private Watcher watcher = null;
     private CuratorWatcher curatorWatcher = null;
 
-    AsyncRemoveWatchesBuilderImpl(CuratorFrameworkImpl client, Filters filters) {
+    AsyncRemoveWatchesBuilderImpl(InternalCuratorFramework client, Filters filters) {
         this.client = client;
         this.filters = filters;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncSetACLBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncSetACLBuilderImpl.java
@@ -22,7 +22,7 @@ package org.apache.curator.x.async.details;
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import static org.apache.curator.x.async.details.BackgroundProcs.statProc;
 import java.util.List;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.SetACLBuilderImpl;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncPathable;
@@ -31,12 +31,12 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncSetACLBuilderImpl implements AsyncSetACLBuilder, AsyncPathable<AsyncStage<Stat>> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private int version = -1;
     private List<ACL> aclList = null;
 
-    AsyncSetACLBuilderImpl(InternalCuratorFramework client, Filters filters) {
+    AsyncSetACLBuilderImpl(CuratorFrameworkBase client, Filters filters) {
         this.client = client;
         this.filters = filters;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncSetACLBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncSetACLBuilderImpl.java
@@ -22,7 +22,7 @@ package org.apache.curator.x.async.details;
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import static org.apache.curator.x.async.details.BackgroundProcs.statProc;
 import java.util.List;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.framework.imps.SetACLBuilderImpl;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncPathable;
@@ -31,12 +31,12 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncSetACLBuilderImpl implements AsyncSetACLBuilder, AsyncPathable<AsyncStage<Stat>> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private int version = -1;
     private List<ACL> aclList = null;
 
-    AsyncSetACLBuilderImpl(CuratorFrameworkImpl client, Filters filters) {
+    AsyncSetACLBuilderImpl(InternalCuratorFramework client, Filters filters) {
         this.client = client;
         this.filters = filters;
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncSetDataBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncSetDataBuilderImpl.java
@@ -21,7 +21,7 @@ package org.apache.curator.x.async.details;
 
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import static org.apache.curator.x.async.details.BackgroundProcs.statProc;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.framework.imps.SetDataBuilderImpl;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncPathAndBytesable;
@@ -29,12 +29,12 @@ import org.apache.curator.x.async.api.AsyncSetDataBuilder;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncSetDataBuilderImpl implements AsyncSetDataBuilder {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private boolean compressed;
     private int version = -1;
 
-    AsyncSetDataBuilderImpl(CuratorFrameworkImpl client, Filters filters) {
+    AsyncSetDataBuilderImpl(InternalCuratorFramework client, Filters filters) {
         this.client = client;
         this.filters = filters;
         this.compressed = client.compressionEnabled();

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncSetDataBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncSetDataBuilderImpl.java
@@ -21,7 +21,7 @@ package org.apache.curator.x.async.details;
 
 import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import static org.apache.curator.x.async.details.BackgroundProcs.statProc;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.SetDataBuilderImpl;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncPathAndBytesable;
@@ -29,12 +29,12 @@ import org.apache.curator.x.async.api.AsyncSetDataBuilder;
 import org.apache.zookeeper.data.Stat;
 
 class AsyncSetDataBuilderImpl implements AsyncSetDataBuilder {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private boolean compressed;
     private int version = -1;
 
-    AsyncSetDataBuilderImpl(InternalCuratorFramework client, Filters filters) {
+    AsyncSetDataBuilderImpl(CuratorFrameworkBase client, Filters filters) {
         this.client = client;
         this.filters = filters;
         this.compressed = client.compressionEnabled();

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
@@ -27,7 +27,7 @@ import org.apache.curator.framework.api.VersionPathAndBytesable;
 import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.framework.api.transaction.TransactionCreateBuilder2;
 import org.apache.curator.framework.api.transaction.TransactionSetDataBuilder;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.x.async.api.AsyncPathAndBytesable;
 import org.apache.curator.x.async.api.AsyncPathable;
 import org.apache.curator.x.async.api.AsyncTransactionCheckBuilder;
@@ -39,9 +39,9 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.ACL;
 
 class AsyncTransactionOpImpl implements AsyncTransactionOp {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
 
-    AsyncTransactionOpImpl(CuratorFrameworkImpl client) {
+    AsyncTransactionOpImpl(InternalCuratorFramework client) {
         this.client = client;
     }
 

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncTransactionOpImpl.java
@@ -27,7 +27,7 @@ import org.apache.curator.framework.api.VersionPathAndBytesable;
 import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.framework.api.transaction.TransactionCreateBuilder2;
 import org.apache.curator.framework.api.transaction.TransactionSetDataBuilder;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.x.async.api.AsyncPathAndBytesable;
 import org.apache.curator.x.async.api.AsyncPathable;
 import org.apache.curator.x.async.api.AsyncTransactionCheckBuilder;
@@ -39,9 +39,9 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.ACL;
 
 class AsyncTransactionOpImpl implements AsyncTransactionOp {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
 
-    AsyncTransactionOpImpl(InternalCuratorFramework client) {
+    AsyncTransactionOpImpl(CuratorFrameworkBase client) {
         this.client = client;
     }
 

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncWatchBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncWatchBuilderImpl.java
@@ -24,7 +24,7 @@ import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import org.apache.curator.framework.api.CuratorWatcher;
 import org.apache.curator.framework.api.WatchableBase;
 import org.apache.curator.framework.imps.AddWatchBuilderImpl;
-import org.apache.curator.framework.imps.CuratorFrameworkImpl;
+import org.apache.curator.framework.imps.InternalCuratorFramework;
 import org.apache.curator.framework.imps.Watching;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncPathable;
@@ -38,12 +38,12 @@ class AsyncWatchBuilderImpl
                 AsyncWatchBuilder2,
                 WatchableBase<AsyncPathable<AsyncStage<Void>>>,
                 AsyncPathable<AsyncStage<Void>> {
-    private final CuratorFrameworkImpl client;
+    private final InternalCuratorFramework client;
     private final Filters filters;
     private Watching watching;
     private AddWatchMode mode = AddWatchMode.PERSISTENT_RECURSIVE;
 
-    AsyncWatchBuilderImpl(CuratorFrameworkImpl client, Filters filters) {
+    AsyncWatchBuilderImpl(InternalCuratorFramework client, Filters filters) {
         this.client = client;
         this.filters = filters;
         watching = new Watching(client, true);

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncWatchBuilderImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/details/AsyncWatchBuilderImpl.java
@@ -24,7 +24,7 @@ import static org.apache.curator.x.async.details.BackgroundProcs.safeCall;
 import org.apache.curator.framework.api.CuratorWatcher;
 import org.apache.curator.framework.api.WatchableBase;
 import org.apache.curator.framework.imps.AddWatchBuilderImpl;
-import org.apache.curator.framework.imps.InternalCuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.imps.Watching;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.curator.x.async.api.AsyncPathable;
@@ -38,12 +38,12 @@ class AsyncWatchBuilderImpl
                 AsyncWatchBuilder2,
                 WatchableBase<AsyncPathable<AsyncStage<Void>>>,
                 AsyncPathable<AsyncStage<Void>> {
-    private final InternalCuratorFramework client;
+    private final CuratorFrameworkBase client;
     private final Filters filters;
     private Watching watching;
     private AddWatchMode mode = AddWatchMode.PERSISTENT_RECURSIVE;
 
-    AsyncWatchBuilderImpl(InternalCuratorFramework client, Filters filters) {
+    AsyncWatchBuilderImpl(CuratorFrameworkBase client, Filters filters) {
         this.client = client;
         this.filters = filters;
         watching = new Watching(client, true);


### PR DESCRIPTION
This closes https://github.com/apache/curator/issues/1233.

Currently, the `CuratorFrameworkImpl` hierarchy is neither simple nor composable.

Ideally, there should be only one instance of `CuratorFrameworkImpl`. Additional functionalities should be added by intercepting methods on purpose, but not by cloning through `CuratorFrameworkImpl(CuratorFrameworkImpl parent)`.

We could take CURATOR-626 and CURATOR-710 as lessons to know how brittle the currently hierarchy.