### PR TITLE
CURATOR-728: Not issue ZooKeeper::create if possible in ZkPaths::mkdirs

### DIFF
--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreate.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestCreate.java
@@ -47,6 +47,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class TestCreate extends BaseClassForTests {
@@ -684,6 +685,7 @@ public class TestCreate extends BaseClassForTests {
      * but just to the first ancestor parent. (See https://issues.apache.org/jira/browse/ZOOKEEPER-2590)
      */
     @Test
+    @Tag("ZOOKEEPER-2590")
     public void testForbiddenAncestors() throws Exception {
         CuratorFramework client = createClient(testACLProvider);
         try {
@@ -696,9 +698,10 @@ public class TestCreate extends BaseClassForTests {
 
             // In creation attempts where the parent ("/bat") has ACL that restricts read, creation request fails.
             try {
-                client.create().creatingParentsIfNeeded().forPath("/bat/bost");
+                client.create().creatingParentsIfNeeded().forPath("/bat/foo/bost");
                 fail("Expected NoAuthException when not authorized to read new node grandparent");
             } catch (KeeperException.NoAuthException noAuthException) {
+                assertEquals(noAuthException.getPath(), "/bat");
             }
 
             // But creating a node in the same subtree where its grandparent has read access is allowed and

--- a/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnsureContainers.java
+++ b/curator-framework/src/test/java/org/apache/curator/framework/imps/TestEnsureContainers.java
@@ -19,14 +19,20 @@
 
 package org.apache.curator.framework.imps;
 
+import static org.apache.zookeeper.ZooDefs.Ids.ANYONE_ID_UNSAFE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.Collections;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.EnsureContainers;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.BaseClassForTests;
 import org.apache.curator.utils.CloseableUtils;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
 import org.junit.jupiter.api.Test;
 
 public class TestEnsureContainers extends BaseClassForTests {
@@ -59,6 +65,33 @@ public class TestEnsureContainers extends BaseClassForTests {
             client.delete().forPath("/one/two/three");
             ensureContainers.ensure();
             assertNull(client.checkExists().forPath("/one/two/three"));
+        } finally {
+            CloseableUtils.closeQuietly(client);
+        }
+    }
+
+    @Test
+    public void testNodeExistsButNoCreatePermission() throws Exception {
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), new RetryOneTime(1));
+        try {
+            client.start();
+
+            // given: "/bar/foo" created
+            client.create().creatingParentsIfNeeded().forPath("/bar/foo");
+            // given: only permission read to "/bar"
+            client.setACL()
+                    .withACL(Collections.singletonList(new ACL(ZooDefs.Perms.READ, ANYONE_ID_UNSAFE)))
+                    .forPath("/bar");
+
+            // check: create "/bar/foo" will fail with NoAuth
+            assertThrows(KeeperException.NoAuthException.class, () -> {
+                client.create().forPath("/bar/foo");
+            });
+
+            // when: mkdirs("/bar/foo")
+            // then: everything fine as "/bar/foo" exists, and we have READ permission
+            EnsureContainers ensureContainers = new EnsureContainers(client, "/bar/foo");
+            ensureContainers.ensure();
         } finally {
             CloseableUtils.closeQuietly(client);
         }

--- a/curator-test-zk37/pom.xml
+++ b/curator-test-zk37/pom.xml
@@ -224,7 +224,7 @@
                         <dependency>org.apache.curator:curator-recipes</dependency>
                         <dependency>org.apache.curator:curator-client</dependency>
                     </dependenciesToScan>
-                    <excludedGroups>master</excludedGroups>
+                    <excludedGroups>master,ZOOKEEPER-2590</excludedGroups>
                 </configuration>
             </plugin>
         </plugins>

--- a/curator-test-zk38/pom.xml
+++ b/curator-test-zk38/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>curator-test-zk38</artifactId>
 
     <properties>
-        <zookeeper-38-version>3.8.3</zookeeper-38-version>
+        <zookeeper-38-version>3.8.4</zookeeper-38-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
`ZkPaths::mkdir("/bar/foo")` will not run into `NoAuthException` if
"/bar/foo" exists, and we have `READ` permission to "/bar/foo" but not
`CREATE` permission to "/bar".
