### PR TITLE
chore: Enable GitHub Issues

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,7 +26,7 @@ github:
     - consensus
   features:
     wiki: false
-    issues: false
+    issues: true
     projects: false
   enabled_merge_buttons:
     squash:  true


### PR DESCRIPTION
Here we have several open issues:

1. @gmcdonald, will this move stop all the possibility that INFRA will help migrate JIRA tickets? I remember that I was told not to enable GitHub Issues by myself but to wait for INFRA's response. But as you can see, the ticket gets stalled, and we don't know whether it will make progress.

2. The PR title and commit message flavor may change. As we now follow `CURATOR-xxx` where `xxx` is mapped to a JIRA ticket and we have the autolink to JIRA. With GitHub issues, it can be easily linked within the PR description. And thus,
    1. I'd keep the `autolink_jira` option for all existing PRs and commits;
    2. I'd suggest all the following PR/commit use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

3. The release note generation step in release process should be updated. I suppose either GitHub releases can autogenerate one, or we maintain a CHANGELOG file and update it per PR. Either should work.