### PR TITLE
CURATOR-729: Fix PersistentWatcher dead loop after curator closed

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/api/CuratorClosedException.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/api/CuratorClosedException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.curator.framework.api;
+
+public class CuratorClosedException extends IllegalStateException {
+    public CuratorClosedException() {
+        super("Expected state [STARTED] was [STOPPED]");
+    }
+}

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -51,6 +51,7 @@ import org.apache.curator.framework.WatcherRemoveCuratorFramework;
 import org.apache.curator.framework.api.ACLProvider;
 import org.apache.curator.framework.api.CompressionProvider;
 import org.apache.curator.framework.api.CreateBuilder;
+import org.apache.curator.framework.api.CuratorClosedException;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.framework.api.CuratorListener;
@@ -462,11 +463,15 @@ public class CuratorFrameworkImpl implements CuratorFramework {
 
     private void checkState() {
         CuratorFrameworkState state = getState();
-        Preconditions.checkState(
-                state == CuratorFrameworkState.STARTED,
-                "Expected state [%s] was [%s]",
-                CuratorFrameworkState.STARTED,
-                state);
+        switch (state) {
+            case STARTED:
+                return;
+            case STOPPED:
+                throw new CuratorClosedException();
+            default:
+                String msg = String.format("Expected state [%s] was [%s]", CuratorFrameworkState.STARTED, state);
+                throw new IllegalStateException(msg);
+        }
     }
 
     @Override
@@ -525,11 +530,13 @@ public class CuratorFrameworkImpl implements CuratorFramework {
 
     @Override
     public ReconfigBuilder reconfig() {
+        checkState();
         return new ReconfigBuilderImpl(this);
     }
 
     @Override
     public GetConfigBuilder getConfig() {
+        checkState();
         return new GetConfigBuilderImpl(this);
     }
 
@@ -577,11 +584,13 @@ public class CuratorFrameworkImpl implements CuratorFramework {
 
     @Override
     public SyncBuilder sync() {
+        checkState();
         return new SyncBuilderImpl(this);
     }
 
     @Override
     public RemoveWatchesBuilder watches() {
+        checkState();
         return new RemoveWatchesBuilderImpl(this);
     }
 
@@ -590,6 +599,7 @@ public class CuratorFrameworkImpl implements CuratorFramework {
         Preconditions.checkState(
                 zookeeperCompatibility.hasPersistentWatchers(),
                 "watchers() is not supported in the ZooKeeper library and/or server being used. Use watches() instead.");
+        checkState();
         return new WatchesBuilderImpl(this);
     }
 


### PR DESCRIPTION
The dead loop is multifold:
1. `CuratorFramework::watchers` does not check `CuratorFrameworkState` as `getData` or others do.
2. `PersistentWatcher` loops itself through `reset` in `BackgroundCallback`.
3. Callback in `inBackground(callback).forPath(path)` is invoked synchronously.

This commit enforces `CuratorFrameworkState` checking also to `watchers`, `watches`, `sync`, `reconfig` and `getConfig`.

Additionally, this commit will issue `KeeperState.Closed` to listeners of `PersistentWatcher` when curator get closed. This is not required to fix CURATOR-729, but will make the closing behavior consistent with ZooKeeper. Also, I think it is good for asynchronous `Watcher`.

Refs: CURATOR-529, CURATOR-673