### PR TITLE
[CURATOR-730] Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         java: [8, 11, 17, 21]
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v3
 
@@ -91,7 +91,7 @@ jobs:
       matrix:
         zookeeper: [curator-test-zk38, curator-test-zk37, curator-test-zk36, curator-test-zk35]
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -22,6 +22,7 @@
 <develocity
         xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+    <projectId>curator</projectId>
     <server>
         <url>https://develocity.apache.org</url>
     </server>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -23,7 +23,7 @@
         xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
     <server>
-        <url>https://ge.apache.org</url>
+        <url>https://develocity.apache.org</url>
     </server>
     <buildScan>
         <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -25,7 +25,7 @@
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
         <!--
-          Make sure the extension version is compatible with server version of https://ge.apache.org/, otherwise CI
+          Make sure the extension version is compatible with server version of https://develocity.apache.org/, otherwise CI
           could pass while build scan rejected. It might be good to fail CI in this case, so we can drop this comment,
           but I did not find an option.
 
@@ -36,6 +36,6 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>2.0</version>
+        <version>2.0.1</version>
     </extension>
 </extensions>


### PR DESCRIPTION
This PR migrates the Curator project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR sets a projectId for use by Develocity.

https://issues.apache.org/jira/browse/CURATOR-730