### PR TITLE
GH-1246. Asynchronously initialize cache before reading

### DIFF
--- a/curator-x-async/pom.xml
+++ b/curator-x-async/pom.xml
@@ -65,6 +65,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/ModeledFramework.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/ModeledFramework.java
@@ -94,6 +94,13 @@ public interface ModeledFramework<T> {
     CachedModeledFramework<T> cached(ExecutorService executor);
 
     /**
+     * Return a cached framework which waits for cache to be initialized before accessing it.
+     *
+     * @return wrapped cached framework that waits for initialization.
+     */
+    CachedModeledFramework<T> initialized();
+
+    /**
      * Return mutator APIs that work with {@link org.apache.curator.x.async.modeled.versioned.Versioned} containers
      *
      * @return wrapped instance

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
@@ -185,6 +185,11 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T> {
     }
 
     @Override
+    public CachedModeledFramework<T> initialized() {
+        return new InitializedCachedModeledFramework<>(this);
+    }
+
+    @Override
     public AsyncStage<Stat> update(T model) {
         return client.update(model);
     }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/InitializedCachedModeledFramework.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/InitializedCachedModeledFramework.java
@@ -19,6 +19,9 @@
 
 package org.apache.curator.x.async.modeled.details;
 
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
 import org.apache.curator.framework.listen.Listenable;
@@ -34,256 +37,251 @@ import org.apache.curator.x.async.modeled.cached.ModeledCacheListener;
 import org.apache.curator.x.async.modeled.versioned.VersionedModeledFramework;
 import org.apache.zookeeper.data.Stat;
 
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.function.Supplier;
-
 public class InitializedCachedModeledFramework<T> implements CachedModeledFramework<T> {
 
-  private final CachedModeledFramework<T> framework;
-  private final ModelStage<Void> init;
+    private final CachedModeledFramework<T> framework;
+    private final ModelStage<Void> init;
 
-  private InitializedCachedModeledFramework(CachedModeledFramework<T> framework, ModelStage<Void> init) {
-    this.framework = framework;
-    this.init = init;
-  }
+    private InitializedCachedModeledFramework(CachedModeledFramework<T> framework, ModelStage<Void> init) {
+        this.framework = framework;
+        this.init = init;
+    }
 
-  InitializedCachedModeledFramework(CachedModeledFramework<T> framework) {
-    this.framework = framework;
-    init = ModelStage.make();
-    listenable().addListener(new ModeledCacheListener<T>() {
+    InitializedCachedModeledFramework(CachedModeledFramework<T> framework) {
+        this.framework = framework;
+        init = ModelStage.make();
+        listenable().addListener(new ModeledCacheListener<T>() {
 
-      @Override
-      public void accept(Type type, ZPath path, Stat stat, Object model) {
-        // NOP
-      }
+            @Override
+            public void accept(Type type, ZPath path, Stat stat, Object model) {
+                // NOP
+            }
 
-      @Override
-      public void initialized() {
-        init.complete(null);
-        ModeledCacheListener.super.initialized();
-      }
+            @Override
+            public void initialized() {
+                init.complete(null);
+                ModeledCacheListener.super.initialized();
+            }
 
-      @Override
-      public void handleException(Exception e) {
-        init.completeExceptionally(e);
-        ModeledCacheListener.super.handleException(e);
-      }
-    });
-  }
-
-  @Override
-  public ModeledCache<T> cache() {
-    return framework.cache();
-  }
-
-  @Override
-  public void start() {
-    framework.start();
-  }
-
-  @Override
-  public void close() {
-    framework.close();
-  }
-
-  @Override
-  public Listenable<ModeledCacheListener<T>> listenable() {
-    return framework.listenable();
-  }
-
-  @Override
-  public AsyncStage<List<ZNode<T>>> childrenAsZNodes() {
-    return internalRead(framework::childrenAsZNodes);
-  }
-
-  @Override
-  public CuratorOp createOp(T model) {
-    return framework.createOp(model);
-  }
-
-  @Override
-  public CuratorOp updateOp(T model) {
-    return framework.updateOp(model);
-  }
-
-  @Override
-  public CuratorOp updateOp(T model, int version) {
-    return framework.updateOp(model, version);
-  }
-
-  @Override
-  public CuratorOp deleteOp() {
-    return framework.deleteOp();
-  }
-
-  @Override
-  public CuratorOp deleteOp(int version) {
-    return framework.deleteOp(version);
-  }
-
-  @Override
-  public CuratorOp checkExistsOp() {
-    return framework.checkExistsOp();
-  }
-
-  @Override
-  public CuratorOp checkExistsOp(int version) {
-    return framework.checkExistsOp(version);
-  }
-
-  @Override
-  public AsyncStage<List<CuratorTransactionResult>> inTransaction(List<CuratorOp> operations) {
-    return framework.inTransaction(operations);
-  }
-
-  @Override
-  public CachedModeledFramework<T> cached() {
-    throw new UnsupportedOperationException("Already a cached instance");
-  }
-
-  @Override
-  public CachedModeledFramework<T> cached(ExecutorService executor) {
-    throw new UnsupportedOperationException("Already a cached instance");
-  }
-
-  @Override
-  public VersionedModeledFramework<T> versioned() {
-    return new VersionedModeledFrameworkImpl<>(this);
-  }
-
-  @Override
-  public AsyncCuratorFramework unwrap() {
-    return framework.unwrap();
-  }
-
-  @Override
-  public ModelSpec<T> modelSpec() {
-    return framework.modelSpec();
-  }
-
-  @Override
-  public CachedModeledFramework<T> child(Object child) {
-    return new InitializedCachedModeledFramework<>(framework.child(child), init);
-  }
-
-  @Override
-  public ModeledFramework<T> parent() {
-    throw new UnsupportedOperationException(
-        "Not supported for CachedModeledFramework. Instead, call parent() on the ModeledFramework before calling cached()");
-  }
-
-  @Override
-  public CachedModeledFramework<T> withPath(ZPath path) {
-    return new InitializedCachedModeledFramework<>(framework.withPath(path), init);
-  }
-
-  @Override
-  public AsyncStage<String> set(T model) {
-    return framework.set(model);
-  }
-
-  @Override
-  public AsyncStage<String> set(T model, int version) {
-    return framework.set(model, version);
-  }
-
-  @Override
-  public AsyncStage<String> set(T model, Stat storingStatIn) {
-    return framework.set(model, storingStatIn);
-  }
-
-  @Override
-  public AsyncStage<String> set(T model, Stat storingStatIn, int version) {
-    return framework.set(model, storingStatIn, version);
-  }
-
-  @Override
-  public AsyncStage<T> read() {
-    return internalRead(framework::read);
-  }
-
-  @Override
-  public AsyncStage<T> read(Stat storingStatIn) {
-    return internalRead(() -> framework.read(storingStatIn));
-  }
-
-  @Override
-  public AsyncStage<ZNode<T>> readAsZNode() {
-    return internalRead(framework::readAsZNode);
-  }
-
-  @Override
-  public AsyncStage<Stat> update(T model) {
-    return framework.update(model);
-  }
-
-  @Override
-  public AsyncStage<Stat> update(T model, int version) {
-    return framework.update(model, version);
-  }
-
-  @Override
-  public AsyncStage<Void> delete() {
-    return framework.delete();
-  }
-
-  @Override
-  public AsyncStage<Void> delete(int version) {
-    return framework.delete(version);
-  }
-
-  @Override
-  public AsyncStage<Stat> checkExists() {
-    return framework.checkExists();
-  }
-
-  @Override
-  public AsyncStage<List<ZPath>> children() {
-    return internalRead(framework::children);
-  }
-
-  @Override
-  public AsyncStage<T> readThrough() {
-    return internalRead(framework::readThrough);
-  }
-
-  @Override
-  public AsyncStage<T> readThrough(Stat storingStatIn) {
-    return internalRead(() -> framework.readThrough(storingStatIn));
-  }
-
-  @Override
-  public AsyncStage<ZNode<T>> readThroughAsZNode() {
-    return internalRead(framework::readThroughAsZNode);
-  }
-
-  @Override
-  public AsyncStage<List<T>> list() {
-    return internalRead(framework::list);
-  }
-
-  @Override
-  public CachedModeledFramework<T> initialized() {
-    throw new UnsupportedOperationException("Already an initialized instance");
-  }
-
-  private <U> AsyncStage<U> internalRead(Supplier<AsyncStage<U>> innerSupplier) {
-    ModelStage<U> stage = ModelStage.make();
-    init.whenComplete((data, throwable) -> {
-          if (throwable == null) {
-            innerSupplier.get().whenComplete((data1, throwable1) -> {
-                  if (throwable1 == null) {
-                    stage.complete(data1);
-                  } else {
-                    stage.completeExceptionally(throwable1);
-                  }
-                }
-            );
-          } else {
-            stage.completeExceptionally(throwable);
-          }
+            @Override
+            public void handleException(Exception e) {
+                init.completeExceptionally(e);
+                ModeledCacheListener.super.handleException(e);
+            }
         });
-    return stage;
-  }
+    }
+
+    @Override
+    public ModeledCache<T> cache() {
+        return framework.cache();
+    }
+
+    @Override
+    public void start() {
+        framework.start();
+    }
+
+    @Override
+    public void close() {
+        framework.close();
+    }
+
+    @Override
+    public Listenable<ModeledCacheListener<T>> listenable() {
+        return framework.listenable();
+    }
+
+    @Override
+    public AsyncStage<List<ZNode<T>>> childrenAsZNodes() {
+        return internalRead(framework::childrenAsZNodes);
+    }
+
+    @Override
+    public CuratorOp createOp(T model) {
+        return framework.createOp(model);
+    }
+
+    @Override
+    public CuratorOp updateOp(T model) {
+        return framework.updateOp(model);
+    }
+
+    @Override
+    public CuratorOp updateOp(T model, int version) {
+        return framework.updateOp(model, version);
+    }
+
+    @Override
+    public CuratorOp deleteOp() {
+        return framework.deleteOp();
+    }
+
+    @Override
+    public CuratorOp deleteOp(int version) {
+        return framework.deleteOp(version);
+    }
+
+    @Override
+    public CuratorOp checkExistsOp() {
+        return framework.checkExistsOp();
+    }
+
+    @Override
+    public CuratorOp checkExistsOp(int version) {
+        return framework.checkExistsOp(version);
+    }
+
+    @Override
+    public AsyncStage<List<CuratorTransactionResult>> inTransaction(List<CuratorOp> operations) {
+        return framework.inTransaction(operations);
+    }
+
+    @Override
+    public CachedModeledFramework<T> cached() {
+        throw new UnsupportedOperationException("Already a cached instance");
+    }
+
+    @Override
+    public CachedModeledFramework<T> cached(ExecutorService executor) {
+        throw new UnsupportedOperationException("Already a cached instance");
+    }
+
+    @Override
+    public VersionedModeledFramework<T> versioned() {
+        return new VersionedModeledFrameworkImpl<>(this);
+    }
+
+    @Override
+    public AsyncCuratorFramework unwrap() {
+        return framework.unwrap();
+    }
+
+    @Override
+    public ModelSpec<T> modelSpec() {
+        return framework.modelSpec();
+    }
+
+    @Override
+    public CachedModeledFramework<T> child(Object child) {
+        return new InitializedCachedModeledFramework<>(framework.child(child), init);
+    }
+
+    @Override
+    public ModeledFramework<T> parent() {
+        throw new UnsupportedOperationException(
+                "Not supported for CachedModeledFramework. Instead, call parent() on the ModeledFramework before calling cached()");
+    }
+
+    @Override
+    public CachedModeledFramework<T> withPath(ZPath path) {
+        return new InitializedCachedModeledFramework<>(framework.withPath(path), init);
+    }
+
+    @Override
+    public AsyncStage<String> set(T model) {
+        return framework.set(model);
+    }
+
+    @Override
+    public AsyncStage<String> set(T model, int version) {
+        return framework.set(model, version);
+    }
+
+    @Override
+    public AsyncStage<String> set(T model, Stat storingStatIn) {
+        return framework.set(model, storingStatIn);
+    }
+
+    @Override
+    public AsyncStage<String> set(T model, Stat storingStatIn, int version) {
+        return framework.set(model, storingStatIn, version);
+    }
+
+    @Override
+    public AsyncStage<T> read() {
+        return internalRead(framework::read);
+    }
+
+    @Override
+    public AsyncStage<T> read(Stat storingStatIn) {
+        return internalRead(() -> framework.read(storingStatIn));
+    }
+
+    @Override
+    public AsyncStage<ZNode<T>> readAsZNode() {
+        return internalRead(framework::readAsZNode);
+    }
+
+    @Override
+    public AsyncStage<Stat> update(T model) {
+        return framework.update(model);
+    }
+
+    @Override
+    public AsyncStage<Stat> update(T model, int version) {
+        return framework.update(model, version);
+    }
+
+    @Override
+    public AsyncStage<Void> delete() {
+        return framework.delete();
+    }
+
+    @Override
+    public AsyncStage<Void> delete(int version) {
+        return framework.delete(version);
+    }
+
+    @Override
+    public AsyncStage<Stat> checkExists() {
+        return framework.checkExists();
+    }
+
+    @Override
+    public AsyncStage<List<ZPath>> children() {
+        return internalRead(framework::children);
+    }
+
+    @Override
+    public AsyncStage<T> readThrough() {
+        return internalRead(framework::readThrough);
+    }
+
+    @Override
+    public AsyncStage<T> readThrough(Stat storingStatIn) {
+        return internalRead(() -> framework.readThrough(storingStatIn));
+    }
+
+    @Override
+    public AsyncStage<ZNode<T>> readThroughAsZNode() {
+        return internalRead(framework::readThroughAsZNode);
+    }
+
+    @Override
+    public AsyncStage<List<T>> list() {
+        return internalRead(framework::list);
+    }
+
+    @Override
+    public CachedModeledFramework<T> initialized() {
+        throw new UnsupportedOperationException("Already an initialized instance");
+    }
+
+    private <U> AsyncStage<U> internalRead(Supplier<AsyncStage<U>> innerSupplier) {
+        ModelStage<U> stage = ModelStage.make();
+        init.whenComplete((data, throwable) -> {
+            if (throwable == null) {
+                innerSupplier.get().whenComplete((data1, throwable1) -> {
+                    if (throwable1 == null) {
+                        stage.complete(data1);
+                    } else {
+                        stage.completeExceptionally(throwable1);
+                    }
+                });
+            } else {
+                stage.completeExceptionally(throwable);
+            }
+        });
+        return stage;
+    }
 }

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/InitializedCachedModeledFramework.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/InitializedCachedModeledFramework.java
@@ -39,16 +39,16 @@ import org.apache.zookeeper.data.Stat;
 
 public class InitializedCachedModeledFramework<T> implements CachedModeledFramework<T> {
 
-    private final CachedModeledFramework<T> framework;
+    private final CachedModeledFramework<T> client;
     private final ModelStage<Void> init;
 
-    private InitializedCachedModeledFramework(CachedModeledFramework<T> framework, ModelStage<Void> init) {
-        this.framework = framework;
+    private InitializedCachedModeledFramework(CachedModeledFramework<T> client, ModelStage<Void> init) {
+        this.client = client;
         this.init = init;
     }
 
-    InitializedCachedModeledFramework(CachedModeledFramework<T> framework) {
-        this.framework = framework;
+    InitializedCachedModeledFramework(CachedModeledFramework<T> client) {
+        this.client = client;
         init = ModelStage.make();
         listenable().addListener(new ModeledCacheListener<T>() {
 
@@ -73,67 +73,67 @@ public class InitializedCachedModeledFramework<T> implements CachedModeledFramew
 
     @Override
     public ModeledCache<T> cache() {
-        return framework.cache();
+        return client.cache();
     }
 
     @Override
     public void start() {
-        framework.start();
+        client.start();
     }
 
     @Override
     public void close() {
-        framework.close();
+        client.close();
     }
 
     @Override
     public Listenable<ModeledCacheListener<T>> listenable() {
-        return framework.listenable();
+        return client.listenable();
     }
 
     @Override
     public AsyncStage<List<ZNode<T>>> childrenAsZNodes() {
-        return internalRead(framework::childrenAsZNodes);
+        return internalRead(client::childrenAsZNodes);
     }
 
     @Override
     public CuratorOp createOp(T model) {
-        return framework.createOp(model);
+        return client.createOp(model);
     }
 
     @Override
     public CuratorOp updateOp(T model) {
-        return framework.updateOp(model);
+        return client.updateOp(model);
     }
 
     @Override
     public CuratorOp updateOp(T model, int version) {
-        return framework.updateOp(model, version);
+        return client.updateOp(model, version);
     }
 
     @Override
     public CuratorOp deleteOp() {
-        return framework.deleteOp();
+        return client.deleteOp();
     }
 
     @Override
     public CuratorOp deleteOp(int version) {
-        return framework.deleteOp(version);
+        return client.deleteOp(version);
     }
 
     @Override
     public CuratorOp checkExistsOp() {
-        return framework.checkExistsOp();
+        return client.checkExistsOp();
     }
 
     @Override
     public CuratorOp checkExistsOp(int version) {
-        return framework.checkExistsOp(version);
+        return client.checkExistsOp(version);
     }
 
     @Override
     public AsyncStage<List<CuratorTransactionResult>> inTransaction(List<CuratorOp> operations) {
-        return framework.inTransaction(operations);
+        return client.inTransaction(operations);
     }
 
     @Override
@@ -153,17 +153,17 @@ public class InitializedCachedModeledFramework<T> implements CachedModeledFramew
 
     @Override
     public AsyncCuratorFramework unwrap() {
-        return framework.unwrap();
+        return client.unwrap();
     }
 
     @Override
     public ModelSpec<T> modelSpec() {
-        return framework.modelSpec();
+        return client.modelSpec();
     }
 
     @Override
     public CachedModeledFramework<T> child(Object child) {
-        return new InitializedCachedModeledFramework<>(framework.child(child), init);
+        return new InitializedCachedModeledFramework<>(client.child(child), init);
     }
 
     @Override
@@ -174,92 +174,92 @@ public class InitializedCachedModeledFramework<T> implements CachedModeledFramew
 
     @Override
     public CachedModeledFramework<T> withPath(ZPath path) {
-        return new InitializedCachedModeledFramework<>(framework.withPath(path), init);
+        return new InitializedCachedModeledFramework<>(client.withPath(path), init);
     }
 
     @Override
     public AsyncStage<String> set(T model) {
-        return framework.set(model);
+        return client.set(model);
     }
 
     @Override
     public AsyncStage<String> set(T model, int version) {
-        return framework.set(model, version);
+        return client.set(model, version);
     }
 
     @Override
     public AsyncStage<String> set(T model, Stat storingStatIn) {
-        return framework.set(model, storingStatIn);
+        return client.set(model, storingStatIn);
     }
 
     @Override
     public AsyncStage<String> set(T model, Stat storingStatIn, int version) {
-        return framework.set(model, storingStatIn, version);
+        return client.set(model, storingStatIn, version);
     }
 
     @Override
     public AsyncStage<T> read() {
-        return internalRead(framework::read);
+        return internalRead(client::read);
     }
 
     @Override
     public AsyncStage<T> read(Stat storingStatIn) {
-        return internalRead(() -> framework.read(storingStatIn));
+        return internalRead(() -> client.read(storingStatIn));
     }
 
     @Override
     public AsyncStage<ZNode<T>> readAsZNode() {
-        return internalRead(framework::readAsZNode);
+        return internalRead(client::readAsZNode);
     }
 
     @Override
     public AsyncStage<Stat> update(T model) {
-        return framework.update(model);
+        return client.update(model);
     }
 
     @Override
     public AsyncStage<Stat> update(T model, int version) {
-        return framework.update(model, version);
+        return client.update(model, version);
     }
 
     @Override
     public AsyncStage<Void> delete() {
-        return framework.delete();
+        return client.delete();
     }
 
     @Override
     public AsyncStage<Void> delete(int version) {
-        return framework.delete(version);
+        return client.delete(version);
     }
 
     @Override
     public AsyncStage<Stat> checkExists() {
-        return framework.checkExists();
+        return client.checkExists();
     }
 
     @Override
     public AsyncStage<List<ZPath>> children() {
-        return internalRead(framework::children);
+        return internalRead(client::children);
     }
 
     @Override
     public AsyncStage<T> readThrough() {
-        return internalRead(framework::readThrough);
+        return internalRead(client::readThrough);
     }
 
     @Override
     public AsyncStage<T> readThrough(Stat storingStatIn) {
-        return internalRead(() -> framework.readThrough(storingStatIn));
+        return internalRead(() -> client.readThrough(storingStatIn));
     }
 
     @Override
     public AsyncStage<ZNode<T>> readThroughAsZNode() {
-        return internalRead(framework::readThroughAsZNode);
+        return internalRead(client::readThroughAsZNode);
     }
 
     @Override
     public AsyncStage<List<T>> list() {
-        return internalRead(framework::list);
+        return internalRead(client::list);
     }
 
     @Override

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/InitializedCachedModeledFramework.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/InitializedCachedModeledFramework.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.curator.x.async.modeled.details;
+
+import org.apache.curator.framework.api.transaction.CuratorOp;
+import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
+import org.apache.curator.framework.listen.Listenable;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.curator.x.async.AsyncStage;
+import org.apache.curator.x.async.modeled.ModelSpec;
+import org.apache.curator.x.async.modeled.ModeledFramework;
+import org.apache.curator.x.async.modeled.ZNode;
+import org.apache.curator.x.async.modeled.ZPath;
+import org.apache.curator.x.async.modeled.cached.CachedModeledFramework;
+import org.apache.curator.x.async.modeled.cached.ModeledCache;
+import org.apache.curator.x.async.modeled.cached.ModeledCacheListener;
+import org.apache.curator.x.async.modeled.versioned.VersionedModeledFramework;
+import org.apache.zookeeper.data.Stat;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+
+public class InitializedCachedModeledFramework<T> implements CachedModeledFramework<T> {
+
+  private final CachedModeledFramework<T> framework;
+  private final ModelStage<Void> init;
+
+  private InitializedCachedModeledFramework(CachedModeledFramework<T> framework, ModelStage<Void> init) {
+    this.framework = framework;
+    this.init = init;
+  }
+
+  InitializedCachedModeledFramework(CachedModeledFramework<T> framework) {
+    this.framework = framework;
+    init = ModelStage.make();
+    listenable().addListener(new ModeledCacheListener<T>() {
+
+      @Override
+      public void accept(Type type, ZPath path, Stat stat, Object model) {
+        // NOP
+      }
+
+      @Override
+      public void initialized() {
+        init.complete(null);
+        ModeledCacheListener.super.initialized();
+      }
+
+      @Override
+      public void handleException(Exception e) {
+        init.completeExceptionally(e);
+        ModeledCacheListener.super.handleException(e);
+      }
+    });
+  }
+
+  @Override
+  public ModeledCache<T> cache() {
+    return framework.cache();
+  }
+
+  @Override
+  public void start() {
+    framework.start();
+  }
+
+  @Override
+  public void close() {
+    framework.close();
+  }
+
+  @Override
+  public Listenable<ModeledCacheListener<T>> listenable() {
+    return framework.listenable();
+  }
+
+  @Override
+  public AsyncStage<List<ZNode<T>>> childrenAsZNodes() {
+    return internalRead(framework::childrenAsZNodes);
+  }
+
+  @Override
+  public CuratorOp createOp(T model) {
+    return framework.createOp(model);
+  }
+
+  @Override
+  public CuratorOp updateOp(T model) {
+    return framework.updateOp(model);
+  }
+
+  @Override
+  public CuratorOp updateOp(T model, int version) {
+    return framework.updateOp(model, version);
+  }
+
+  @Override
+  public CuratorOp deleteOp() {
+    return framework.deleteOp();
+  }
+
+  @Override
+  public CuratorOp deleteOp(int version) {
+    return framework.deleteOp(version);
+  }
+
+  @Override
+  public CuratorOp checkExistsOp() {
+    return framework.checkExistsOp();
+  }
+
+  @Override
+  public CuratorOp checkExistsOp(int version) {
+    return framework.checkExistsOp(version);
+  }
+
+  @Override
+  public AsyncStage<List<CuratorTransactionResult>> inTransaction(List<CuratorOp> operations) {
+    return framework.inTransaction(operations);
+  }
+
+  @Override
+  public CachedModeledFramework<T> cached() {
+    throw new UnsupportedOperationException("Already a cached instance");
+  }
+
+  @Override
+  public CachedModeledFramework<T> cached(ExecutorService executor) {
+    throw new UnsupportedOperationException("Already a cached instance");
+  }
+
+  @Override
+  public VersionedModeledFramework<T> versioned() {
+    return new VersionedModeledFrameworkImpl<>(this);
+  }
+
+  @Override
+  public AsyncCuratorFramework unwrap() {
+    return framework.unwrap();
+  }
+
+  @Override
+  public ModelSpec<T> modelSpec() {
+    return framework.modelSpec();
+  }
+
+  @Override
+  public CachedModeledFramework<T> child(Object child) {
+    return new InitializedCachedModeledFramework<>(framework.child(child), init);
+  }
+
+  @Override
+  public ModeledFramework<T> parent() {
+    throw new UnsupportedOperationException(
+        "Not supported for CachedModeledFramework. Instead, call parent() on the ModeledFramework before calling cached()");
+  }
+
+  @Override
+  public CachedModeledFramework<T> withPath(ZPath path) {
+    return new InitializedCachedModeledFramework<>(framework.withPath(path), init);
+  }
+
+  @Override
+  public AsyncStage<String> set(T model) {
+    return framework.set(model);
+  }
+
+  @Override
+  public AsyncStage<String> set(T model, int version) {
+    return framework.set(model, version);
+  }
+
+  @Override
+  public AsyncStage<String> set(T model, Stat storingStatIn) {
+    return framework.set(model, storingStatIn);
+  }
+
+  @Override
+  public AsyncStage<String> set(T model, Stat storingStatIn, int version) {
+    return framework.set(model, storingStatIn, version);
+  }
+
+  @Override
+  public AsyncStage<T> read() {
+    return internalRead(framework::read);
+  }
+
+  @Override
+  public AsyncStage<T> read(Stat storingStatIn) {
+    return internalRead(() -> framework.read(storingStatIn));
+  }
+
+  @Override
+  public AsyncStage<ZNode<T>> readAsZNode() {
+    return internalRead(framework::readAsZNode);
+  }
+
+  @Override
+  public AsyncStage<Stat> update(T model) {
+    return framework.update(model);
+  }
+
+  @Override
+  public AsyncStage<Stat> update(T model, int version) {
+    return framework.update(model, version);
+  }
+
+  @Override
+  public AsyncStage<Void> delete() {
+    return framework.delete();
+  }
+
+  @Override
+  public AsyncStage<Void> delete(int version) {
+    return framework.delete(version);
+  }
+
+  @Override
+  public AsyncStage<Stat> checkExists() {
+    return framework.checkExists();
+  }
+
+  @Override
+  public AsyncStage<List<ZPath>> children() {
+    return internalRead(framework::children);
+  }
+
+  @Override
+  public AsyncStage<T> readThrough() {
+    return internalRead(framework::readThrough);
+  }
+
+  @Override
+  public AsyncStage<T> readThrough(Stat storingStatIn) {
+    return internalRead(() -> framework.readThrough(storingStatIn));
+  }
+
+  @Override
+  public AsyncStage<ZNode<T>> readThroughAsZNode() {
+    return internalRead(framework::readThroughAsZNode);
+  }
+
+  @Override
+  public AsyncStage<List<T>> list() {
+    return internalRead(framework::list);
+  }
+
+  @Override
+  public CachedModeledFramework<T> initialized() {
+    throw new UnsupportedOperationException("Already an initialized instance");
+  }
+
+  private <U> AsyncStage<U> internalRead(Supplier<AsyncStage<U>> innerSupplier) {
+    ModelStage<U> stage = ModelStage.make();
+    init.whenComplete((data, throwable) -> {
+          if (throwable == null) {
+            innerSupplier.get().whenComplete((data1, throwable1) -> {
+                  if (throwable1 == null) {
+                    stage.complete(data1);
+                  } else {
+                    stage.completeExceptionally(throwable1);
+                  }
+                }
+            );
+          } else {
+            stage.completeExceptionally(throwable);
+          }
+        });
+    return stage;
+  }
+}

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledFrameworkImpl.java
@@ -132,6 +132,11 @@ public class ModeledFrameworkImpl<T> implements ModeledFramework<T> {
     }
 
     @Override
+    public CachedModeledFramework<T> initialized() {
+        return new InitializedCachedModeledFramework<>(cached());
+    }
+
+    @Override
     public CachedModeledFramework<T> cached(ExecutorService executor) {
         Preconditions.checkState(
                 !isWatched,

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
@@ -213,7 +213,8 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
         verifyEmptyNodeDeserialization(byteModel, byteModelSpec, type);
     }
 
-    private <T> void verifyEmptyNodeDeserialization(T model, ModelSpec<T> parentModelSpec, CachedModeledFrameworkType type) {
+    private <T> void verifyEmptyNodeDeserialization(
+            T model, ModelSpec<T> parentModelSpec, CachedModeledFrameworkType type) {
         // The sub-path is the ZNode that will be removed that does not contain any model data. Their should be no
         // attempt to deserialize this empty ZNode.
         final String subPath = parentModelSpec.path().toString() + "/sub";

--- a/pom.xml
+++ b/pom.xml
@@ -593,6 +593,12 @@
 
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit-version}</version>
             </dependency>


### PR DESCRIPTION
Linked issue https://github.com/apache/curator/issues/1246

The current `CachedModeledFrameworkImpl` doesn't manage cache initialization for you. A perfect example of the kind of code you can expect to see in the wild is in the `CachedModeledFramework` tests themselves, i.e. blocking on semaphores that pin the reading thread to prevent it from certain operations that are cache dependent (but as far as I can tell exactly _which_ operations are cache dependent is not really guaranteed so this is arguably cumbersome). Either way, this is fine in a lot of cases...

However, I propose an additional `InitializedCachedModeledFramework` implementation which asynchronously waits for the cache initialization trigger and only _then_ proceeds to read from the cache. I implemented something similar for my personal use-case where I couldn't rely on, i.e. `readThrough`, to handle the uninitialized case because `readThrough` cannot disambiguate between a znode that is missing because it truly is missing from zk vs one that is missing because the cache hasn't initialized. In my case the znode wouldn't always exist in zk and so using `readThrough` would result in a lot of wasted calls to zk, greatly reducing the benefit of the cache in the first place.

To reiterate `InitializedCachedModeledFramework` has a couple benefits over the existing implementation:

1. No more possibility of misleading `NoNodeException` in the case of reading from `CachedModeledFramework` _before_ the cache has warmed. (I say misleading because the node may exist .. just not in the cache)
2. No more temptation to add blocking semaphores in front of this non-blocking interface.
3. IMO generally less [confusion about how to properly use](https://stackoverflow.com/questions/65328623/how-to-be-notified-when-cachedmodeledframework-is-initialized) this otherwise great(!) feature.