### PR TITLE
GH-1246. Asynchronously initialize cache before reading II

### DIFF
--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
@@ -226,17 +226,7 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T> {
 
     @Override
     public AsyncStage<Stat> checkExists() {
-        ModelStage<Stat> stage = ModelStage.make();
-        init.whenComplete((__, throwable) -> {
-            if (throwable == null) {
-                ZPath path = client.modelSpec().path();
-                Stat stat = cache.currentData(path).map(ZNode::stat).orElse(null);
-                stage.complete(stat);
-            } else {
-                stage.completeExceptionally(throwable);
-            }
-        });
-        return stage;
+        return internalRead(ZNode::stat, () -> ModelStage.completed(null));
     }
 
     @Override

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
@@ -268,6 +268,22 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
         }
     }
 
+    @Test
+    void testReadThroughFailure() throws InterruptedException, TimeoutException, ExecutionException {
+        try (CachedModeledFramework<TestModel> client =
+                ModeledFramework.wrap(async, modelSpec).cached()) {
+            client.start();
+            assertNull(timing.getFuture(client.delete().toCompletableFuture()));
+            complete(client.readThrough(), (d, e) -> {
+                if (e == null) {
+                    fail("This test should result in a NoNodeException");
+                } else {
+                    assertEquals(KeeperException.NoNodeException.class, e.getClass());
+                }
+            });
+        }
+    }
+
     private <T> void verifyEmptyNodeDeserialization(T model, ModelSpec<T> parentModelSpec) {
         // The sub-path is the ZNode that will be removed that does not contain any model data. Their should be no
         // attempt to deserialize this empty ZNode.

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
@@ -236,6 +236,11 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
             } catch (ExecutionException e) {
                 assertTrue(e.getCause() instanceof KeeperException.NoNodeException);
             }
+
+            complete(client.child(asyncModel).checkExists().whenComplete((value, e) -> {
+                assertNull(value);
+                assertNull(e);
+            }));
         }
     }
 

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
@@ -237,7 +237,7 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
                 assertTrue(e.getCause() instanceof KeeperException.NoNodeException);
             }
 
-            complete(client.child(asyncModel).checkExists().whenComplete((value, e) -> {
+            complete(client.checkExists().whenComplete((value, e) -> {
                 assertNull(value);
                 assertNull(e);
             }));


### PR DESCRIPTION
This is an alternative, simpler implementation to https://github.com/apache/curator/pull/1247 with the same motivation, namely to solve https://github.com/apache/curator/issues/1246