### PR TITLE
GH 1256. Fix cached modeled framework list

### DIFF
--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
@@ -172,12 +172,7 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T> {
 
     @Override
     public AsyncStage<T> read(Stat storingStatIn) {
-        return internalRead(n -> {
-            if (storingStatIn != null) {
-                DataTree.copyStat(n.stat(), storingStatIn);
-            }
-            return n.model();
-        });
+        return internalRead(n -> this.toModelWithStat(n, storingStatIn));
     }
 
     @Override
@@ -192,7 +187,7 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T> {
 
     @Override
     public AsyncStage<T> readThrough(Stat storingStatIn) {
-        return internalRead(ZNode::model, () -> client.read(storingStatIn));
+        return internalRead(n -> this.toModelWithStat(n, storingStatIn), () -> client.read(storingStatIn));
     }
 
     @Override
@@ -202,7 +197,7 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T> {
 
     @Override
     public AsyncStage<List<T>> list() {
-        return this.internalList(entry -> entry.getValue().model());
+        return this.allCacheChildren(entry -> entry.getValue().model());
     }
 
     @Override
@@ -232,12 +227,12 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T> {
 
     @Override
     public AsyncStage<List<ZPath>> children() {
-        return this.internalChildren(Map.Entry::getKey);
+        return this.clientPathDirectChildren(Map.Entry::getKey);
     }
 
     @Override
     public AsyncStage<List<ZNode<T>>> childrenAsZNodes() {
-        return this.internalChildren(Map.Entry::getValue);
+        return this.clientPathDirectChildren(Map.Entry::getValue);
     }
 
     @Override
@@ -280,6 +275,13 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T> {
         return client.inTransaction(operations);
     }
 
+    private T toModelWithStat(ZNode<T> n, Stat storingStatIn) {
+        if (storingStatIn != null) {
+            DataTree.copyStat(n.stat(), storingStatIn);
+        }
+        return n.model();
+    }
+
     private <U> AsyncStage<U> internalRead(Function<ZNode<T>, U> resolver) {
         return internalRead(resolver, null);
     }
@@ -313,16 +315,17 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T> {
         return stage;
     }
 
-    private <U> ModelStage<List<U>> internalList(Function<Map.Entry<ZPath, ZNode<T>>, U> resolver) {
-        return internalChildren(resolver, __ -> true);
+    private <U> ModelStage<List<U>> allCacheChildren(Function<Map.Entry<ZPath, ZNode<T>>, U> resolver) {
+        return filteredCacheChildren(resolver, __ -> true);
     }
 
-    private <U> ModelStage<List<U>> internalChildren(Function<Map.Entry<ZPath, ZNode<T>>, U> resolver) {
-        return internalChildren(resolver, e -> e.getKey().parent().equals(client.modelSpec().path()));
+    private <U> ModelStage<List<U>> clientPathDirectChildren(Function<Map.Entry<ZPath, ZNode<T>>, U> resolver) {
+        return filteredCacheChildren(
+                resolver, e -> e.getKey().parent().equals(client.modelSpec().path()));
     }
 
-    private <U> ModelStage<List<U>> internalChildren(Function<Map.Entry<ZPath, ZNode<T>>, U> resolver,
-                                                     Predicate<Map.Entry<ZPath, ZNode<T>>> filter) {
+    private <U> ModelStage<List<U>> filteredCacheChildren(
+            Function<Map.Entry<ZPath, ZNode<T>>, U> resolver, Predicate<Map.Entry<ZPath, ZNode<T>>> filter) {
         ModelStage<List<U>> stage = ModelStage.make();
         init.whenComplete((__, throwable) -> {
             if (throwable == null) {

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/CachedModeledFrameworkImpl.java
@@ -197,7 +197,7 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T> {
 
     @Override
     public AsyncStage<List<T>> list() {
-        return this.allCacheChildren(entry -> entry.getValue().model());
+        return this.filteredCacheChildren(entry -> entry.getValue().model(), __ -> true);
     }
 
     @Override
@@ -313,10 +313,6 @@ class CachedModeledFrameworkImpl<T> implements CachedModeledFramework<T> {
             }
         });
         return stage;
-    }
-
-    private <U> ModelStage<List<U>> allCacheChildren(Function<Map.Entry<ZPath, ZNode<T>>, U> resolver) {
-        return filteredCacheChildren(resolver, __ -> true);
     }
 
     private <U> ModelStage<List<U>> clientPathDirectChildren(Function<Map.Entry<ZPath, ZNode<T>>, U> resolver) {

--- a/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledCacheImpl.java
+++ b/curator-x-async/src/main/java/org/apache/curator/x/async/modeled/details/ModeledCacheImpl.java
@@ -118,10 +118,6 @@ class ModeledCacheImpl<T> implements TreeCacheListener, ModeledCache<T> {
         return Optional.empty();
     }
 
-    ZPath basePath() {
-        return basePath;
-    }
-
     Map<ZPath, ZNode<T>> currentChildren() {
         return currentChildren(basePath);
     }

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
@@ -148,6 +148,10 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
                 });
             });
 
+
+            complete(
+                client.child("p").childrenAsZNodes(),
+                (v, e) -> assertEquals(toSet(v.stream(), ZNode::model), Sets.newHashSet(child1, child2)));
             complete(
                     client.child("p").child("c1").childrenAsZNodes(),
                     (v, e) -> assertEquals(toSet(v.stream(), ZNode::model), Sets.newHashSet(grandChild1)));
@@ -157,10 +161,16 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
 
             complete(
                     client.child("p").child("c1").list(),
-                    (v, e) -> assertEquals(toSet(v.stream(), Function.identity()), Sets.newHashSet(grandChild1)));
+                    (v, e) -> assertEquals(toSet(v.stream(), Function.identity()), Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
             complete(
                     client.child("p").child("c2").list(),
-                    (v, e) -> assertEquals(toSet(v.stream(), Function.identity()), Sets.newHashSet(grandChild2)));
+                    (v, e) -> assertEquals(toSet(v.stream(), Function.identity()), Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
+            complete(
+                client.child("p").list(),
+                (v, e) -> assertEquals(toSet(v.stream(), Function.identity()), Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
+            complete(
+                client.child("p").child("c2").child("g2").list(),
+                (v, e) -> assertEquals(toSet(v.stream(), Function.identity()), Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
         }
     }
 

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
@@ -148,10 +148,12 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
                 });
             });
 
-
             complete(
-                client.child("p").childrenAsZNodes(),
-                (v, e) -> assertEquals(toSet(v.stream(), ZNode::model), Sets.newHashSet(child1, child2)));
+                    client.child("p").childrenAsZNodes(),
+                    (v, e) -> assertEquals(toSet(v.stream(), ZNode::model), Sets.newHashSet(child1, child2)));
+            complete(
+                    client.withPath(ZPath.from(path, "p")).childrenAsZNodes(),
+                    (v, e) -> assertEquals(toSet(v.stream(), ZNode::model), Sets.newHashSet(child1, child2)));
             complete(
                     client.child("p").child("c1").childrenAsZNodes(),
                     (v, e) -> assertEquals(toSet(v.stream(), ZNode::model), Sets.newHashSet(grandChild1)));
@@ -161,16 +163,34 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
 
             complete(
                     client.child("p").child("c1").list(),
-                    (v, e) -> assertEquals(toSet(v.stream(), Function.identity()), Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
+                    (v, e) -> assertEquals(
+                            toSet(v.stream(), Function.identity()),
+                            Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
             complete(
                     client.child("p").child("c2").list(),
-                    (v, e) -> assertEquals(toSet(v.stream(), Function.identity()), Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
+                    (v, e) -> assertEquals(
+                            toSet(v.stream(), Function.identity()),
+                            Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
             complete(
-                client.child("p").list(),
-                (v, e) -> assertEquals(toSet(v.stream(), Function.identity()), Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
+                    client.child("p").list(),
+                    (v, e) -> assertEquals(
+                            toSet(v.stream(), Function.identity()),
+                            Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
             complete(
-                client.child("p").child("c2").child("g2").list(),
-                (v, e) -> assertEquals(toSet(v.stream(), Function.identity()), Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
+                    client.child("p").child("c2").child("g2").list(),
+                    (v, e) -> assertEquals(
+                            toSet(v.stream(), Function.identity()),
+                            Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
+        }
+
+        try (CachedModeledFramework<TestModel> client =
+                ModeledFramework.wrap(async, modelSpec.withPath(ZPath.root)).cached()) {
+            client.start();
+            complete(
+                    client.list(),
+                    (v, e) -> assertEquals(
+                            toSet(v.stream(), Function.identity()),
+                            Sets.newHashSet(parent, child1, child2, grandChild1, grandChild2)));
         }
     }
 
@@ -255,6 +275,36 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
     }
 
     @Test
+    void testRead() throws InterruptedException, TimeoutException, ExecutionException {
+        try (CachedModeledFramework<TestModel> client =
+                ModeledFramework.wrap(async, modelSpec).cached()) {
+            TestModel model = new TestModel("a", "b", "c", 1, BigInteger.ONE);
+            assertNotNull(timing.getFuture(client.set(model).toCompletableFuture()));
+            Semaphore semaphore = new Semaphore(0);
+            client.listenable().addListener(new ModeledCacheListener<TestModel>() {
+                @Override
+                public void accept(Type type, ZPath path, Stat stat, TestModel model) {
+                    // NOP
+                }
+
+                @Override
+                public void initialized() {
+                    semaphore.release();
+                }
+            });
+            client.start();
+            assertTrue(timing.acquireSemaphore(semaphore));
+            assertEquals(model, timing.getFuture(client.read().toCompletableFuture()));
+            assertEquals(
+                    model,
+                    timing.getFuture(client.readAsZNode().toCompletableFuture()).model());
+            Stat stat = new Stat();
+            assertEquals(model, timing.getFuture(client.read(stat).toCompletableFuture()));
+            assertTrue(stat.getDataLength() > 0);
+        }
+    }
+
+    @Test
     void testReadThrough() throws InterruptedException, TimeoutException, ExecutionException {
         try (CachedModeledFramework<TestModel> client =
                 ModeledFramework.wrap(async, modelSpec).cached()) {
@@ -274,6 +324,13 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
             client.start();
             assertTrue(timing.acquireSemaphore(semaphore));
             assertNotNull(timing.getFuture(client.set(model).toCompletableFuture()));
+            Stat stat = new Stat();
+            assertEquals(model, timing.getFuture(client.readThrough(stat).toCompletableFuture()));
+            assertTrue(stat.getDataLength() > 0);
+            assertEquals(
+                    model,
+                    timing.getFuture(client.readThroughAsZNode().toCompletableFuture())
+                            .model());
             assertEquals(model, timing.getFuture(client.readThrough().toCompletableFuture()));
         }
     }

--- a/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
+++ b/curator-x-async/src/test/java/org/apache/curator/x/async/modeled/TestCachedModeledFramework.java
@@ -280,20 +280,7 @@ public class TestCachedModeledFramework extends TestModeledFrameworkBase {
                 ModeledFramework.wrap(async, modelSpec).cached()) {
             TestModel model = new TestModel("a", "b", "c", 1, BigInteger.ONE);
             assertNotNull(timing.getFuture(client.set(model).toCompletableFuture()));
-            Semaphore semaphore = new Semaphore(0);
-            client.listenable().addListener(new ModeledCacheListener<TestModel>() {
-                @Override
-                public void accept(Type type, ZPath path, Stat stat, TestModel model) {
-                    // NOP
-                }
-
-                @Override
-                public void initialized() {
-                    semaphore.release();
-                }
-            });
             client.start();
-            assertTrue(timing.acquireSemaphore(semaphore));
             assertEquals(model, timing.getFuture(client.read().toCompletableFuture()));
             assertEquals(
                     model,


### PR DESCRIPTION
Fix `CachedModeledFramework::list` so it returns unfiltered list of children based on the cache path (not client path). See https://github.com/apache/curator/issues/1256 for more details.

Also added really minor fix to `CachedModeledFramework::readThrough(Stat)`. This surfaced after I enhanced the tests a bit. This bug predates https://github.com/apache/curator/pull/1250