### PR TITLE
Fix PersistentWatcher not working with NamespaceFacade

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkBase.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkBase.java
@@ -58,6 +58,11 @@ import org.apache.zookeeper.ZooKeeper;
 public abstract class CuratorFrameworkBase implements CuratorFramework {
     abstract NamespaceImpl getNamespaceImpl();
 
+    /**
+     * Return the underlying client which is the one constructed from {@link org.apache.curator.framework.CuratorFrameworkFactory}.
+     */
+    public abstract CuratorFramework client();
+
     @Override
     public final CuratorFramework nonNamespaceView() {
         return usingNamespace(null);

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -255,6 +255,11 @@ public final class CuratorFrameworkImpl extends CuratorFrameworkBase {
     }
 
     @Override
+    public CuratorFramework client() {
+        return this;
+    }
+
+    @Override
     public CuratorFrameworkState getState() {
         return state.get();
     }

--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/DelegatingCuratorFramework.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/DelegatingCuratorFramework.java
@@ -48,6 +48,11 @@ abstract class DelegatingCuratorFramework extends CuratorFrameworkBase {
     }
 
     @Override
+    public final CuratorFramework client() {
+        return client.client();
+    }
+
+    @Override
     public CuratorFrameworkState getState() {
         return client.getState();
     }

--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/watch/PersistentWatcher.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/watch/PersistentWatcher.java
@@ -27,6 +27,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorClosedException;
 import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.listen.Listenable;
 import org.apache.curator.framework.listen.StandardListenerManager;
 import org.apache.curator.framework.state.ConnectionStateListener;
@@ -80,7 +81,8 @@ public class PersistentWatcher implements Closeable {
     public void start() {
         Preconditions.checkState(state.compareAndSet(State.LATENT, State.STARTED), "Already started");
         client.getConnectionStateListenable().addListener(connectionStateListener);
-        client.getCuratorListenable().addListener(((ignored, event) -> {
+        // This could be a namespaced facade which does not support getCuratorListenable.
+        ((CuratorFrameworkBase) client).client().getCuratorListenable().addListener(((ignored, event) -> {
             if (event.getType() == CuratorEventType.CLOSING) {
                 onClientClosed();
             }


### PR DESCRIPTION
`NamespaceFacade` does not support `getCuratorListenable` while #520 use it to listen for `CuratorEventType.CLOSING` to fix CURATOR-729.

This commit exports `CuratorFrameworkBase::client` to retrieve underlying framework client to listen for for `CuratorEventType.CLOSING`.

Fixes #1259.