### PR TITLE
GH-1269: Bump Jetty to 9.4.57.v20241219

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <!-- See https://stackoverflow.com/questions/43574426#comment93992044_43574427 -->
         <jaxb-version>2.2.11</jaxb-version>
         <javax-activation-version>1.1.1</javax-activation-version>
-        <jetty-version>9.4.45.v20220203</jetty-version>
+        <jetty-version>9.4.57.v20241219</jetty-version>
         <scannotation-version>1.0.2</scannotation-version>
         <!-- resteasy-jaxrs dependency cannot be higher than 2.x for compatibility with Jersey 1.x -->
         <resteasy-jaxrs-version>2.3.5.Final</resteasy-jaxrs-version>


### PR DESCRIPTION
This closes https://github.com/apache/curator/issues/1269.