### PR TITLE
Fix flaky TestReadOnly.testConnectionStateNewClient in ZooKeeper 3.9.3

### DIFF
--- a/curator-test/src/main/java/org/apache/curator/test/Timing.java
+++ b/curator-test/src/main/java/org/apache/curator/test/Timing.java
@@ -33,7 +33,7 @@ public class Timing {
 
     private static final int DEFAULT_SECONDS = 10;
     private static final int DEFAULT_WAITING_MULTIPLE = 5;
-    private static final double SESSION_MULTIPLE = .25;
+    private static final double SESSION_MULTIPLE = 1.5;
 
     /**
      * Use the default base time


### PR DESCRIPTION
ZOOKEEPER-4508 reports `SessionExpired` after exhausting session timeout
in session establishment instead of endless retries. It is easy to get
in this now with small session timeout.

Besides above, `sessionTimeoutMs` should bigger than `connectionTimeoutMs`,
while default `Timing::session()` and `Timing::connection()` are `2s` and
`10s` respectively now.

```
// from CuratorZookeeperClient

if (sessionTimeoutMs < connectionTimeoutMs) {
    log.warn(
            "session timeout [{}] is less than connection timeout [{}]", sessionTimeoutMs, connectionTimeoutMs);
}
```
