### PR TITLE
Add debug logging for client port hijack failures in ZooKeeperServerE…

### DIFF
--- a/curator-test/src/main/java/org/apache/curator/test/ZooKeeperServerEmbeddedAdapter.java
+++ b/curator-test/src/main/java/org/apache/curator/test/ZooKeeperServerEmbeddedAdapter.java
@@ -100,7 +100,7 @@ public class ZooKeeperServerEmbeddedAdapter implements ZooKeeperMainFace {
             }
         } catch (Exception e) {
             // swallow hijack failure to accommodate possible upstream changes
-            log.debug("Failed to hijack client port configuration, this may be due to upstream changes", e);
+            log.debug("Failed to hijack client port configuration. This may be due to upstream changes", e);
         }
         return false;
     }


### PR DESCRIPTION
…mbeddedAdapter

Add debug log for some specify situation to help developer identify the issue location

It's will eat the exception if can't find the `ZooKeeperServerEmbeddedImpl` class in some case, it will makes keep trying startup the zk server with same port. so the unit test will throw the address in used without any useful info.
This change add info for investigate 