### PR TITLE
Enforce string values in InstanceSpec's custom properties

### DIFF
--- a/curator-test/src/main/java/org/apache/curator/test/InstanceSpec.java
+++ b/curator-test/src/main/java/org/apache/curator/test/InstanceSpec.java
@@ -209,9 +209,19 @@ public class InstanceSpec {
         this.tickTime = (tickTime > 0 ? tickTime : -1); // -1 to set default value
         this.maxClientCnxns = (maxClientCnxns >= 0 ? maxClientCnxns : -1); // -1 to set default value
         this.customProperties = customProperties != null
-                ? Collections.<String, Object>unmodifiableMap(customProperties)
-                : Collections.<String, Object>emptyMap();
+                ? Collections.unmodifiableMap(enforceStringMap(customProperties))
+                : Collections.emptyMap();
         this.hostname = hostname == null ? localhost : hostname;
+    }
+
+    private static Map<String, Object> enforceStringMap(Map<String, Object> properties) {
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            if (!(entry.getValue() instanceof String)) {
+                String msg = String.format("property %s has non string value %s", entry.getKey(), entry.getValue());
+                throw new IllegalArgumentException(msg);
+            }
+        }
+        return properties;
     }
 
     public int getServerId() {


### PR DESCRIPTION
`InstanceSpec`'s `customProperties` will be fed to `Properties` in
`QuorumConfigBuilder::buildConfigProperties`, so we have to make sure it
contains only string values.

Instead of `ClassCastException` in read phase, this pr complains in
`InstanceSpec` construction phase.

We could deprecate these constructors in next step by introducing builder
for `InstanceSpec`(https://github.com/apache/curator/issues/1222).

Fixes https://github.com/apache/curator/issues/1178, CURATOR-663.