### PR TITLE
GH-1290. Fix barrier bypass in DistributedDoubleBarrier due to spurious wakeups or SyncConnected events

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/barriers/DistributedDoubleBarrier.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/barriers/DistributedDoubleBarrier.java
@@ -57,7 +57,6 @@ public class DistributedDoubleBarrier {
     private final int memberQty;
     private final String ourPath;
     private final String readyPath;
-    private final AtomicBoolean hasBeenNotified = new AtomicBoolean(false);
     private final AtomicBoolean connectionLost = new AtomicBoolean(false);
     private final Watcher watcher = new Watcher() {
         @Override
@@ -65,7 +64,6 @@ public class DistributedDoubleBarrier {
             connectionLost.set(event.getState() != Event.KeeperState.SyncConnected);
             client.runSafe(() -> {
                 synchronized (DistributedDoubleBarrier.this) {
-                    hasBeenNotified.set(true);
                     DistributedDoubleBarrier.this.notifyAll();
                 }
             });
@@ -253,8 +251,7 @@ public class DistributedDoubleBarrier {
     }
 
     private synchronized boolean internalEnter(long startMs, boolean hasMaxWait, long maxWaitMs) throws Exception {
-        boolean result = true;
-        do {
+        while (true) {
             List<String> children = getChildrenForEntering();
             int count = (children != null) ? children.size() : 0;
             if (count >= memberQty) {
@@ -263,26 +260,19 @@ public class DistributedDoubleBarrier {
                 } catch (KeeperException.NodeExistsException ignore) {
                     // ignore
                 }
-                break;
+                return true;
             }
 
-            if (hasMaxWait && !hasBeenNotified.get()) {
+            if (hasMaxWait) {
                 long elapsed = System.currentTimeMillis() - startMs;
                 long thisWaitMs = maxWaitMs - elapsed;
                 if (thisWaitMs <= 0) {
-                    result = false;
-                } else {
-                    wait(thisWaitMs);
+                    return false;
                 }
-
-                if (!hasBeenNotified.get()) {
-                    result = false;
-                }
+                wait(thisWaitMs);
             } else {
                 wait();
             }
-        } while (false);
-
-        return result;
+        }
     }
 }


### PR DESCRIPTION
Fixes [GH-1290](https://github.com/apache/curator/issues/1290).

Replace the do { ... } while (false) in internalEnter() with a while (true) loop that re-checks the ZooKeeper children count after every wakeup. This ensures the barrier condition is always verified before returning.

Also removes the hasBeenNotified flag as redundant now that the check is performed in the while loop.