### PR TITLE
GH-1292 Fix memory leak in PersistentWatcher

### DIFF
--- a/curator-recipes/src/main/java/org/apache/curator/framework/recipes/watch/PersistentWatcher.java
+++ b/curator-recipes/src/main/java/org/apache/curator/framework/recipes/watch/PersistentWatcher.java
@@ -27,6 +27,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorClosedException;
 import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.api.CuratorListener;
 import org.apache.curator.framework.imps.CuratorFrameworkBase;
 import org.apache.curator.framework.listen.Listenable;
 import org.apache.curator.framework.listen.StandardListenerManager;
@@ -51,6 +52,11 @@ public class PersistentWatcher implements Closeable {
     private final ConnectionStateListener connectionStateListener = (client, newState) -> {
         if (newState.isConnected()) {
             reset();
+        }
+    };
+    private final CuratorListener clientCloseListener = (ignored, event) -> {
+        if (event.getType() == CuratorEventType.CLOSING) {
+            onClientClosed();
         }
     };
     private final Watcher watcher = event -> listeners.forEach(w -> w.process(event));
@@ -82,11 +88,7 @@ public class PersistentWatcher implements Closeable {
         Preconditions.checkState(state.compareAndSet(State.LATENT, State.STARTED), "Already started");
         client.getConnectionStateListenable().addListener(connectionStateListener);
         // This could be a namespaced facade which does not support getCuratorListenable.
-        ((CuratorFrameworkBase) client).client().getCuratorListenable().addListener(((ignored, event) -> {
-            if (event.getType() == CuratorEventType.CLOSING) {
-                onClientClosed();
-            }
-        }));
+        ((CuratorFrameworkBase) client).client().getCuratorListenable().addListener(clientCloseListener);
         reset();
     }
 
@@ -97,6 +99,7 @@ public class PersistentWatcher implements Closeable {
     public void close() {
         if (state.compareAndSet(State.STARTED, State.CLOSED)) {
             listeners.clear();
+            ((CuratorFrameworkBase) client).client().getCuratorListenable().removeListener(clientCloseListener);
             client.getConnectionStateListenable().removeListener(connectionStateListener);
             try {
                 client.watchers().remove(watcher).guaranteed().inBackground().forPath(basePath);

--- a/curator-recipes/src/test/java/org/apache/curator/framework/recipes/watch/TestPersistentWatcher.java
+++ b/curator-recipes/src/test/java/org/apache/curator/framework/recipes/watch/TestPersistentWatcher.java
@@ -28,6 +28,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.listen.StandardListenerManager;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.compatibility.CuratorTestBase;
@@ -132,6 +133,24 @@ public class TestPersistentWatcher extends CuratorTestBase {
         assertNotNull(event);
         assertEquals(Watcher.Event.EventType.None, event.getType());
         assertEquals(Watcher.Event.KeeperState.Closed, event.getState());
+    }
+
+    // GH-1292 Curator listener Leak in PersistentWatcher
+    @Test
+    public void testCuratorListenersNotLeaking() {
+        try (CuratorFramework client = CuratorFrameworkFactory.newClient(
+                server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1))) {
+            client.start();
+
+            for (int i = 0; i < 100; i++) {
+                try (PersistentWatcher persistentWatcher = new PersistentWatcher(client, "/top/main", true)) {
+                    persistentWatcher.start();
+                }
+            }
+
+            assertEquals(0, ((StandardListenerManager<?>) client.getCuratorListenable()).size(),
+                    "Curator listeners set up by the now closed PersistentWatchers should have been de-registered");
+        }
     }
 
     private void internalTest(boolean recursive) throws Exception {


### PR DESCRIPTION
Remove the curator listener registered during `PersistentWatcher#start` when the `PersistentWatcher` is closed to avoid a leak of listeners