### PR TITLE
chore: Upgrade jackson-version to 2.18.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,7 @@
         <doxia-module-confluence-version>1.11.1</doxia-module-confluence-version>
         <javassist-version>3.24.1-GA</javassist-version>
         <commons-math-version>2.2</commons-math-version>
-        <jackson-mapper-asl-version>1.9.13</jackson-mapper-asl-version>
-        <jackson-version>2.18.1</jackson-version>
+        <jackson-version>2.18.9</jackson-version>
         <assertj-version>3.27.7</assertj-version>
         <!-- Upgrading to Jersey 2.x is difficult and of unclear benefits, see
              https://stackoverflow.com/questions/17098341#22033825 -->


### PR DESCRIPTION
Updated jackson-version to 2.18.9. Multiple CVEs fixed.
https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.18.1