### PR TITLE
CURATOR-676: Notify CuratorListener for retriable errors when no callback specified

### DIFF
--- a/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/org/apache/curator/framework/imps/CuratorFrameworkImpl.java
@@ -534,9 +534,6 @@ public final class CuratorFrameworkImpl extends CuratorFrameworkBase {
     }
 
     private void abortOperation(OperationAndData<?> operation, Throwable e) {
-        if (operation.getCallback() == null) {
-            return;
-        }
         CuratorEvent event;
         if (e instanceof KeeperException) {
             event = new CuratorEventImpl(
@@ -580,6 +577,11 @@ public final class CuratorFrameworkImpl extends CuratorFrameworkBase {
                     null,
                     null,
                     null);
+        }
+        if (operation.getCallback() == null) {
+            // CURATOR-676: Notify CuratorListener when no callback is specified
+            processEvent(event);
+            return;
         }
         sendToBackgroundCallback(operation, event);
     }


### PR DESCRIPTION
## Description

When `abortOperation` is called for a retriable error and no `BackgroundCallback` was specified on the operation, the `CuratorListener` was silently ignored (the method returned early at `if (operation.getCallback() == null) { return; }`).

According to the documented behavior, `CuratorListener` is a catch-all fallback for `BackgroundCallback` when no callback is specified at the operation level. This fix ensures that the `CuratorListener` is properly notified via `processEvent()` in this case.

## Changes

In `CuratorFrameworkImpl.abortOperation()`:
- Moved the callback-null check after the event creation
- When `callback == null`, call `processEvent(event)` to notify all registered `CuratorListener` instances
- When `callback != null`, continue to call `sendToBackgroundCallback(operation, event)` as before

Fixes #1191